### PR TITLE
feat: 管理画面レイアウトとサイドバーを追加

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import { AdminHeader } from "@/components/layout/admin-header";
+import { AdminSidebar } from "@/components/layout/admin-sidebar";
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-1 bg-brand-bg-light text-brand-brown-dark">
+      <AdminSidebar />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <AdminHeader />
+        <main className="flex-1 overflow-x-hidden px-4 py-6 md:px-8 md:py-8">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -22,7 +22,7 @@ const CARDS: DashboardCard[] = [
 
 async function fetchCounts() {
   const supabase = await createClient();
-  const results = await Promise.all(
+  const results = await Promise.allSettled(
     CARDS.map(async (card) => {
       const { count, error } = await supabase
         .from(card.table)
@@ -31,7 +31,10 @@ async function fetchCounts() {
     })
   );
   const map = new Map<string, number | null>();
-  for (const r of results) map.set(r.table, r.count);
+  results.forEach((r, index) => {
+    const table = CARDS[index].table;
+    map.set(table, r.status === "fulfilled" ? r.value.count : null);
+  });
   return map;
 }
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,24 +1,74 @@
-import { signOut } from "@/lib/actions/auth";
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 
-export default async function AdminPage() {
+type DashboardCard = {
+  label: string;
+  table: string;
+  href: string;
+};
+
+const CARDS: DashboardCard[] = [
+  { label: "芸人", table: "artists", href: "/admin/artists" },
+  { label: "コンビ", table: "comedy_groups", href: "/admin/combos" },
+  { label: "ユニット", table: "units", href: "/admin/units" },
+  { label: "受賞歴", table: "achievements", href: "/admin/achievements" },
+  { label: "動画", table: "videos", href: "/admin/videos" },
+  { label: "ライブ", table: "lives", href: "/admin/lives" },
+  { label: "ラジオ", table: "radios", href: "/admin/radios" },
+  { label: "記事", table: "articles", href: "/admin/articles" },
+  { label: "テレビ", table: "tv_shows", href: "/admin/tv" },
+  { label: "トピック", table: "topics", href: "/admin/topics" },
+];
+
+async function fetchCounts() {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const results = await Promise.all(
+    CARDS.map(async (card) => {
+      const { count, error } = await supabase
+        .from(card.table)
+        .select("*", { count: "exact", head: true });
+      return { table: card.table, count: error ? null : count };
+    })
+  );
+  const map = new Map<string, number | null>();
+  for (const r of results) map.set(r.table, r.count);
+  return map;
+}
+
+export default async function AdminDashboardPage() {
+  const counts = await fetchCounts();
 
   return (
-    <main className="flex flex-1 flex-col items-center justify-center gap-4 bg-brand-bg-light px-4 py-12 text-brand-brown-dark">
-      <h1 className="text-2xl font-bold">管理画面</h1>
-      <p className="text-sm">ログイン中: {user?.email}</p>
-      <form action={signOut}>
-        <button
-          type="submit"
-          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white hover:bg-brand-sky-dark"
-        >
-          ログアウト
-        </button>
-      </form>
-    </main>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-bold text-brand-brown-dark">
+          ダッシュボード
+        </h1>
+        <p className="mt-1 text-sm text-brand-brown-light">
+          各テーブルの登録件数サマリ
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {CARDS.map((card) => {
+          const count = counts.get(card.table);
+          return (
+            <Link
+              key={card.table}
+              href={card.href}
+              className="block rounded-lg border border-brand-border-light bg-brand-card-light px-4 py-4 transition hover:border-brand-sky hover:shadow-sm"
+            >
+              <div className="text-xs text-brand-brown-light">{card.label}</div>
+              <div className="mt-2 flex items-baseline gap-1">
+                <span className="text-2xl font-semibold text-brand-brown-dark">
+                  {count ?? "—"}
+                </span>
+                <span className="text-xs text-brand-brown-light">件</span>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/src/components/layout/admin-header.tsx
+++ b/src/components/layout/admin-header.tsx
@@ -1,0 +1,32 @@
+import { signOut } from "@/lib/actions/auth";
+import { createClient } from "@/lib/supabase/server";
+
+export async function AdminHeader() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return (
+    <header className="flex items-center justify-between border-b border-brand-border-light bg-brand-card-light px-6 py-3">
+      <div className="text-sm font-medium text-brand-brown-dark">
+        DonDecorte Lab 管理画面
+      </div>
+      <div className="flex items-center gap-3">
+        {user?.email ? (
+          <span className="hidden text-xs text-brand-brown-light sm:inline">
+            {user.email}
+          </span>
+        ) : null}
+        <form action={signOut}>
+          <button
+            type="submit"
+            className="rounded-md border border-brand-border-light bg-white px-3 py-1.5 text-xs font-medium text-brand-brown-dark transition hover:bg-brand-bg-light"
+          >
+            ログアウト
+          </button>
+        </form>
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/admin-header.tsx
+++ b/src/components/layout/admin-header.tsx
@@ -1,5 +1,5 @@
-import { signOut } from "@/lib/actions/auth";
 import { createClient } from "@/lib/supabase/server";
+import { AdminSignOutButton } from "./admin-sign-out-button";
 
 export async function AdminHeader() {
   const supabase = await createClient();
@@ -18,14 +18,7 @@ export async function AdminHeader() {
             {user.email}
           </span>
         ) : null}
-        <form action={signOut}>
-          <button
-            type="submit"
-            className="rounded-md border border-brand-border-light bg-white px-3 py-1.5 text-xs font-medium text-brand-brown-dark transition hover:bg-brand-bg-light"
-          >
-            ログアウト
-          </button>
-        </form>
+        <AdminSignOutButton />
       </div>
     </header>
   );

--- a/src/components/layout/admin-sidebar.tsx
+++ b/src/components/layout/admin-sidebar.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type AdminNavItem = {
+  href: string;
+  label: string;
+};
+
+const NAV_ITEMS: AdminNavItem[] = [
+  { href: "/admin", label: "ダッシュボード" },
+  { href: "/admin/artists", label: "芸人（Artists）" },
+  { href: "/admin/combos", label: "コンビ（Combos）" },
+  { href: "/admin/units", label: "ユニット（Units）" },
+  { href: "/admin/achievements", label: "受賞歴（Achievements）" },
+  { href: "/admin/videos", label: "動画（Videos）" },
+  { href: "/admin/lives", label: "ライブ（Lives）" },
+  { href: "/admin/radios", label: "ラジオ（Radios）" },
+  { href: "/admin/articles", label: "記事（Articles）" },
+  { href: "/admin/tv", label: "テレビ（TV）" },
+  { href: "/admin/topics", label: "トピック（Topics）" },
+];
+
+function isActive(pathname: string, href: string) {
+  if (href === "/admin") return pathname === "/admin";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function AdminSidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="hidden w-60 shrink-0 border-r border-brand-border-light bg-brand-card-light md:flex md:flex-col">
+      <div className="border-b border-brand-border-light px-5 py-5">
+        <Link
+          href="/admin"
+          className="block text-base font-bold text-brand-brown-dark"
+        >
+          DonDecorte Lab
+        </Link>
+        <p className="mt-0.5 text-xs text-brand-brown-light">管理画面</p>
+      </div>
+      <nav className="flex-1 overflow-y-auto px-3 py-4">
+        <ul className="space-y-1">
+          {NAV_ITEMS.map((item) => {
+            const active = isActive(pathname, item.href);
+            return (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  aria-current={active ? "page" : undefined}
+                  className={
+                    active
+                      ? "block rounded-md bg-brand-sky-pale px-3 py-2 text-sm font-medium text-brand-sky"
+                      : "block rounded-md px-3 py-2 text-sm text-brand-brown-dark transition hover:bg-brand-bg-light hover:text-brand-sky"
+                  }
+                >
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/layout/admin-sign-out-button.tsx
+++ b/src/components/layout/admin-sign-out-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useTransition } from "react";
+import { signOut } from "@/lib/actions/auth";
+
+export function AdminSignOutButton() {
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <form action={() => startTransition(() => signOut())}>
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded-md border border-brand-border-light bg-brand-cream px-3 py-1.5 text-xs font-medium text-brand-brown-dark transition hover:bg-brand-bg-light disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isPending ? "ログアウト中..." : "ログアウト"}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## 概要

issue #6 (1-6 管理画面レイアウト + サイドバー) の対応。

`/admin/*` 配下にサイドバー付きのレイアウトを追加し、ダッシュボードで各テーブルの登録件数を一覧できるようにした。

## 変更内容

- `src/components/layout/admin-sidebar.tsx`（新規）
  - 左メニュー: ダッシュボード / 芸人 / コンビ / ユニット / 受賞歴 / 動画 / ライブ / ラジオ / 記事 / テレビ / トピック
  - `usePathname` で現在位置をハイライト
  - モバイルではサイドバーを非表示（`md:` 以上で表示）
- `src/components/layout/admin-header.tsx`（新規）
  - ログイン中ユーザーのメールアドレス表示 + ログアウトボタン
- `src/app/admin/layout.tsx`（新規）
  - ライトモード固定（`bg-brand-bg-light` クリーム背景 #FBF7F1）
  - サイドバー + ヘッダー + コンテンツ領域を構成
- `src/app/admin/page.tsx`（更新）
  - ダッシュボード化。主要10テーブルの件数を Supabase の `count: exact, head: true` で集計してカード表示
  - 各カードはそれぞれの一覧画面へのリンク

## 動作確認

- [x] `pnpm lint` が通る
- [x] `pnpm exec tsc --noEmit` が通る
- [x] `pnpm build` が成功する
- [ ] `/admin` にサイドバー付きレイアウトが表示される（※ Supabase 接続確認は環境依存のため実環境で要確認）
- [ ] サイドバーの各メニューからリンク遷移できる

Closes #6

https://claude.ai/code/session_016EB1MgcBkynJkfckj5SpcG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New admin interface scaffold with sidebar navigation and persistent header showing user email.
  * Admin dashboard with navigational cards showing counts for key data tables.
  * Responsive layout and styling for admin pages (collapsible/hidden on small screens).
  * Sign-out control with in-progress state feedback for secure logout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->