### PR TITLE
feat: Supabase クライアントと認証ミドルウェア・ログインページを追加

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,24 @@
+import { signOut } from "@/lib/actions/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function AdminPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return (
+    <main className="flex flex-1 flex-col items-center justify-center gap-4 bg-brand-bg-light px-4 py-12 text-brand-brown-dark">
+      <h1 className="text-2xl font-bold">管理画面</h1>
+      <p className="text-sm">ログイン中: {user?.email}</p>
+      <form action={signOut}>
+        <button
+          type="submit"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white hover:bg-brand-sky-dark"
+        >
+          ログアウト
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/auth/login/login-form.tsx
+++ b/src/app/auth/login/login-form.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useActionState } from "react";
+import { signIn, type SignInState } from "@/lib/actions/auth";
+
+const initialState: SignInState = {};
+
+export function LoginForm() {
+  const [state, formAction, isPending] = useActionState(signIn, initialState);
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <div>
+        <label
+          htmlFor="email"
+          className="block text-sm font-medium text-brand-cream"
+        >
+          メールアドレス
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          autoComplete="email"
+          className="mt-1 block w-full rounded-md border border-brand-border-dark bg-brand-bg-dark px-3 py-2 text-brand-cream placeholder-brand-muted focus:border-brand-sky-light focus:outline-none focus:ring-1 focus:ring-brand-sky-light"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="password"
+          className="block text-sm font-medium text-brand-cream"
+        >
+          パスワード
+        </label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          required
+          autoComplete="current-password"
+          className="mt-1 block w-full rounded-md border border-brand-border-dark bg-brand-bg-dark px-3 py-2 text-brand-cream placeholder-brand-muted focus:border-brand-sky-light focus:outline-none focus:ring-1 focus:ring-brand-sky-light"
+        />
+      </div>
+
+      {state.error && (
+        <p className="text-sm text-red-400" role="alert">
+          {state.error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="w-full rounded-md bg-brand-sky px-4 py-2 font-medium text-white transition hover:bg-brand-sky-dark disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isPending ? "ログイン中..." : "ログイン"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { LoginForm } from "./login-form";
+
+export const metadata: Metadata = {
+  title: "ログイン | DonDecorte Lab",
+  robots: { index: false, follow: false },
+};
+
+export default function LoginPage() {
+  return (
+    <main className="flex flex-1 items-center justify-center bg-brand-bg-dark px-4 py-12">
+      <div className="w-full max-w-sm rounded-lg border border-brand-border-dark bg-brand-card-dark p-6 shadow-lg">
+        <h1 className="mb-6 text-center text-xl font-bold text-brand-cream">
+          管理画面ログイン
+        </h1>
+        <LoginForm />
+      </div>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,9 @@ import "./globals.css";
 
 const notoSansJP = Noto_Sans_JP({
   variable: "--font-noto-sans-jp",
-  subsets: ["latin", "japanese"],
+  subsets: ["latin"],
   display: "swap",
+  preload: false,
 });
 
 const inter = Inter({

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -30,6 +30,9 @@ export async function signIn(
 
 export async function signOut() {
   const supabase = await createClient();
-  await supabase.auth.signOut();
+  const { error } = await supabase.auth.signOut();
+  if (error) {
+    redirect("/admin");
+  }
   redirect("/");
 }

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export type SignInState = {
+  error?: string;
+};
+
+export async function signIn(
+  _prev: SignInState,
+  formData: FormData
+): Promise<SignInState> {
+  const email = String(formData.get("email") ?? "").trim();
+  const password = String(formData.get("password") ?? "");
+
+  if (!email || !password) {
+    return { error: "メールアドレスとパスワードを入力してください" };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    return { error: "メールアドレスまたはパスワードが正しくありません" };
+  }
+
+  redirect("/admin");
+}
+
+export async function signOut() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  redirect("/");
+}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const adminClient = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createClient } from "@supabase/supabase-js";
 
 export const adminClient = createClient(

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,27 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function createClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          } catch {
+            // Server Component からの呼び出し時は無視
+          }
+        },
+      },
+    }
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,16 +29,22 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (request.nextUrl.pathname.startsWith("/admin") && !user) {
+  const redirectWithCookies = (pathname: string) => {
     const url = request.nextUrl.clone();
-    url.pathname = "/auth/login";
-    return NextResponse.redirect(url);
+    url.pathname = pathname;
+    const response = NextResponse.redirect(url);
+    for (const cookie of supabaseResponse.cookies.getAll()) {
+      response.cookies.set(cookie);
+    }
+    return response;
+  };
+
+  if (request.nextUrl.pathname.startsWith("/admin") && !user) {
+    return redirectWithCookies("/auth/login");
   }
 
   if (request.nextUrl.pathname === "/auth/login" && user) {
-    const url = request.nextUrl.clone();
-    url.pathname = "/admin";
-    return NextResponse.redirect(url);
+    return redirectWithCookies("/admin");
   }
 
   return supabaseResponse;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,49 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value)
+          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (request.nextUrl.pathname.startsWith("/admin") && !user) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/auth/login";
+    return NextResponse.redirect(url);
+  }
+
+  if (request.nextUrl.pathname === "/auth/login" && user) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/admin";
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: ["/admin/:path*", "/auth/:path*"],
+};


### PR DESCRIPTION
## 概要
Next.js アプリの認証基盤を整備します。Supabase クライアント3種に加え、`/admin/*` の認証ガードとログインページを追加しました。

## 変更内容

### Supabase クライアント (#4)
- **ブラウザ用** (`src/lib/supabase/client.ts`)
- **サーバー用** (`src/lib/supabase/server.ts`): `cookies()` 連携、Server Component 向け try/catch
- **サービスロール用** (`src/lib/supabase/admin.ts`): `import "server-only"` でクライアント誤import防止

### 認証ミドルウェア & ログインページ (#5)
- **`src/middleware.ts`**: `/admin/*` 未認証→`/auth/login`、`/auth/login` ログイン済→`/admin`
- **`/auth/login`**: メール + パスワードのシンプルフォーム。`robots: noindex` で検索回避。UI上にリンクは一切設けず URL 直打ちのみ。
- **`src/lib/actions/auth.ts`**: `signIn` / `signOut` の Server Action。`useActionState` でエラー表示。
- **`/admin`**: 認証確認用の最小ダッシュボード（ログイン中メール表示 + ログアウト）

## 動作テスト手順
1. Supabase ダッシュボードでサインアップを OFF、ユーザーを手動作成
2. `.env.local` に Supabase URL / anon key / service role key を設定
3. 未ログインで `/admin` → `/auth/login` にリダイレクトされること
4. 正しい認証情報でログイン → `/admin` が表示されること
5. 公開ページ (`/`) にログイン導線が存在しないこと

## 備考
- Supabase ダッシュボード側の手動設定（メール認証有効化 / サインアップ無効化 / アカウント作成）は PR 対象外。

Closes #4
Closes #5

https://claude.ai/code/session_01KMs2FyJ5BFWRbRQXYDFJgJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a login page and client-side login form with validation and submit-state UI.
  * Added an admin management page showing the signed-in user and a logout action.
  * Implemented sign-in and sign-out server actions with redirect behavior.

* **Chores**
  * Integrated server- and client-side authentication plumbing and session/cookie handling.
  * Added middleware to enforce redirects between admin and login routes based on auth state.

* **Style**
  * Adjusted site font loading configuration (preload/subset settings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->