### PR TITLE
feat: ユニット CRUD・受賞歴 CRUD・cast-selector を追加 (#9, #10, #11)

### DIFF
--- a/src/app/admin/achievements/[id]/edit/page.tsx
+++ b/src/app/admin/achievements/[id]/edit/page.tsx
@@ -48,7 +48,7 @@ export default async function EditAchievementPage({ params }: Props) {
           artists={artists}
           combos={combos}
           units={units}
-          initialValues={achievement ?? undefined}
+          initialValues={achievement}
           submitLabel="更新する"
         />
       </div>

--- a/src/app/admin/achievements/[id]/edit/page.tsx
+++ b/src/app/admin/achievements/[id]/edit/page.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { AchievementForm } from "@/components/features/achievement/achievement-form";
+import { updateAchievement } from "@/lib/actions/achievements";
+import { getAchievement } from "@/lib/queries/achievements";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditAchievementPage({ params }: Props) {
+  const { id } = await params;
+  const [achievement, artists, combos, units] = await Promise.all([
+    getAchievement(id),
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  if (!achievement) {
+    notFound();
+  }
+
+  const action = updateAchievement.bind(null, id);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/achievements"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← 受賞歴一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          受賞歴を編集
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <AchievementForm
+          action={action}
+          artists={artists}
+          combos={combos}
+          units={units}
+          initialValues={achievement ?? undefined}
+          submitLabel="更新する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/achievements/new/page.tsx
+++ b/src/app/admin/achievements/new/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { AchievementForm } from "@/components/features/achievement/achievement-form";
+import { createAchievement } from "@/lib/actions/achievements";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewAchievementPage() {
+  const [artists, combos, units] = await Promise.all([
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/achievements"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← 受賞歴一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          受賞歴を新規作成
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <AchievementForm
+          action={createAchievement}
+          artists={artists}
+          combos={combos}
+          units={units}
+          submitLabel="作成する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/achievements/page.tsx
+++ b/src/app/admin/achievements/page.tsx
@@ -2,14 +2,13 @@ import Link from "next/link";
 import { AchievementDeleteButton } from "@/components/features/achievement/achievement-delete-button";
 import { deleteAchievement } from "@/lib/actions/achievements";
 import { listAchievements } from "@/lib/queries/achievements";
+import type { AchievementWithTarget } from "@/lib/types/achievement";
 
 export const dynamic = "force-dynamic";
 
-function targetName(achievement: {
-  artist: { name: string } | null;
-  comedy_group: { name: string } | null;
-  unit: { name: string } | null;
-}): string {
+function targetName(
+  achievement: Pick<AchievementWithTarget, "artist" | "comedy_group" | "unit">
+): string {
   return (
     achievement.comedy_group?.name ??
     achievement.artist?.name ??

--- a/src/app/admin/achievements/page.tsx
+++ b/src/app/admin/achievements/page.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+import { AchievementDeleteButton } from "@/components/features/achievement/achievement-delete-button";
+import { deleteAchievement } from "@/lib/actions/achievements";
+import { listAchievements } from "@/lib/queries/achievements";
+
+export const dynamic = "force-dynamic";
+
+function targetName(achievement: {
+  artist: { name: string } | null;
+  comedy_group: { name: string } | null;
+  unit: { name: string } | null;
+}): string {
+  return (
+    achievement.comedy_group?.name ??
+    achievement.artist?.name ??
+    achievement.unit?.name ??
+    "—"
+  );
+}
+
+export default async function AdminAchievementsPage() {
+  const achievements = await listAchievements();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-brand-brown-dark">受賞歴</h1>
+          <p className="mt-1 text-sm text-brand-brown-light">
+            M-1, KOC, R-1 等の大会実績を管理します。
+          </p>
+        </div>
+        <Link
+          href="/admin/achievements/new"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark"
+        >
+          新規作成
+        </Link>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+        {achievements.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
+            まだ受賞歴が登録されていません。
+          </p>
+        ) : (
+          <table className="min-w-full divide-y divide-brand-border-light text-sm">
+            <thead className="bg-brand-bg-light text-xs text-brand-brown-light">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium">年</th>
+                <th className="px-4 py-2 text-left font-medium">大会名</th>
+                <th className="px-4 py-2 text-left font-medium">結果</th>
+                <th className="px-4 py-2 text-left font-medium">対象</th>
+                <th className="px-4 py-2 text-right font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-border-light">
+              {achievements.map((achievement) => (
+                <tr key={achievement.id} className="hover:bg-brand-bg-light">
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {achievement.year}
+                  </td>
+                  <td className="px-4 py-2 font-medium text-brand-brown-dark">
+                    {achievement.title}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {achievement.result}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {targetName(achievement)}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        href={`/admin/achievements/${achievement.id}/edit`}
+                        className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
+                      >
+                        編集
+                      </Link>
+                      <form action={deleteAchievement}>
+                        <input type="hidden" name="id" value={achievement.id} />
+                        <AchievementDeleteButton title={achievement.title} />
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/units/[id]/edit/page.tsx
+++ b/src/app/admin/units/[id]/edit/page.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { UnitForm } from "@/components/features/unit/unit-form";
+import { updateUnit } from "@/lib/actions/units";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { getUnit } from "@/lib/queries/units";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditUnitPage({ params }: Props) {
+  const { id } = await params;
+  const [unit, artists, combos] = await Promise.all([
+    getUnit(id),
+    listArtistSummaries(),
+    listComboSummaries(),
+  ]);
+
+  if (!unit) {
+    notFound();
+  }
+
+  const action = updateUnit.bind(null, id);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/units"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← ユニット一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          {unit.name} を編集
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <UnitForm
+          action={action}
+          artists={artists}
+          combos={combos}
+          initialValues={unit}
+          initialMembers={unit.members}
+          submitLabel="更新する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/units/new/page.tsx
+++ b/src/app/admin/units/new/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { UnitForm } from "@/components/features/unit/unit-form";
+import { createUnit } from "@/lib/actions/units";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewUnitPage() {
+  const [artists, combos] = await Promise.all([
+    listArtistSummaries(),
+    listComboSummaries(),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/units"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← ユニット一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          ユニットを新規作成
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <UnitForm
+          action={createUnit}
+          artists={artists}
+          combos={combos}
+          submitLabel="作成する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/units/page.tsx
+++ b/src/app/admin/units/page.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+import { UnitDeleteButton } from "@/components/features/unit/unit-delete-button";
+import { deleteUnit } from "@/lib/actions/units";
+import { listUnits } from "@/lib/queries/units";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminUnitsPage() {
+  const units = await listUnits();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-brand-brown-dark">ユニット</h1>
+          <p className="mt-1 text-sm text-brand-brown-light">
+            複数コンビ・個人が集まったユニットを管理します。
+          </p>
+        </div>
+        <Link
+          href="/admin/units/new"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark"
+        >
+          新規作成
+        </Link>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+        {units.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
+            まだユニットが登録されていません。
+          </p>
+        ) : (
+          <table className="min-w-full divide-y divide-brand-border-light text-sm">
+            <thead className="bg-brand-bg-light text-xs text-brand-brown-light">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium">名前</th>
+                <th className="px-4 py-2 text-left font-medium">説明</th>
+                <th className="px-4 py-2 text-right font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-border-light">
+              {units.map((unit) => (
+                <tr key={unit.id} className="hover:bg-brand-bg-light">
+                  <td className="px-4 py-2 font-medium text-brand-brown-dark">
+                    {unit.name}
+                  </td>
+                  <td className="max-w-xs truncate px-4 py-2 text-brand-brown-light">
+                    {unit.description ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        href={`/admin/units/${unit.id}/edit`}
+                        className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
+                      >
+                        編集
+                      </Link>
+                      <form action={deleteUnit}>
+                        <input type="hidden" name="id" value={unit.id} />
+                        <UnitDeleteButton name={unit.name} />
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/achievement/achievement-delete-button.tsx
+++ b/src/components/features/achievement/achievement-delete-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+
+type Props = {
+  title: string;
+};
+
+export function AchievementDeleteButton({ title }: Props) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      onClick={(event) => {
+        if (!window.confirm(`「${title}」を削除します。よろしいですか？`)) {
+          event.preventDefault();
+        }
+      }}
+      className="rounded-md border border-brand-gold px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-cream disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {pending ? "削除中..." : "削除"}
+    </button>
+  );
+}

--- a/src/components/features/achievement/achievement-form.tsx
+++ b/src/components/features/achievement/achievement-form.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import Link from "next/link";
+import {
+  useActionState,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
+import { useForm } from "react-hook-form";
+import type { AchievementFormState } from "@/lib/actions/achievements";
+import type { ArtistSummary } from "@/lib/queries/artists";
+import type { ComboSummary } from "@/lib/queries/combos";
+import type { UnitSummary } from "@/lib/queries/units";
+import type { Achievement, AchievementTargetType } from "@/lib/types/achievement";
+
+type AchievementFormAction = (
+  prev: AchievementFormState,
+  formData: FormData
+) => Promise<AchievementFormState>;
+
+type AchievementFormValues = {
+  title: string;
+  result: string;
+  year: string;
+  sort_order: string;
+};
+
+type Props = {
+  action: AchievementFormAction;
+  artists: ArtistSummary[];
+  combos: ComboSummary[];
+  units: UnitSummary[];
+  initialValues?: Partial<Achievement>;
+  submitLabel: string;
+};
+
+const TARGET_TYPE_OPTIONS: { value: AchievementTargetType; label: string }[] =
+  [
+    { value: "comedy_group", label: "コンビ" },
+    { value: "artist", label: "芸人（個人）" },
+    { value: "unit", label: "ユニット" },
+  ];
+
+function getInitialTargetType(
+  initial?: Partial<Achievement>
+): AchievementTargetType {
+  if (initial?.artist_id) return "artist";
+  if (initial?.unit_id) return "unit";
+  return "comedy_group";
+}
+
+function getInitialTargetId(
+  initial?: Partial<Achievement>,
+  type?: AchievementTargetType
+): string {
+  if (type === "artist") return initial?.artist_id ?? "";
+  if (type === "unit") return initial?.unit_id ?? "";
+  return initial?.comedy_group_id ?? "";
+}
+
+export function AchievementForm({
+  action,
+  artists,
+  combos,
+  units,
+  initialValues,
+  submitLabel,
+}: Props) {
+  const [state, formAction] = useActionState<AchievementFormState, FormData>(
+    action,
+    {}
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const defaultTargetType = getInitialTargetType(initialValues);
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<AchievementFormValues>({
+    defaultValues: {
+      title: initialValues?.title ?? "",
+      result: initialValues?.result ?? "",
+      year: initialValues?.year ? String(initialValues.year) : String(new Date().getFullYear()),
+      sort_order: String(initialValues?.sort_order ?? 0),
+    },
+  });
+
+  const [targetType, setTargetType] =
+    useState<AchievementTargetType>(defaultTargetType);
+  const [targetId, setTargetId] = useState(
+    getInitialTargetId(initialValues, defaultTargetType)
+  );
+
+  useEffect(() => {
+    if (!state.fieldErrors) return;
+    for (const [field, message] of Object.entries(state.fieldErrors)) {
+      if (!message) continue;
+      if (field === "target_type" || field === "target_id") continue;
+      setError(field as keyof AchievementFormValues, {
+        type: "server",
+        message,
+      });
+    }
+  }, [state, setError]);
+
+  const targetOptions = useMemo(() => {
+    if (targetType === "artist") {
+      return artists.map((a) => ({ id: a.id, label: a.name }));
+    }
+    if (targetType === "unit") {
+      return units.map((u) => ({ id: u.id, label: u.name }));
+    }
+    return combos.map((c) => ({ id: c.id, label: c.name }));
+  }, [targetType, artists, combos, units]);
+
+  const onSubmit = handleSubmit((values) => {
+    const formData = new FormData();
+    for (const [key, value] of Object.entries(values)) {
+      formData.append(key, value ?? "");
+    }
+    formData.append("target_type", targetType);
+    formData.append("target_id", targetId);
+    startTransition(() => {
+      formAction(formData);
+    });
+  });
+
+  const inputClass =
+    "mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky";
+
+  const targetTypeError = state.fieldErrors?.target_type;
+  const targetIdError = state.fieldErrors?.target_id;
+
+  return (
+    <form onSubmit={onSubmit} noValidate className="space-y-6">
+      {state.error && (
+        <p
+          className="rounded-md bg-brand-cream px-3 py-2 text-sm text-brand-brown-dark"
+          role="alert"
+        >
+          {state.error}
+        </p>
+      )}
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-semibold text-brand-brown-dark">受賞情報</h2>
+
+        <Field id="title" label="大会名・タイトル" required error={errors.title?.message}>
+          <input
+            id="title"
+            type="text"
+            autoComplete="off"
+            className={inputClass}
+            placeholder="例: M-1グランプリ 2025"
+            {...register("title", {
+              required: "タイトルを入力してください",
+              maxLength: { value: 200, message: "200文字以内で入力してください" },
+            })}
+          />
+        </Field>
+
+        <Field id="result" label="結果" required error={errors.result?.message}>
+          <input
+            id="result"
+            type="text"
+            autoComplete="off"
+            className={inputClass}
+            placeholder="例: 準優勝、準決勝進出"
+            {...register("result", {
+              required: "結果を入力してください",
+              maxLength: { value: 100, message: "100文字以内で入力してください" },
+            })}
+          />
+        </Field>
+
+        <Field id="year" label="年" required error={errors.year?.message}>
+          <input
+            id="year"
+            type="number"
+            inputMode="numeric"
+            min={1900}
+            max={2100}
+            className={inputClass}
+            {...register("year", {
+              required: "年を入力してください",
+              validate: (value) => {
+                const num = Number(value);
+                if (!Number.isInteger(num) || num < 1900 || num > 2100) {
+                  return "1900〜2100の整数で入力してください";
+                }
+                return true;
+              },
+            })}
+          />
+        </Field>
+
+        <Field
+          id="sort_order"
+          label="表示順（小さいほど上に表示）"
+          error={errors.sort_order?.message}
+        >
+          <input
+            id="sort_order"
+            type="number"
+            inputMode="numeric"
+            className={inputClass}
+            {...register("sort_order")}
+          />
+        </Field>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-semibold text-brand-brown-dark">対象</h2>
+
+        <div>
+          <label className="block text-sm font-medium text-brand-brown-dark">
+            種別 <span className="ml-1 text-brand-gold">*</span>
+          </label>
+          <div className="mt-2 flex gap-3">
+            {TARGET_TYPE_OPTIONS.map((opt) => (
+              <label key={opt.value} className="flex items-center gap-1.5 text-sm text-brand-brown-dark cursor-pointer">
+                <input
+                  type="radio"
+                  value={opt.value}
+                  checked={targetType === opt.value}
+                  onChange={() => {
+                    setTargetType(opt.value);
+                    setTargetId("");
+                  }}
+                  className="accent-brand-sky"
+                />
+                {opt.label}
+              </label>
+            ))}
+          </div>
+          {targetTypeError && (
+            <p className="mt-1 text-xs text-brand-gold" role="alert">
+              {targetTypeError}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor="target_id"
+            className="block text-sm font-medium text-brand-brown-dark"
+          >
+            対象を選択 <span className="ml-1 text-brand-gold">*</span>
+          </label>
+          <select
+            id="target_id"
+            value={targetId}
+            onChange={(e) => setTargetId(e.target.value)}
+            className={inputClass}
+          >
+            <option value="">-- 選択してください --</option>
+            {targetOptions.map((opt) => (
+              <option key={opt.id} value={opt.id}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          {targetIdError && (
+            <p className="mt-1 text-xs text-brand-gold" role="alert">
+              {targetIdError}
+            </p>
+          )}
+          {targetOptions.length === 0 && (
+            <p className="mt-1 text-xs text-brand-brown-light">
+              対象が登録されていません。先に登録してください。
+            </p>
+          )}
+        </div>
+      </section>
+
+      <div className="flex items-center gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isPending ? "保存中..." : submitLabel}
+        </button>
+        <Link
+          href="/admin/achievements"
+          className="rounded-md border border-brand-border-light px-4 py-2 text-sm text-brand-brown-dark transition hover:bg-brand-bg-light"
+        >
+          キャンセル
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  id,
+  label,
+  required,
+  error,
+  children,
+}: {
+  id: string;
+  label: string;
+  required?: boolean;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="block text-sm font-medium text-brand-brown-dark"
+      >
+        {label}
+        {required && <span className="ml-1 text-brand-gold">*</span>}
+      </label>
+      {children}
+      {error && (
+        <p className="mt-1 text-xs text-brand-gold" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/achievement/achievement-form.tsx
+++ b/src/components/features/achievement/achievement-form.tsx
@@ -131,7 +131,7 @@ export function AchievementForm({
   });
 
   const inputClass =
-    "mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky";
+    "mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky";
 
   const targetTypeError = state.fieldErrors?.target_type;
   const targetIdError = state.fieldErrors?.target_id;
@@ -226,6 +226,7 @@ export function AchievementForm({
               <label key={opt.value} className="flex items-center gap-1.5 text-sm text-brand-brown-dark cursor-pointer">
                 <input
                   type="radio"
+                  name="target_type"
                   value={opt.value}
                   checked={targetType === opt.value}
                   onChange={() => {
@@ -282,7 +283,7 @@ export function AchievementForm({
         <button
           type="submit"
           disabled={isPending}
-          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-brand-cream transition hover:bg-brand-sky-dark disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isPending ? "保存中..." : submitLabel}
         </button>

--- a/src/components/features/cast-selector/cast-search.tsx
+++ b/src/components/features/cast-selector/cast-search.tsx
@@ -4,15 +4,17 @@ type Props = {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  ariaLabel?: string;
 };
 
-export function CastSearch({ value, onChange, placeholder }: Props) {
+export function CastSearch({ value, onChange, placeholder, ariaLabel }: Props) {
   return (
     <input
       type="search"
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder ?? "名前で検索"}
+      aria-label={ariaLabel ?? placeholder ?? "名前で検索"}
       className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
     />
   );

--- a/src/components/features/cast-selector/cast-search.tsx
+++ b/src/components/features/cast-selector/cast-search.tsx
@@ -13,7 +13,7 @@ export function CastSearch({ value, onChange, placeholder }: Props) {
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder ?? "名前で検索"}
-      className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+      className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
     />
   );
 }

--- a/src/components/features/cast-selector/cast-search.tsx
+++ b/src/components/features/cast-selector/cast-search.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+};
+
+export function CastSearch({ value, onChange, placeholder }: Props) {
+  return (
+    <input
+      type="search"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder ?? "名前で検索"}
+      className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+    />
+  );
+}

--- a/src/components/features/cast-selector/cast-selector.tsx
+++ b/src/components/features/cast-selector/cast-selector.tsx
@@ -115,10 +115,17 @@ export function CastSelector({
         />
 
         <div>
+          <label
+            htmlFor="cast_selector_target"
+            className="block text-xs font-medium text-brand-brown-dark"
+          >
+            追加対象
+          </label>
           <select
+            id="cast_selector_target"
             value={selectedId}
             onChange={(e) => setSelectedId(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+            className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
           >
             <option value="">-- 選択してください --</option>
             {currentItems.map((item) => (

--- a/src/components/features/cast-selector/cast-selector.tsx
+++ b/src/components/features/cast-selector/cast-selector.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { CastSearch } from "./cast-search";
+import { CastTab } from "./cast-tab";
+import { CastTagList } from "./cast-tag-list";
+import type { ArtistSummary } from "@/lib/queries/artists";
+import type { ComboSummary } from "@/lib/queries/combos";
+import type { UnitSummary } from "@/lib/queries/units";
+import type { CastEntry, CastType } from "@/lib/types";
+
+type Props = {
+  artists: ArtistSummary[];
+  combos: ComboSummary[];
+  units: UnitSummary[];
+  value: CastEntry[];
+  onChange: (entries: CastEntry[]) => void;
+};
+
+export function CastSelector({
+  artists,
+  combos,
+  units,
+  value,
+  onChange,
+}: Props) {
+  const [activeTab, setActiveTab] = useState<CastType>("comedy_group");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedId, setSelectedId] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedIds = useMemo(() => {
+    const map = new Map<CastType, Set<string>>();
+    for (const entry of value) {
+      if (!map.has(entry.type)) map.set(entry.type, new Set());
+      map.get(entry.type)!.add(entry.id);
+    }
+    return map;
+  }, [value]);
+
+  const currentItems: { id: string; name: string; kana_name?: string | null }[] =
+    useMemo(() => {
+      const query = searchQuery.trim().toLowerCase();
+      const selected = selectedIds.get(activeTab) ?? new Set();
+
+      const filter = (items: { id: string; name: string; kana_name?: string | null }[]) =>
+        items
+          .filter((item) => !selected.has(item.id))
+          .filter((item) =>
+            !query
+              ? true
+              : item.name.toLowerCase().includes(query) ||
+                (item.kana_name ?? "").toLowerCase().includes(query)
+          );
+
+      if (activeTab === "comedy_group") return filter(combos);
+      if (activeTab === "artist") return filter(artists);
+      return filter(units);
+    }, [activeTab, searchQuery, selectedIds, artists, combos, units]);
+
+  const handleTabChange = (type: CastType) => {
+    setActiveTab(type);
+    setSearchQuery("");
+    setSelectedId("");
+    setError(null);
+  };
+
+  const handleAdd = () => {
+    if (!selectedId) {
+      setError("追加する対象を選択してください");
+      return;
+    }
+
+    const allItems =
+      activeTab === "comedy_group"
+        ? combos
+        : activeTab === "artist"
+          ? artists
+          : units;
+
+    const found = allItems.find((item) => item.id === selectedId);
+    if (!found) {
+      setError("選択した対象が見つかりません");
+      return;
+    }
+
+    if (selectedIds.get(activeTab)?.has(found.id)) {
+      setError("すでに追加されています");
+      return;
+    }
+
+    onChange([...value, { type: activeTab, id: found.id, name: found.name }]);
+    setSelectedId("");
+    setSearchQuery("");
+    setError(null);
+  };
+
+  const handleRemove = (entry: CastEntry) => {
+    onChange(value.filter((e) => !(e.type === entry.type && e.id === entry.id)));
+  };
+
+  return (
+    <div className="space-y-3">
+      <CastTagList entries={value} onRemove={handleRemove} />
+
+      <div className="space-y-3 rounded-md border border-dashed border-brand-border-light p-4">
+        <CastTab active={activeTab} onChange={handleTabChange} />
+
+        <CastSearch
+          value={searchQuery}
+          onChange={(q) => {
+            setSearchQuery(q);
+            setSelectedId("");
+          }}
+        />
+
+        <div>
+          <select
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          >
+            <option value="">-- 選択してください --</option>
+            {currentItems.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.name}
+                {item.kana_name ? `（${item.kana_name}）` : ""}
+              </option>
+            ))}
+          </select>
+          {currentItems.length === 0 && (
+            <p className="mt-1 text-xs text-brand-brown-light">
+              該当する対象がいません。
+            </p>
+          )}
+        </div>
+
+        {error && (
+          <p className="text-xs text-brand-gold" role="alert">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="rounded-md border border-brand-sky px-3 py-1 text-xs text-brand-sky transition hover:bg-brand-sky-pale"
+        >
+          出演者を追加
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/cast-selector/cast-selector.tsx
+++ b/src/components/features/cast-selector/cast-selector.tsx
@@ -124,7 +124,10 @@ export function CastSelector({
           <select
             id="cast_selector_target"
             value={selectedId}
-            onChange={(e) => setSelectedId(e.target.value)}
+            onChange={(e) => {
+              setSelectedId(e.target.value);
+              setError(null);
+            }}
             className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
           >
             <option value="">-- 選択してください --</option>

--- a/src/components/features/cast-selector/cast-tab.tsx
+++ b/src/components/features/cast-selector/cast-tab.tsx
@@ -20,6 +20,7 @@ export function CastTab({ active, onChange }: Props) {
         <button
           key={tab.type}
           type="button"
+          aria-pressed={active === tab.type}
           onClick={() => onChange(tab.type)}
           className={
             active === tab.type

--- a/src/components/features/cast-selector/cast-tab.tsx
+++ b/src/components/features/cast-selector/cast-tab.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { CastType } from "@/lib/types";
+
+const TABS: { type: CastType; label: string }[] = [
+  { type: "comedy_group", label: "コンビ" },
+  { type: "artist", label: "芸人" },
+  { type: "unit", label: "ユニット" },
+];
+
+type Props = {
+  active: CastType;
+  onChange: (type: CastType) => void;
+};
+
+export function CastTab({ active, onChange }: Props) {
+  return (
+    <div className="flex gap-2">
+      {TABS.map((tab) => (
+        <button
+          key={tab.type}
+          type="button"
+          onClick={() => onChange(tab.type)}
+          className={
+            active === tab.type
+              ? "rounded-md bg-brand-sky px-3 py-1 text-xs font-medium text-white"
+              : "rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
+          }
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/features/cast-selector/cast-tab.tsx
+++ b/src/components/features/cast-selector/cast-tab.tsx
@@ -23,7 +23,7 @@ export function CastTab({ active, onChange }: Props) {
           onClick={() => onChange(tab.type)}
           className={
             active === tab.type
-              ? "rounded-md bg-brand-sky px-3 py-1 text-xs font-medium text-white"
+              ? "rounded-md bg-brand-sky px-3 py-1 text-xs font-medium text-brand-cream"
               : "rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
           }
         >

--- a/src/components/features/cast-selector/cast-tag-list.tsx
+++ b/src/components/features/cast-selector/cast-tag-list.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import type { CastEntry } from "@/lib/types";
+import type { CastEntry, CastType } from "@/lib/types";
 
-const TYPE_LABELS: Record<string, string> = {
+const TYPE_LABELS: Record<CastType, string> = {
   artist: "個人",
   comedy_group: "コンビ",
   unit: "ユニット",
@@ -30,7 +30,7 @@ export function CastTagList({ entries, onRemove }: Props) {
           className="flex items-center gap-1 rounded-full border border-brand-border-light bg-brand-bg-light px-3 py-1 text-xs text-brand-brown-dark"
         >
           <span className="text-brand-brown-light">
-            {TYPE_LABELS[entry.type] ?? entry.type}
+            {TYPE_LABELS[entry.type]}
           </span>
           <span className="font-medium">{entry.name}</span>
           <button

--- a/src/components/features/cast-selector/cast-tag-list.tsx
+++ b/src/components/features/cast-selector/cast-tag-list.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { CastEntry } from "@/lib/types";
+
+const TYPE_LABELS: Record<string, string> = {
+  artist: "個人",
+  comedy_group: "コンビ",
+  unit: "ユニット",
+};
+
+type Props = {
+  entries: CastEntry[];
+  onRemove: (entry: CastEntry) => void;
+};
+
+export function CastTagList({ entries, onRemove }: Props) {
+  if (entries.length === 0) {
+    return (
+      <p className="text-xs text-brand-brown-light">
+        出演者がまだ選択されていません。
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {entries.map((entry) => (
+        <li
+          key={`${entry.type}:${entry.id}`}
+          className="flex items-center gap-1 rounded-full border border-brand-border-light bg-brand-bg-light px-3 py-1 text-xs text-brand-brown-dark"
+        >
+          <span className="text-brand-brown-light">
+            {TYPE_LABELS[entry.type] ?? entry.type}
+          </span>
+          <span className="font-medium">{entry.name}</span>
+          <button
+            type="button"
+            aria-label={`${entry.name} を解除`}
+            onClick={() => onRemove(entry)}
+            className="ml-1 rounded-full text-brand-brown-light transition hover:text-brand-sky"
+          >
+            ×
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/features/unit/unit-delete-button.tsx
+++ b/src/components/features/unit/unit-delete-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+
+type Props = {
+  name: string;
+};
+
+export function UnitDeleteButton({ name }: Props) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      onClick={(event) => {
+        if (!window.confirm(`「${name}」を削除します。よろしいですか？`)) {
+          event.preventDefault();
+        }
+      }}
+      className="rounded-md border border-brand-gold px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-cream disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {pending ? "削除中..." : "削除"}
+    </button>
+  );
+}

--- a/src/components/features/unit/unit-form.tsx
+++ b/src/components/features/unit/unit-form.tsx
@@ -270,14 +270,12 @@ export function UnitForm({
         </div>
 
         <div className="space-y-3 rounded-md border border-dashed border-brand-border-light p-4">
-          <div className="flex gap-2" role="tablist" aria-label="メンバー種別">
+          <div className="flex gap-2" role="group" aria-label="メンバー種別">
             {(["comedy_group", "artist"] as const).map((tab) => (
               <button
                 key={tab}
                 type="button"
-                role="tab"
-                aria-selected={activeTab === tab}
-                tabIndex={activeTab === tab ? 0 : -1}
+                aria-pressed={activeTab === tab}
                 onClick={() => {
                   setActiveTab(tab);
                   setSelectedId("");

--- a/src/components/features/unit/unit-form.tsx
+++ b/src/components/features/unit/unit-form.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import Link from "next/link";
+import {
+  useActionState,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
+import { useForm } from "react-hook-form";
+import type { UnitFormState } from "@/lib/actions/units";
+import type { ArtistSummary } from "@/lib/queries/artists";
+import type { ComboSummary } from "@/lib/queries/combos";
+import type { UnitInput, UnitMemberEntry } from "@/lib/types/unit";
+
+type UnitFormAction = (
+  prev: UnitFormState,
+  formData: FormData
+) => Promise<UnitFormState>;
+
+type UnitFormValues = {
+  name: string;
+  description: string;
+};
+
+type Props = {
+  action: UnitFormAction;
+  artists: ArtistSummary[];
+  combos: ComboSummary[];
+  initialValues?: Partial<UnitInput>;
+  initialMembers?: UnitMemberEntry[];
+  submitLabel: string;
+};
+
+type MemberTab = "comedy_group" | "artist";
+
+function toFormValues(initial?: Partial<UnitInput>): UnitFormValues {
+  return {
+    name: initial?.name ?? "",
+    description: initial?.description ?? "",
+  };
+}
+
+export function UnitForm({
+  action,
+  artists,
+  combos,
+  initialValues,
+  initialMembers,
+  submitLabel,
+}: Props) {
+  const [state, formAction] = useActionState<UnitFormState, FormData>(
+    action,
+    {}
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<UnitFormValues>({
+    defaultValues: toFormValues(initialValues),
+  });
+
+  const [members, setMembers] = useState<UnitMemberEntry[]>(
+    () => initialMembers ?? []
+  );
+  const [localMemberError, setLocalMemberError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<MemberTab>("comedy_group");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedId, setSelectedId] = useState("");
+
+  const memberError = localMemberError ?? state.fieldErrors?.members ?? null;
+
+  const selectedComboIds = useMemo(
+    () =>
+      new Set(
+        members.filter((m) => m.type === "comedy_group").map((m) => m.id)
+      ),
+    [members]
+  );
+  const selectedArtistIds = useMemo(
+    () =>
+      new Set(members.filter((m) => m.type === "artist").map((m) => m.id)),
+    [members]
+  );
+
+  const filteredCombos = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    return combos
+      .filter((c) => !selectedComboIds.has(c.id))
+      .filter((c) =>
+        !q
+          ? true
+          : c.name.toLowerCase().includes(q) ||
+            (c.kana_name ?? "").toLowerCase().includes(q)
+      );
+  }, [combos, searchQuery, selectedComboIds]);
+
+  const filteredArtists = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    return artists
+      .filter((a) => !selectedArtistIds.has(a.id))
+      .filter((a) =>
+        !q
+          ? true
+          : a.name.toLowerCase().includes(q) ||
+            (a.kana_name ?? "").toLowerCase().includes(q)
+      );
+  }, [artists, searchQuery, selectedArtistIds]);
+
+  useEffect(() => {
+    if (!state.fieldErrors) return;
+    for (const [field, message] of Object.entries(state.fieldErrors)) {
+      if (!message) continue;
+      if (field === "members") continue;
+      setError(field as keyof UnitFormValues, { type: "server", message });
+    }
+  }, [state, setError]);
+
+  const addMember = () => {
+    if (!selectedId) {
+      setLocalMemberError("追加する対象を選択してください");
+      return;
+    }
+
+    if (activeTab === "comedy_group") {
+      const combo = combos.find((c) => c.id === selectedId);
+      if (!combo) {
+        setLocalMemberError("選択したコンビが見つかりません");
+        return;
+      }
+      if (selectedComboIds.has(combo.id)) {
+        setLocalMemberError("すでに追加されています");
+        return;
+      }
+      setMembers((prev) => [
+        ...prev,
+        { type: "comedy_group", id: combo.id, name: combo.name, kana_name: combo.kana_name },
+      ]);
+    } else {
+      const artist = artists.find((a) => a.id === selectedId);
+      if (!artist) {
+        setLocalMemberError("選択した芸人が見つかりません");
+        return;
+      }
+      if (selectedArtistIds.has(artist.id)) {
+        setLocalMemberError("すでに追加されています");
+        return;
+      }
+      setMembers((prev) => [
+        ...prev,
+        { type: "artist", id: artist.id, name: artist.name, kana_name: artist.kana_name },
+      ]);
+    }
+
+    setSelectedId("");
+    setSearchQuery("");
+    setLocalMemberError(null);
+  };
+
+  const removeMember = (type: MemberTab, id: string) => {
+    setMembers((prev) => prev.filter((m) => !(m.type === type && m.id === id)));
+  };
+
+  const onSubmit = handleSubmit((values) => {
+    const formData = new FormData();
+    for (const [key, value] of Object.entries(values)) {
+      formData.append(key, value ?? "");
+    }
+    for (const m of members) {
+      formData.append("member_type", m.type);
+      formData.append("member_id", m.id);
+      formData.append("member_name", m.name);
+    }
+    startTransition(() => {
+      formAction(formData);
+    });
+  });
+
+  const inputClass =
+    "mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky";
+
+  const currentList =
+    activeTab === "comedy_group" ? filteredCombos : filteredArtists;
+
+  return (
+    <form onSubmit={onSubmit} noValidate className="space-y-6">
+      {state.error && (
+        <p
+          className="rounded-md bg-brand-cream px-3 py-2 text-sm text-brand-brown-dark"
+          role="alert"
+        >
+          {state.error}
+        </p>
+      )}
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-semibold text-brand-brown-dark">基本情報</h2>
+
+        <Field id="name" label="名前" required error={errors.name?.message}>
+          <input
+            id="name"
+            type="text"
+            autoComplete="off"
+            className={inputClass}
+            {...register("name", {
+              required: "名前を入力してください",
+              maxLength: { value: 100, message: "100文字以内で入力してください" },
+            })}
+          />
+        </Field>
+
+        <Field id="description" label="説明" error={errors.description?.message}>
+          <textarea
+            id="description"
+            rows={4}
+            className={inputClass}
+            {...register("description")}
+          />
+        </Field>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-semibold text-brand-brown-dark">メンバー</h2>
+
+        {memberError && (
+          <p
+            className="rounded-md bg-brand-cream px-3 py-2 text-sm text-brand-brown-dark"
+            role="alert"
+          >
+            {memberError}
+          </p>
+        )}
+
+        <div className="space-y-2">
+          {members.length === 0 ? (
+            <p className="text-xs text-brand-brown-light">
+              まだメンバーが追加されていません。
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {members.map((m) => (
+                <li
+                  key={`${m.type}:${m.id}`}
+                  className="flex items-center justify-between gap-3 rounded-md border border-brand-border-light bg-brand-bg-light px-3 py-2 text-sm"
+                >
+                  <div>
+                    <span className="rounded-sm bg-white px-2 py-0.5 text-xs text-brand-brown-light mr-2">
+                      {m.type === "comedy_group" ? "コンビ" : "個人"}
+                    </span>
+                    <span className="font-medium text-brand-brown-dark">
+                      {m.name}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      removeMember(m.type as MemberTab, m.id)
+                    }
+                    className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-white"
+                  >
+                    削除
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-3 rounded-md border border-dashed border-brand-border-light p-4">
+          <div className="flex gap-2">
+            {(["comedy_group", "artist"] as const).map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => {
+                  setActiveTab(tab);
+                  setSelectedId("");
+                  setSearchQuery("");
+                }}
+                className={
+                  activeTab === tab
+                    ? "rounded-md bg-brand-sky px-3 py-1 text-xs font-medium text-white"
+                    : "rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
+                }
+              >
+                {tab === "comedy_group" ? "コンビ" : "個人"}
+              </button>
+            ))}
+          </div>
+
+          <div>
+            <label
+              htmlFor="unit_member_search"
+              className="block text-xs font-medium text-brand-brown-dark"
+            >
+              {activeTab === "comedy_group" ? "コンビを検索" : "芸人を検索"}
+            </label>
+            <input
+              id="unit_member_search"
+              type="search"
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value);
+                setSelectedId("");
+              }}
+              placeholder="名前で検索"
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="unit_member_select"
+              className="block text-xs font-medium text-brand-brown-dark"
+            >
+              選択
+            </label>
+            <select
+              id="unit_member_select"
+              value={selectedId}
+              onChange={(e) => setSelectedId(e.target.value)}
+              className={inputClass}
+            >
+              <option value="">-- 選択してください --</option>
+              {currentList.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.name}
+                  {"kana_name" in item && item.kana_name
+                    ? `（${item.kana_name}）`
+                    : ""}
+                </option>
+              ))}
+            </select>
+            {currentList.length === 0 && (
+              <p className="mt-1 text-xs text-brand-brown-light">
+                該当する{activeTab === "comedy_group" ? "コンビ" : "芸人"}がいません。
+              </p>
+            )}
+          </div>
+
+          <button
+            type="button"
+            onClick={addMember}
+            className="rounded-md border border-brand-sky px-3 py-1 text-xs text-brand-sky transition hover:bg-brand-sky-pale"
+          >
+            メンバーを追加
+          </button>
+        </div>
+      </section>
+
+      <div className="flex items-center gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isPending ? "保存中..." : submitLabel}
+        </button>
+        <Link
+          href="/admin/units"
+          className="rounded-md border border-brand-border-light px-4 py-2 text-sm text-brand-brown-dark transition hover:bg-brand-bg-light"
+        >
+          キャンセル
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  id,
+  label,
+  required,
+  error,
+  children,
+}: {
+  id: string;
+  label: string;
+  required?: boolean;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="block text-sm font-medium text-brand-brown-dark"
+      >
+        {label}
+        {required && <span className="ml-1 text-brand-gold">*</span>}
+      </label>
+      {children}
+      {error && (
+        <p className="mt-1 text-xs text-brand-gold" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/unit/unit-form.tsx
+++ b/src/components/features/unit/unit-form.tsx
@@ -258,9 +258,7 @@ export function UnitForm({
                   </div>
                   <button
                     type="button"
-                    onClick={() =>
-                      removeMember(m.type as MemberTab, m.id)
-                    }
+                    onClick={() => removeMember(m.type, m.id)}
                     className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-card-light"
                   >
                     削除
@@ -272,11 +270,14 @@ export function UnitForm({
         </div>
 
         <div className="space-y-3 rounded-md border border-dashed border-brand-border-light p-4">
-          <div className="flex gap-2">
+          <div className="flex gap-2" role="tablist" aria-label="メンバー種別">
             {(["comedy_group", "artist"] as const).map((tab) => (
               <button
                 key={tab}
                 type="button"
+                role="tab"
+                aria-selected={activeTab === tab}
+                tabIndex={activeTab === tab ? 0 : -1}
                 onClick={() => {
                   setActiveTab(tab);
                   setSelectedId("");

--- a/src/components/features/unit/unit-form.tsx
+++ b/src/components/features/unit/unit-form.tsx
@@ -182,7 +182,7 @@ export function UnitForm({
   });
 
   const inputClass =
-    "mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky";
+    "mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky";
 
   const currentList =
     activeTab === "comedy_group" ? filteredCombos : filteredArtists;
@@ -261,7 +261,7 @@ export function UnitForm({
                     onClick={() =>
                       removeMember(m.type as MemberTab, m.id)
                     }
-                    className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-white"
+                    className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-card-light"
                   >
                     削除
                   </button>
@@ -281,10 +281,11 @@ export function UnitForm({
                   setActiveTab(tab);
                   setSelectedId("");
                   setSearchQuery("");
+                  setLocalMemberError(null);
                 }}
                 className={
                   activeTab === tab
-                    ? "rounded-md bg-brand-sky px-3 py-1 text-xs font-medium text-white"
+                    ? "rounded-md bg-brand-sky px-3 py-1 text-xs font-medium text-brand-cream"
                     : "rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
                 }
               >
@@ -357,7 +358,7 @@ export function UnitForm({
         <button
           type="submit"
           disabled={isPending}
-          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-brand-cream transition hover:bg-brand-sky-dark disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isPending ? "保存中..." : submitLabel}
         </button>

--- a/src/components/features/unit/unit-form.tsx
+++ b/src/components/features/unit/unit-form.tsx
@@ -249,7 +249,7 @@ export function UnitForm({
                   className="flex items-center justify-between gap-3 rounded-md border border-brand-border-light bg-brand-bg-light px-3 py-2 text-sm"
                 >
                   <div>
-                    <span className="rounded-sm bg-white px-2 py-0.5 text-xs text-brand-brown-light mr-2">
+                    <span className="mr-2 rounded-sm bg-brand-cream px-2 py-0.5 text-xs text-brand-brown-light">
                       {m.type === "comedy_group" ? "コンビ" : "個人"}
                     </span>
                     <span className="font-medium text-brand-brown-dark">

--- a/src/lib/actions/achievements.ts
+++ b/src/lib/actions/achievements.ts
@@ -54,9 +54,18 @@ function parseFormData(formData: FormData): {
     }
   }
 
-  const sortOrderRaw = String(formData.get("sort_order") ?? "0").trim();
-  const sortOrder = Number(sortOrderRaw);
-  const sortOrderVal = Number.isInteger(sortOrder) ? sortOrder : 0;
+  const sortOrderRaw = String(formData.get("sort_order") ?? "").trim();
+  let sortOrderVal = 0;
+  if (!sortOrderRaw) {
+    fieldErrors.sort_order = "表示順を入力してください";
+  } else {
+    const parsedSortOrder = Number(sortOrderRaw);
+    if (!Number.isInteger(parsedSortOrder)) {
+      fieldErrors.sort_order = "表示順は整数で入力してください";
+    } else {
+      sortOrderVal = parsedSortOrder;
+    }
+  }
 
   const targetType = String(formData.get("target_type") ?? "").trim();
   if (!(TARGET_TYPES as string[]).includes(targetType)) {
@@ -116,6 +125,10 @@ export async function updateAchievement(
   _prev: AchievementFormState,
   formData: FormData
 ): Promise<AchievementFormState> {
+  if (!UUID_PATTERN.test(id)) {
+    return { error: "IDが不正です" };
+  }
+
   const { values, fieldErrors } = parseFormData(formData);
   if (fieldErrors && Object.keys(fieldErrors).length > 0) {
     return { fieldErrors };
@@ -145,6 +158,9 @@ export async function updateAchievement(
 export async function deleteAchievement(formData: FormData): Promise<void> {
   const id = String(formData.get("id") ?? "").trim();
   if (!id) return;
+  if (!UUID_PATTERN.test(id)) {
+    throw new Error("IDが不正です");
+  }
 
   const supabase = await createClient();
 

--- a/src/lib/actions/achievements.ts
+++ b/src/lib/actions/achievements.ts
@@ -1,0 +1,149 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type { AchievementInput, AchievementTargetType } from "@/lib/types/achievement";
+
+export type AchievementFormState = {
+  error?: string;
+  fieldErrors?: Partial<
+    Record<keyof AchievementInput | "target_type" | "target_id", string>
+  >;
+};
+
+const TARGET_TYPES: AchievementTargetType[] = [
+  "artist",
+  "comedy_group",
+  "unit",
+];
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function parseFormData(formData: FormData): {
+  values: AchievementInput;
+  fieldErrors: AchievementFormState["fieldErrors"];
+} {
+  const fieldErrors: AchievementFormState["fieldErrors"] = {};
+
+  const title = String(formData.get("title") ?? "").trim();
+  if (!title) {
+    fieldErrors.title = "タイトルを入力してください";
+  } else if (title.length > 200) {
+    fieldErrors.title = "200文字以内で入力してください";
+  }
+
+  const result = String(formData.get("result") ?? "").trim();
+  if (!result) {
+    fieldErrors.result = "結果を入力してください";
+  } else if (result.length > 100) {
+    fieldErrors.result = "100文字以内で入力してください";
+  }
+
+  const yearRaw = String(formData.get("year") ?? "").trim();
+  let year = 0;
+  if (!yearRaw) {
+    fieldErrors.year = "年を入力してください";
+  } else {
+    const parsed = Number(yearRaw);
+    if (!Number.isInteger(parsed) || parsed < 1900 || parsed > 2100) {
+      fieldErrors.year = "1900〜2100の整数で入力してください";
+    } else {
+      year = parsed;
+    }
+  }
+
+  const sortOrderRaw = String(formData.get("sort_order") ?? "0").trim();
+  const sortOrder = Number(sortOrderRaw);
+  const sortOrderVal = Number.isInteger(sortOrder) ? sortOrder : 0;
+
+  const targetType = String(formData.get("target_type") ?? "").trim();
+  if (!(TARGET_TYPES as string[]).includes(targetType)) {
+    fieldErrors.target_type = "対象種別を選択してください";
+  }
+
+  const targetId = String(formData.get("target_id") ?? "").trim();
+  if (!targetId) {
+    fieldErrors.target_id = "対象を選択してください";
+  } else if (!UUID_PATTERN.test(targetId)) {
+    fieldErrors.target_id = "対象のIDが不正です";
+  }
+
+  const values: AchievementInput = {
+    artist_id: targetType === "artist" ? targetId : null,
+    comedy_group_id: targetType === "comedy_group" ? targetId : null,
+    unit_id: targetType === "unit" ? targetId : null,
+    title,
+    result,
+    year,
+    sort_order: sortOrderVal,
+  };
+
+  return { values, fieldErrors };
+}
+
+export async function createAchievement(
+  _prev: AchievementFormState,
+  formData: FormData
+): Promise<AchievementFormState> {
+  const { values, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.from("achievements").insert(values);
+
+  if (error) {
+    return {
+      error: `受賞歴の登録に失敗しました: ${error.message}`,
+    };
+  }
+
+  revalidatePath("/admin/achievements");
+  redirect("/admin/achievements");
+}
+
+export async function updateAchievement(
+  id: string,
+  _prev: AchievementFormState,
+  formData: FormData
+): Promise<AchievementFormState> {
+  const { values, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("achievements")
+    .update(values)
+    .eq("id", id);
+
+  if (error) {
+    return { error: `受賞歴の更新に失敗しました: ${error.message}` };
+  }
+
+  revalidatePath("/admin/achievements");
+  revalidatePath(`/admin/achievements/${id}/edit`);
+  redirect("/admin/achievements");
+}
+
+export async function deleteAchievement(formData: FormData): Promise<void> {
+  const id = String(formData.get("id") ?? "").trim();
+  if (!id) return;
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("achievements")
+    .delete()
+    .eq("id", id);
+
+  if (error) {
+    throw new Error(`受賞歴の削除に失敗しました: ${error.message}`);
+  }
+
+  revalidatePath("/admin/achievements");
+  redirect("/admin/achievements");
+}

--- a/src/lib/actions/achievements.ts
+++ b/src/lib/actions/achievements.ts
@@ -93,6 +93,12 @@ export async function createAchievement(
   }
 
   const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
   const { error } = await supabase.from("achievements").insert(values);
 
   if (error) {
@@ -116,6 +122,12 @@ export async function updateAchievement(
   }
 
   const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
   const { error } = await supabase
     .from("achievements")
     .update(values)
@@ -135,6 +147,12 @@ export async function deleteAchievement(formData: FormData): Promise<void> {
   if (!id) return;
 
   const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    throw new Error("認証が必要です");
+  }
+
   const { error } = await supabase
     .from("achievements")
     .delete()

--- a/src/lib/actions/units.ts
+++ b/src/lib/actions/units.ts
@@ -119,6 +119,12 @@ export async function createUnit(
   }
 
   const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
   const { data, error } = await supabase
     .from("units")
     .insert(values)
@@ -151,6 +157,12 @@ export async function updateUnit(
   }
 
   const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
   const { error } = await supabase
     .from("units")
     .update({ ...values, updated_at: new Date().toISOString() })
@@ -175,6 +187,12 @@ export async function deleteUnit(formData: FormData): Promise<void> {
   if (!id) return;
 
   const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    throw new Error("認証が必要です");
+  }
+
   const { error } = await supabase.from("units").delete().eq("id", id);
 
   if (error) {

--- a/src/lib/actions/units.ts
+++ b/src/lib/actions/units.ts
@@ -5,6 +5,9 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { UnitInput, UnitMemberEntry } from "@/lib/types/unit";
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export type UnitFormState = {
   error?: string;
   fieldErrors?: Partial<Record<keyof UnitInput | "members", string>>;
@@ -151,6 +154,10 @@ export async function updateUnit(
   _prev: UnitFormState,
   formData: FormData
 ): Promise<UnitFormState> {
+  if (!UUID_PATTERN.test(id)) {
+    return { error: "IDが不正です" };
+  }
+
   const { values, members, fieldErrors } = parseFormData(formData);
   if (fieldErrors && Object.keys(fieldErrors).length > 0) {
     return { fieldErrors };
@@ -185,6 +192,9 @@ export async function updateUnit(
 export async function deleteUnit(formData: FormData): Promise<void> {
   const id = String(formData.get("id") ?? "").trim();
   if (!id) return;
+  if (!UUID_PATTERN.test(id)) {
+    throw new Error("IDが不正です");
+  }
 
   const supabase = await createClient();
 

--- a/src/lib/actions/units.ts
+++ b/src/lib/actions/units.ts
@@ -1,0 +1,186 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type { UnitInput, UnitMemberEntry } from "@/lib/types/unit";
+
+export type UnitFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof UnitInput | "members", string>>;
+};
+
+function toNullableString(value: FormDataEntryValue | null): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function parseMembers(formData: FormData): {
+  members: UnitMemberEntry[];
+  error?: string;
+} {
+  const types = formData.getAll("member_type").map((v) => String(v));
+  const ids = formData.getAll("member_id").map((v) => String(v));
+  const names = formData.getAll("member_name").map((v) => String(v));
+
+  const members: UnitMemberEntry[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < types.length; i += 1) {
+    const type = types[i]?.trim();
+    const id = ids[i]?.trim();
+    const name = names[i]?.trim() ?? "";
+
+    if (!type || !id) continue;
+    if (type !== "comedy_group" && type !== "artist") {
+      return { members: [], error: "メンバーの種別が不正です" };
+    }
+
+    const key = `${type}:${id}`;
+    if (seen.has(key)) {
+      return { members: [], error: "同じメンバーを複数回追加できません" };
+    }
+    seen.add(key);
+
+    members.push({ type, id, name, kana_name: null });
+  }
+
+  return { members };
+}
+
+function parseFormData(formData: FormData): {
+  values: UnitInput;
+  members: UnitMemberEntry[];
+  fieldErrors: UnitFormState["fieldErrors"];
+} {
+  const fieldErrors: UnitFormState["fieldErrors"] = {};
+
+  const name = String(formData.get("name") ?? "").trim();
+  if (!name) {
+    fieldErrors.name = "名前を入力してください";
+  } else if (name.length > 100) {
+    fieldErrors.name = "100文字以内で入力してください";
+  }
+
+  const values: UnitInput = {
+    name,
+    description: toNullableString(formData.get("description")),
+  };
+
+  const { members, error: membersError } = parseMembers(formData);
+  if (membersError) {
+    fieldErrors.members = membersError;
+  }
+
+  return { values, members, fieldErrors };
+}
+
+async function replaceUnitMembers(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  unitId: string,
+  members: UnitMemberEntry[]
+): Promise<{ error?: string }> {
+  const { error: deleteError } = await supabase
+    .from("unit_members")
+    .delete()
+    .eq("unit_id", unitId);
+
+  if (deleteError) {
+    return { error: `メンバーの削除に失敗しました: ${deleteError.message}` };
+  }
+
+  if (members.length === 0) return {};
+
+  const rows = members.map((m) => ({
+    unit_id: unitId,
+    comedy_group_id: m.type === "comedy_group" ? m.id : null,
+    artist_id: m.type === "artist" ? m.id : null,
+  }));
+
+  const { error: insertError } = await supabase
+    .from("unit_members")
+    .insert(rows);
+
+  if (insertError) {
+    return { error: `メンバーの追加に失敗しました: ${insertError.message}` };
+  }
+
+  return {};
+}
+
+export async function createUnit(
+  _prev: UnitFormState,
+  formData: FormData
+): Promise<UnitFormState> {
+  const { values, members, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("units")
+    .insert(values)
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    return {
+      error: `ユニットの登録に失敗しました: ${error?.message ?? "unknown"}`,
+    };
+  }
+
+  const membersResult = await replaceUnitMembers(supabase, data.id, members);
+  if (membersResult.error) {
+    return { error: membersResult.error };
+  }
+
+  revalidatePath("/admin/units");
+  redirect("/admin/units");
+}
+
+export async function updateUnit(
+  id: string,
+  _prev: UnitFormState,
+  formData: FormData
+): Promise<UnitFormState> {
+  const { values, members, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("units")
+    .update({ ...values, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    return { error: `ユニットの更新に失敗しました: ${error.message}` };
+  }
+
+  const membersResult = await replaceUnitMembers(supabase, id, members);
+  if (membersResult.error) {
+    return { error: membersResult.error };
+  }
+
+  revalidatePath("/admin/units");
+  revalidatePath(`/admin/units/${id}/edit`);
+  redirect("/admin/units");
+}
+
+export async function deleteUnit(formData: FormData): Promise<void> {
+  const id = String(formData.get("id") ?? "").trim();
+  if (!id) return;
+
+  const supabase = await createClient();
+  const { error } = await supabase.from("units").delete().eq("id", id);
+
+  if (error) {
+    throw new Error(`ユニットの削除に失敗しました: ${error.message}`);
+  }
+
+  revalidatePath("/admin/units");
+  redirect("/admin/units");
+}

--- a/src/lib/queries/achievements.ts
+++ b/src/lib/queries/achievements.ts
@@ -1,0 +1,44 @@
+import { createClient } from "@/lib/supabase/server";
+import type { Achievement, AchievementWithTarget } from "@/lib/types/achievement";
+
+export async function listAchievements(): Promise<AchievementWithTarget[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("achievements")
+    .select(
+      `*,
+       artist:artists(id, name),
+       comedy_group:comedy_groups(id, name),
+       unit:units(id, name)`
+    )
+    .order("year", { ascending: false })
+    .order("sort_order", { ascending: true });
+
+  if (error) {
+    throw new Error(`受賞歴一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as AchievementWithTarget[];
+}
+
+export async function getAchievement(
+  id: string
+): Promise<AchievementWithTarget | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("achievements")
+    .select(
+      `*,
+       artist:artists(id, name),
+       comedy_group:comedy_groups(id, name),
+       unit:units(id, name)`
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`受賞歴の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? null) as AchievementWithTarget | null;
+}

--- a/src/lib/queries/combos.ts
+++ b/src/lib/queries/combos.ts
@@ -1,6 +1,8 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Combo, ComboMemberWithArtist } from "@/lib/types/combo";
 
+export type ComboSummary = Pick<Combo, "id" | "name" | "kana_name">;
+
 export type ComboWithMembers = Combo & {
   members: ComboMemberWithArtist[];
 };
@@ -42,4 +44,19 @@ export async function getCombo(id: string): Promise<ComboWithMembers | null> {
   }
 
   return (data ?? null) as ComboWithMembers | null;
+}
+
+export async function listComboSummaries(): Promise<ComboSummary[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("comedy_groups")
+    .select("id, name, kana_name")
+    .order("kana_name", { ascending: true, nullsFirst: false })
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw new Error(`コンビ一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as ComboSummary[];
 }

--- a/src/lib/queries/units.ts
+++ b/src/lib/queries/units.ts
@@ -1,0 +1,104 @@
+import { createClient } from "@/lib/supabase/server";
+import type { Unit, UnitMemberEntry } from "@/lib/types/unit";
+
+export type UnitSummary = Pick<Unit, "id" | "name">;
+
+export type UnitWithMembers = Unit & {
+  members: UnitMemberEntry[];
+};
+
+export async function listUnits(): Promise<Unit[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("units")
+    .select("*")
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw new Error(`ユニット一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as Unit[];
+}
+
+export async function getUnit(id: string): Promise<UnitWithMembers | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("units")
+    .select(
+      `*,
+       unit_members(
+         id,
+         unit_id,
+         comedy_group_id,
+         artist_id,
+         created_at,
+         comedy_group:comedy_groups(id, name, kana_name),
+         artist:artists(id, name, kana_name)
+       )`
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`ユニット情報の取得に失敗しました: ${error.message}`);
+  }
+
+  if (!data) return null;
+
+  const rawMembers = (data as Record<string, unknown>)
+    .unit_members as Array<{
+    comedy_group_id: string | null;
+    artist_id: string | null;
+    comedy_group: { id: string; name: string; kana_name: string | null } | null;
+    artist: { id: string; name: string; kana_name: string | null } | null;
+  }>;
+
+  const members: UnitMemberEntry[] = (rawMembers ?? []).flatMap((m) => {
+    if (m.comedy_group_id && m.comedy_group) {
+      return [
+        {
+          type: "comedy_group" as const,
+          id: m.comedy_group.id,
+          name: m.comedy_group.name,
+          kana_name: m.comedy_group.kana_name,
+        },
+      ];
+    }
+    if (m.artist_id && m.artist) {
+      return [
+        {
+          type: "artist" as const,
+          id: m.artist.id,
+          name: m.artist.name,
+          kana_name: m.artist.kana_name,
+        },
+      ];
+    }
+    return [];
+  });
+
+  const unitBase: Unit = {
+    id: (data as { id: string }).id,
+    name: (data as { name: string }).name,
+    description: (data as { description: string | null }).description,
+    created_at: (data as { created_at: string }).created_at,
+    updated_at: (data as { updated_at: string }).updated_at,
+  };
+
+  return { ...unitBase, members };
+}
+
+export async function listUnitSummaries(): Promise<UnitSummary[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("units")
+    .select("id, name")
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw new Error(`ユニット一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as UnitSummary[];
+}

--- a/src/lib/queries/units.ts
+++ b/src/lib/queries/units.ts
@@ -46,13 +46,16 @@ export async function getUnit(id: string): Promise<UnitWithMembers | null> {
 
   if (!data) return null;
 
-  const rawMembers = (data as Record<string, unknown>)
-    .unit_members as Array<{
+  type UnitMemberRow = {
     comedy_group_id: string | null;
     artist_id: string | null;
     comedy_group: { id: string; name: string; kana_name: string | null } | null;
     artist: { id: string; name: string; kana_name: string | null } | null;
-  }>;
+  };
+
+  const rawMembers = (
+    (data as Record<string, unknown>).unit_members as UnitMemberRow[]
+  );
 
   const members: UnitMemberEntry[] = (rawMembers ?? []).flatMap((m) => {
     if (m.comedy_group_id && m.comedy_group) {

--- a/src/lib/types/achievement.ts
+++ b/src/lib/types/achievement.ts
@@ -14,15 +14,17 @@ export type Achievement = {
   created_at: string;
 };
 
-export type AchievementInput = {
-  artist_id: string | null;
-  comedy_group_id: string | null;
-  unit_id: string | null;
+type AchievementBaseInput = {
   title: string;
   result: string;
   year: number;
   sort_order: number;
 };
+
+export type AchievementInput =
+  | (AchievementBaseInput & { artist_id: string; comedy_group_id: null; unit_id: null })
+  | (AchievementBaseInput & { artist_id: null; comedy_group_id: string; unit_id: null })
+  | (AchievementBaseInput & { artist_id: null; comedy_group_id: null; unit_id: string });
 
 export type AchievementWithTarget = Achievement & {
   artist: { id: string; name: string } | null;

--- a/src/lib/types/achievement.ts
+++ b/src/lib/types/achievement.ts
@@ -1,4 +1,6 @@
-export type AchievementTargetType = "artist" | "comedy_group" | "unit";
+import type { CastType } from "@/lib/types";
+
+export type AchievementTargetType = CastType;
 
 export type Achievement = {
   id: string;

--- a/src/lib/types/achievement.ts
+++ b/src/lib/types/achievement.ts
@@ -1,0 +1,29 @@
+export type AchievementTargetType = "artist" | "comedy_group" | "unit";
+
+export type Achievement = {
+  id: string;
+  artist_id: string | null;
+  comedy_group_id: string | null;
+  unit_id: string | null;
+  title: string;
+  result: string;
+  year: number;
+  sort_order: number;
+  created_at: string;
+};
+
+export type AchievementInput = {
+  artist_id: string | null;
+  comedy_group_id: string | null;
+  unit_id: string | null;
+  title: string;
+  result: string;
+  year: number;
+  sort_order: number;
+};
+
+export type AchievementWithTarget = Achievement & {
+  artist: { id: string; name: string } | null;
+  comedy_group: { id: string; name: string } | null;
+  unit: { id: string; name: string } | null;
+};

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,0 +1,15 @@
+export type CastType = "artist" | "comedy_group" | "unit";
+
+export type CastEntry = {
+  type: CastType;
+  id: string;
+  name: string;
+};
+
+export type ContentType =
+  | "video"
+  | "live"
+  | "radio"
+  | "article"
+  | "tv_show"
+  | "topic";

--- a/src/lib/types/unit.ts
+++ b/src/lib/types/unit.ts
@@ -14,10 +14,11 @@ export type UnitInput = {
 export type UnitMember = {
   id: string;
   unit_id: string;
-  comedy_group_id: string | null;
-  artist_id: string | null;
   created_at: string;
-};
+} & (
+  | { comedy_group_id: string; artist_id: null }
+  | { comedy_group_id: null; artist_id: string }
+);
 
 export type UnitMemberEntry = {
   type: "comedy_group" | "artist";

--- a/src/lib/types/unit.ts
+++ b/src/lib/types/unit.ts
@@ -1,0 +1,27 @@
+export type Unit = {
+  id: string;
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type UnitInput = {
+  name: string;
+  description: string | null;
+};
+
+export type UnitMember = {
+  id: string;
+  unit_id: string;
+  comedy_group_id: string | null;
+  artist_id: string | null;
+  created_at: string;
+};
+
+export type UnitMemberEntry = {
+  type: "comedy_group" | "artist";
+  id: string;
+  name: string;
+  kana_name: string | null;
+};

--- a/supabase/migrations/003_fix_unit_members_unique.sql
+++ b/supabase/migrations/003_fix_unit_members_unique.sql
@@ -1,0 +1,26 @@
+-- unit_members の unique 制約を修正する
+--
+-- 問題: NULLS NOT DISTINCT を使った unique (unit_id, artist_id) は、
+--       コンビメンバー行（artist_id = NULL）が2件以上あると衝突する。
+--       例: (unit_id=X, comedy_group_id=A, artist_id=NULL)
+--           (unit_id=X, comedy_group_id=B, artist_id=NULL)
+--       → (X, NULL) = (X, NULL) と判定されてしまう。
+--
+-- 修正: NULLS NOT DISTINCT の unique 制約を削除し、
+--       NULL を除外した部分インデックスに置き換える。
+
+-- 既存の制約を削除
+alter table unit_members
+  drop constraint if exists unit_members_unit_id_comedy_group_id_key;
+
+alter table unit_members
+  drop constraint if exists unit_members_unit_id_artist_id_key;
+
+-- 部分インデックスで重複防止（NULL 行は一意性チェックから除外）
+create unique index if not exists unit_members_unit_comedy_group_unique
+  on unit_members (unit_id, comedy_group_id)
+  where comedy_group_id is not null;
+
+create unique index if not exists unit_members_unit_artist_unique
+  on unit_members (unit_id, artist_id)
+  where artist_id is not null;


### PR DESCRIPTION
## 概要

issues #9・#10・#11 を実装しました。

- **#9 ユニット CRUD + メンバー紐付け**
- **#10 受賞歴 CRUD**
- **#11 cast-selector 共通コンポーネント**

## 変更内容

### #9 ユニット CRUD + メンバー紐付け

- `src/lib/types/unit.ts` — Unit / UnitInput / UnitMemberEntry 型
- `src/lib/queries/units.ts` — listUnits / getUnit / listUnitSummaries
- `src/lib/actions/units.ts` — createUnit / updateUnit / deleteUnit（Server Actions）
- `src/components/features/unit/unit-form.tsx` — コンビ単位・個人単位のタブ切り替えでメンバーを紐付けるフォーム
- `src/components/features/unit/unit-delete-button.tsx` — 削除ボタン
- `src/app/admin/units/` — 一覧・新規作成・編集ページ

### #10 受賞歴 CRUD

- `src/lib/types/achievement.ts` — Achievement / AchievementInput / AchievementWithTarget 型
- `src/lib/queries/achievements.ts` — listAchievements / getAchievement
- `src/lib/actions/achievements.ts` — createAchievement / updateAchievement / deleteAchievement（Server Actions）
- `src/components/features/achievement/achievement-form.tsx` — コンビ/芸人/ユニットをラジオボタンで切り替えて対象を選択するフォーム
- `src/components/features/achievement/achievement-delete-button.tsx` — 削除ボタン
- `src/app/admin/achievements/` — 一覧・新規作成・編集ページ

### #11 cast-selector 共通コンポーネント

- `src/lib/types/index.ts` — CastEntry・CastType・ContentType 型を定義
- `src/components/features/cast-selector/cast-selector.tsx` — メインコンポーネント（Artist / Combo / Unit タブ切り替え + 検索 + タグ表示）
- `src/components/features/cast-selector/cast-tab.tsx` — タブ UI
- `src/components/features/cast-selector/cast-search.tsx` — 検索入力
- `src/components/features/cast-selector/cast-tag-list.tsx` — 選択済みタグ一覧
- `src/lib/queries/combos.ts` — listComboSummaries を追加（cast-selector / unit-form で使用）

## 動作概要

- ユニットフォームはコンビ・個人タブで切り替え、名前検索でフィルタし選択
- メンバーはタグで表示、×ボタンで解除
- 受賞歴フォームは対象種別（コンビ/芸人/ユニット）をラジオで切り替えると対象セレクトが連動して更新
- cast-selector は `value: CastEntry[]` / `onChange` の Controlled Component として設計し、#12〜#17 のコンテンツ CRUD で再利用可能

Closes #9
Closes #10
Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI added to list, create, edit, and delete achievements and units with breadcrumbs and Japanese labels
  * New admin pages for creating/editing achievements and units, including forms with validation, server-side error display, pending states, and cancel/navigation links
  * Cast selector components: tabs, search, add/remove tags, and reusable tag/list components
  * Confirming delete buttons that disable and show contextual pending labels

* **Chores**
  * New server-side queries/actions, types, and a database migration tightening unit-members uniqueness constraints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->