### PR TITLE
feat: 管理画面に芸人 CRUD を追加 (#7)

### DIFF
--- a/src/app/admin/artists/[id]/edit/page.tsx
+++ b/src/app/admin/artists/[id]/edit/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArtistForm } from "@/components/features/artist/artist-form";
+import { updateArtist } from "@/lib/actions/artists";
+import { getArtist } from "@/lib/queries/artists";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditArtistPage({ params }: Props) {
+  const { id } = await params;
+  const artist = await getArtist(id);
+  if (!artist) {
+    notFound();
+  }
+
+  const action = updateArtist.bind(null, id);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/artists"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← 芸人一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          {artist.name} を編集
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <ArtistForm
+          action={action}
+          initialValues={artist}
+          submitLabel="更新する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/artists/new/page.tsx
+++ b/src/app/admin/artists/new/page.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { ArtistForm } from "@/components/features/artist/artist-form";
+import { createArtist } from "@/lib/actions/artists";
+
+export default function NewArtistPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/artists"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← 芸人一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          芸人を新規作成
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <ArtistForm action={createArtist} submitLabel="作成する" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/artists/page.tsx
+++ b/src/app/admin/artists/page.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { ArtistDeleteButton } from "@/components/features/artist/artist-delete-button";
+import { deleteArtist } from "@/lib/actions/artists";
+import { listArtists } from "@/lib/queries/artists";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminArtistsPage() {
+  const artists = await listArtists();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-brand-brown-dark">芸人</h1>
+          <p className="mt-1 text-sm text-brand-brown-light">
+            芸人個人のマスタを管理します。
+          </p>
+        </div>
+        <Link
+          href="/admin/artists/new"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark"
+        >
+          新規作成
+        </Link>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+        {artists.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
+            まだ芸人が登録されていません。
+          </p>
+        ) : (
+          <table className="min-w-full divide-y divide-brand-border-light text-sm">
+            <thead className="bg-brand-bg-light text-xs text-brand-brown-light">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium">名前</th>
+                <th className="px-4 py-2 text-left font-medium">よみがな</th>
+                <th className="px-4 py-2 text-left font-medium">デビュー年</th>
+                <th className="px-4 py-2 text-right font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-border-light">
+              {artists.map((artist) => (
+                <tr key={artist.id} className="hover:bg-brand-bg-light">
+                  <td className="px-4 py-2 font-medium text-brand-brown-dark">
+                    {artist.name}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {artist.kana_name ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {artist.debut_year ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        href={`/admin/artists/${artist.id}/edit`}
+                        className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
+                      >
+                        編集
+                      </Link>
+                      <form action={deleteArtist}>
+                        <input type="hidden" name="id" value={artist.id} />
+                        <ArtistDeleteButton name={artist.name} />
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/features/artist/artist-delete-button.tsx
+++ b/src/components/features/artist/artist-delete-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+
+type Props = {
+  name: string;
+};
+
+export function ArtistDeleteButton({ name }: Props) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      onClick={(event) => {
+        if (!window.confirm(`「${name}」を削除します。よろしいですか？`)) {
+          event.preventDefault();
+        }
+      }}
+      className="rounded-md border border-red-200 px-3 py-1 text-xs text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {pending ? "削除中..." : "削除"}
+    </button>
+  );
+}

--- a/src/components/features/artist/artist-delete-button.tsx
+++ b/src/components/features/artist/artist-delete-button.tsx
@@ -18,7 +18,7 @@ export function ArtistDeleteButton({ name }: Props) {
           event.preventDefault();
         }
       }}
-      className="rounded-md border border-red-200 px-3 py-1 text-xs text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+      className="rounded-md border border-brand-gold px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-cream disabled:cursor-not-allowed disabled:opacity-60"
     >
       {pending ? "削除中..." : "削除"}
     </button>

--- a/src/components/features/artist/artist-form.tsx
+++ b/src/components/features/artist/artist-form.tsx
@@ -109,7 +109,7 @@ export function ArtistForm({ action, initialValues, submitLabel }: Props) {
   return (
     <form onSubmit={onSubmit} noValidate className="space-y-6">
       {state.error && (
-        <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
+        <p className="rounded-md bg-brand-cream px-3 py-2 text-sm text-brand-brown-dark" role="alert">
           {state.error}
         </p>
       )}
@@ -276,11 +276,11 @@ function Field({
     <div>
       <label htmlFor={id} className="block text-sm font-medium text-brand-brown-dark">
         {label}
-        {required && <span className="ml-1 text-red-600">*</span>}
+        {required && <span className="ml-1 text-brand-gold">*</span>}
       </label>
       {children}
       {error && (
-        <p className="mt-1 text-xs text-red-600" role="alert">
+        <p className="mt-1 text-xs text-brand-gold" role="alert">
           {error}
         </p>
       )}

--- a/src/components/features/artist/artist-form.tsx
+++ b/src/components/features/artist/artist-form.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import Link from "next/link";
+import { useActionState, useEffect, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import type { ArtistFormState } from "@/lib/actions/artists";
+import type { ArtistInput } from "@/lib/types/artist";
+
+type ArtistFormAction = (
+  prev: ArtistFormState,
+  formData: FormData
+) => Promise<ArtistFormState>;
+
+type ArtistFormValues = {
+  name: string;
+  kana_name: string;
+  profile: string;
+  debut_year: string;
+  image_url: string;
+  x_url: string;
+  instagram_url: string;
+  note_url: string;
+  youtube_channel_url: string;
+  tiktok_url: string;
+  website_url: string;
+};
+
+type Props = {
+  action: ArtistFormAction;
+  initialValues?: Partial<ArtistInput>;
+  submitLabel: string;
+};
+
+const URL_PATTERN =
+  /^https?:\/\/[\w\-._~:/?#[\]@!$&'()*+,;=%]+$/i;
+
+const FIELD_LABELS: Record<keyof ArtistFormValues, string> = {
+  name: "名前",
+  kana_name: "よみがな",
+  profile: "プロフィール",
+  debut_year: "デビュー年",
+  image_url: "画像URL",
+  x_url: "X（Twitter）",
+  instagram_url: "Instagram",
+  note_url: "note",
+  youtube_channel_url: "YouTube チャンネル",
+  tiktok_url: "TikTok",
+  website_url: "Webサイト",
+};
+
+function toFormValues(initial?: Partial<ArtistInput>): ArtistFormValues {
+  return {
+    name: initial?.name ?? "",
+    kana_name: initial?.kana_name ?? "",
+    profile: initial?.profile ?? "",
+    debut_year:
+      initial?.debut_year != null ? String(initial.debut_year) : "",
+    image_url: initial?.image_url ?? "",
+    x_url: initial?.x_url ?? "",
+    instagram_url: initial?.instagram_url ?? "",
+    note_url: initial?.note_url ?? "",
+    youtube_channel_url: initial?.youtube_channel_url ?? "",
+    tiktok_url: initial?.tiktok_url ?? "",
+    website_url: initial?.website_url ?? "",
+  };
+}
+
+export function ArtistForm({ action, initialValues, submitLabel }: Props) {
+  const [state, formAction] = useActionState<ArtistFormState, FormData>(
+    action,
+    {}
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<ArtistFormValues>({
+    defaultValues: toFormValues(initialValues),
+  });
+
+  useEffect(() => {
+    if (!state.fieldErrors) return;
+    for (const [field, message] of Object.entries(state.fieldErrors)) {
+      if (message) {
+        setError(field as keyof ArtistFormValues, {
+          type: "server",
+          message,
+        });
+      }
+    }
+  }, [state, setError]);
+
+  const onSubmit = handleSubmit((values) => {
+    const formData = new FormData();
+    for (const [key, value] of Object.entries(values)) {
+      formData.append(key, value ?? "");
+    }
+    startTransition(() => {
+      formAction(formData);
+    });
+  });
+
+  const inputClass =
+    "mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky";
+
+  return (
+    <form onSubmit={onSubmit} noValidate className="space-y-6">
+      {state.error && (
+        <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
+          {state.error}
+        </p>
+      )}
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-semibold text-brand-brown-dark">基本情報</h2>
+
+        <Field
+          id="name"
+          label={FIELD_LABELS.name}
+          required
+          error={errors.name?.message}
+        >
+          <input
+            id="name"
+            type="text"
+            autoComplete="off"
+            className={inputClass}
+            {...register("name", {
+              required: "名前を入力してください",
+              maxLength: { value: 100, message: "100文字以内で入力してください" },
+            })}
+          />
+        </Field>
+
+        <Field
+          id="kana_name"
+          label={FIELD_LABELS.kana_name}
+          error={errors.kana_name?.message}
+        >
+          <input
+            id="kana_name"
+            type="text"
+            autoComplete="off"
+            className={inputClass}
+            {...register("kana_name", {
+              maxLength: { value: 100, message: "100文字以内で入力してください" },
+            })}
+          />
+        </Field>
+
+        <Field
+          id="profile"
+          label={FIELD_LABELS.profile}
+          error={errors.profile?.message}
+        >
+          <textarea
+            id="profile"
+            rows={4}
+            className={inputClass}
+            {...register("profile")}
+          />
+        </Field>
+
+        <Field
+          id="debut_year"
+          label={FIELD_LABELS.debut_year}
+          error={errors.debut_year?.message}
+        >
+          <input
+            id="debut_year"
+            type="number"
+            inputMode="numeric"
+            min={1900}
+            max={2100}
+            className={inputClass}
+            {...register("debut_year", {
+              validate: (value) => {
+                if (!value) return true;
+                const num = Number(value);
+                if (!Number.isInteger(num) || num < 1900 || num > 2100) {
+                  return "1900〜2100の整数で入力してください";
+                }
+                return true;
+              },
+            })}
+          />
+        </Field>
+
+        <Field
+          id="image_url"
+          label={FIELD_LABELS.image_url}
+          error={errors.image_url?.message}
+        >
+          <input
+            id="image_url"
+            type="url"
+            inputMode="url"
+            className={inputClass}
+            placeholder="https://..."
+            {...register("image_url", {
+              pattern: { value: URL_PATTERN, message: "http(s)のURLを入力してください" },
+            })}
+          />
+        </Field>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-semibold text-brand-brown-dark">SNS</h2>
+
+        {(
+          [
+            "x_url",
+            "instagram_url",
+            "note_url",
+            "youtube_channel_url",
+            "tiktok_url",
+            "website_url",
+          ] as const
+        ).map((key) => (
+          <Field
+            key={key}
+            id={key}
+            label={FIELD_LABELS[key]}
+            error={errors[key]?.message}
+          >
+            <input
+              id={key}
+              type="url"
+              inputMode="url"
+              className={inputClass}
+              placeholder="https://..."
+              {...register(key, {
+                pattern: { value: URL_PATTERN, message: "http(s)のURLを入力してください" },
+              })}
+            />
+          </Field>
+        ))}
+      </section>
+
+      <div className="flex items-center gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isPending ? "保存中..." : submitLabel}
+        </button>
+        <Link
+          href="/admin/artists"
+          className="rounded-md border border-brand-border-light px-4 py-2 text-sm text-brand-brown-dark transition hover:bg-brand-bg-light"
+        >
+          キャンセル
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  id,
+  label,
+  required,
+  error,
+  children,
+}: {
+  id: string;
+  label: string;
+  required?: boolean;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-brand-brown-dark">
+        {label}
+        {required && <span className="ml-1 text-red-600">*</span>}
+      </label>
+      {children}
+      {error && (
+        <p className="mt-1 text-xs text-red-600" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/actions/artists.ts
+++ b/src/lib/actions/artists.ts
@@ -1,0 +1,147 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type { ArtistInput } from "@/lib/types/artist";
+
+export type ArtistFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof ArtistInput, string>>;
+};
+
+type ArtistUrlField =
+  | "image_url"
+  | "x_url"
+  | "instagram_url"
+  | "note_url"
+  | "youtube_channel_url"
+  | "tiktok_url"
+  | "website_url";
+
+const URL_FIELDS: ArtistUrlField[] = [
+  "image_url",
+  "x_url",
+  "instagram_url",
+  "note_url",
+  "youtube_channel_url",
+  "tiktok_url",
+  "website_url",
+];
+
+function toNullableString(value: FormDataEntryValue | null): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function parseFormData(formData: FormData): {
+  values: ArtistInput;
+  fieldErrors: ArtistFormState["fieldErrors"];
+} {
+  const fieldErrors: ArtistFormState["fieldErrors"] = {};
+
+  const name = String(formData.get("name") ?? "").trim();
+  if (!name) {
+    fieldErrors.name = "名前を入力してください";
+  }
+
+  const debutYearRaw = toNullableString(formData.get("debut_year"));
+  let debutYear: number | null = null;
+  if (debutYearRaw !== null) {
+    const parsed = Number(debutYearRaw);
+    if (!Number.isInteger(parsed) || parsed < 1900 || parsed > 2100) {
+      fieldErrors.debut_year = "デビュー年は1900〜2100の整数で入力してください";
+    } else {
+      debutYear = parsed;
+    }
+  }
+
+  const values: ArtistInput = {
+    name,
+    kana_name: toNullableString(formData.get("kana_name")),
+    profile: toNullableString(formData.get("profile")),
+    debut_year: debutYear,
+    image_url: toNullableString(formData.get("image_url")),
+    x_url: toNullableString(formData.get("x_url")),
+    instagram_url: toNullableString(formData.get("instagram_url")),
+    note_url: toNullableString(formData.get("note_url")),
+    youtube_channel_url: toNullableString(formData.get("youtube_channel_url")),
+    tiktok_url: toNullableString(formData.get("tiktok_url")),
+    website_url: toNullableString(formData.get("website_url")),
+  };
+
+  for (const key of URL_FIELDS) {
+    const value = values[key];
+    if (value === null) continue;
+    try {
+      const parsed = new URL(value);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        fieldErrors[key] = "http(s)のURLを入力してください";
+      }
+    } catch {
+      fieldErrors[key] = "正しいURL形式で入力してください";
+    }
+  }
+
+  return { values, fieldErrors };
+}
+
+export async function createArtist(
+  _prev: ArtistFormState,
+  formData: FormData
+): Promise<ArtistFormState> {
+  const { values, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.from("artists").insert(values);
+
+  if (error) {
+    return { error: `芸人の登録に失敗しました: ${error.message}` };
+  }
+
+  revalidatePath("/admin/artists");
+  redirect("/admin/artists");
+}
+
+export async function updateArtist(
+  id: string,
+  _prev: ArtistFormState,
+  formData: FormData
+): Promise<ArtistFormState> {
+  const { values, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("artists")
+    .update({ ...values, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    return { error: `芸人の更新に失敗しました: ${error.message}` };
+  }
+
+  revalidatePath("/admin/artists");
+  revalidatePath(`/admin/artists/${id}/edit`);
+  redirect("/admin/artists");
+}
+
+export async function deleteArtist(formData: FormData): Promise<void> {
+  const id = String(formData.get("id") ?? "").trim();
+  if (!id) return;
+
+  const supabase = await createClient();
+  const { error } = await supabase.from("artists").delete().eq("id", id);
+
+  if (error) {
+    throw new Error(`芸人の削除に失敗しました: ${error.message}`);
+  }
+
+  revalidatePath("/admin/artists");
+}

--- a/src/lib/actions/artists.ts
+++ b/src/lib/actions/artists.ts
@@ -44,6 +44,13 @@ function parseFormData(formData: FormData): {
   const name = String(formData.get("name") ?? "").trim();
   if (!name) {
     fieldErrors.name = "名前を入力してください";
+  } else if (name.length > 100) {
+    fieldErrors.name = "100文字以内で入力してください";
+  }
+
+  const kanaName = toNullableString(formData.get("kana_name"));
+  if (kanaName !== null && kanaName.length > 100) {
+    fieldErrors.kana_name = "100文字以内で入力してください";
   }
 
   const debutYearRaw = toNullableString(formData.get("debut_year"));
@@ -59,7 +66,7 @@ function parseFormData(formData: FormData): {
 
   const values: ArtistInput = {
     name,
-    kana_name: toNullableString(formData.get("kana_name")),
+    kana_name: kanaName,
     profile: toNullableString(formData.get("profile")),
     debut_year: debutYear,
     image_url: toNullableString(formData.get("image_url")),

--- a/src/lib/queries/artists.ts
+++ b/src/lib/queries/artists.ts
@@ -1,0 +1,32 @@
+import { createClient } from "@/lib/supabase/server";
+import type { Artist } from "@/lib/types/artist";
+
+export async function listArtists(): Promise<Artist[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("artists")
+    .select("*")
+    .order("kana_name", { ascending: true, nullsFirst: false })
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw new Error(`芸人一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as Artist[];
+}
+
+export async function getArtist(id: string): Promise<Artist | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("artists")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`芸人情報の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? null) as Artist | null;
+}

--- a/src/lib/types/artist.ts
+++ b/src/lib/types/artist.ts
@@ -1,0 +1,30 @@
+export type Artist = {
+  id: string;
+  name: string;
+  kana_name: string | null;
+  profile: string | null;
+  debut_year: number | null;
+  image_url: string | null;
+  x_url: string | null;
+  instagram_url: string | null;
+  note_url: string | null;
+  youtube_channel_url: string | null;
+  tiktok_url: string | null;
+  website_url: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ArtistInput = {
+  name: string;
+  kana_name: string | null;
+  profile: string | null;
+  debut_year: number | null;
+  image_url: string | null;
+  x_url: string | null;
+  instagram_url: string | null;
+  note_url: string | null;
+  youtube_channel_url: string | null;
+  tiktok_url: string | null;
+  website_url: string | null;
+};


### PR DESCRIPTION
## 概要

issue #7「1-7 管理画面：芸人 CRUD」を実装しました。`artists` テーブルに対する CRUD 管理画面と、react-hook-form を用いたフォームを追加しています。

## 追加ファイル

- `src/app/admin/artists/page.tsx` — 一覧（テーブル表示 + 削除ボタン）
- `src/app/admin/artists/new/page.tsx` — 新規作成
- `src/app/admin/artists/[id]/edit/page.tsx` — 編集（`updateArtist.bind(null, id)` で id を固定）
- `src/components/features/artist/artist-form.tsx` — 共通フォーム（react-hook-form）
- `src/components/features/artist/artist-delete-button.tsx` — 確認ダイアログ付き削除ボタン
- `src/lib/actions/artists.ts` — Server Actions（create / update / delete）
- `src/lib/queries/artists.ts` — Server Component からの取得
- `src/lib/types/artist.ts` — `Artist` / `ArtistInput` 型

## フォーム項目

- 基本情報: `name`（必須）, `kana_name`, `profile`, `debut_year`, `image_url`
- SNS: `x_url`, `instagram_url`, `note_url`, `youtube_channel_url`, `tiktok_url`, `website_url`

## バリデーション方針

- クライアント側: react-hook-form で必須チェック、URL 形式、`debut_year` の数値範囲（1900〜2100）を検証
- サーバ側: 同じ条件を Server Action でも再チェックし、`fieldErrors` として UI に反映
- 空文字は `null` に正規化して INSERT / UPDATE

## 動作確認

- [x] `pnpm lint`
- [x] `pnpm build`（型チェック含む）
- [ ] 実機での一覧・作成・編集・削除の動作確認（環境変数が必要なため後続で実施）

Closes #7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full artist management in the admin dashboard: list (sorted), empty-state, create, edit, and delete
  * Create/edit form with client-side validation, URL validation, and server-side error feedback
  * Delete button shows confirmation and displays in-progress state
  * Navigation links for returning to the artist list and contextual headings for edit/new screens
<!-- end of auto-generated comment: release notes by coderabbit.ai -->