### PR TITLE
feat: 管理画面 動画 CRUD + 出演者紐付け (#12)

### DIFF
--- a/src/app/admin/videos/[id]/edit/page.tsx
+++ b/src/app/admin/videos/[id]/edit/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { VideoForm } from "@/components/features/video/video-form";
+import { updateVideo } from "@/lib/actions/videos";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+import { getVideo } from "@/lib/queries/videos";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditVideoPage({ params }: Props) {
+  const { id } = await params;
+  const [video, artists, combos, units] = await Promise.all([
+    getVideo(id),
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  if (!video) {
+    notFound();
+  }
+
+  const action = updateVideo.bind(null, id);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/videos"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← 動画一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          {video.title} を編集
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <VideoForm
+          action={action}
+          artists={artists}
+          combos={combos}
+          units={units}
+          initialValues={video}
+          initialCasts={video.casts}
+          submitLabel="更新する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/videos/new/page.tsx
+++ b/src/app/admin/videos/new/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { VideoForm } from "@/components/features/video/video-form";
+import { createVideo } from "@/lib/actions/videos";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewVideoPage() {
+  const [artists, combos, units] = await Promise.all([
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/videos"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← 動画一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          動画を新規作成
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <VideoForm
+          action={createVideo}
+          artists={artists}
+          combos={combos}
+          units={units}
+          submitLabel="作成する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/videos/page.tsx
+++ b/src/app/admin/videos/page.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+import { VideoDeleteButton } from "@/components/features/video/video-delete-button";
+import { deleteVideo } from "@/lib/actions/videos";
+import { listVideos } from "@/lib/queries/videos";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("ja-JP");
+}
+
+export default async function AdminVideosPage() {
+  const videos = await listVideos();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-brand-brown-dark">動画</h1>
+          <p className="mt-1 text-sm text-brand-brown-light">
+            YouTube動画と出演者を管理します。
+          </p>
+        </div>
+        <Link
+          href="/admin/videos/new"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark"
+        >
+          新規作成
+        </Link>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+        {videos.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
+            まだ動画が登録されていません。
+          </p>
+        ) : (
+          <table className="min-w-full divide-y divide-brand-border-light text-sm">
+            <thead className="bg-brand-bg-light text-xs text-brand-brown-light">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium">タイトル</th>
+                <th className="px-4 py-2 text-left font-medium">公開日</th>
+                <th className="px-4 py-2 text-left font-medium">動画ID</th>
+                <th className="px-4 py-2 text-right font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-border-light">
+              {videos.map((video) => (
+                <tr key={video.id} className="hover:bg-brand-bg-light">
+                  <td className="max-w-xs truncate px-4 py-2 font-medium text-brand-brown-dark">
+                    {video.title}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {formatDate(video.published_at)}
+                  </td>
+                  <td className="px-4 py-2 font-mono text-xs text-brand-brown-light">
+                    {video.youtube_video_id ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        href={`/admin/videos/${video.id}/edit`}
+                        className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
+                      >
+                        編集
+                      </Link>
+                      <form action={deleteVideo}>
+                        <input type="hidden" name="id" value={video.id} />
+                        <VideoDeleteButton title={video.title} />
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/video/video-delete-button.tsx
+++ b/src/components/features/video/video-delete-button.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+type Props = {
+  title: string;
+};
+
+export function VideoDeleteButton({ title }: Props) {
+  return (
+    <button
+      type="submit"
+      onClick={(e) => {
+        if (!confirm(`「${title}」を削除しますか？`)) {
+          e.preventDefault();
+        }
+      }}
+      className="rounded-md border border-red-300 px-3 py-1 text-xs text-red-600 transition hover:bg-red-50"
+    >
+      削除
+    </button>
+  );
+}

--- a/src/components/features/video/video-delete-button.tsx
+++ b/src/components/features/video/video-delete-button.tsx
@@ -13,7 +13,7 @@ export function VideoDeleteButton({ title }: Props) {
           e.preventDefault();
         }
       }}
-      className="rounded-md border border-red-300 px-3 py-1 text-xs text-red-600 transition hover:bg-red-50"
+      className="rounded-md border border-brand-gold px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-cream"
     >
       削除
     </button>

--- a/src/components/features/video/video-form.tsx
+++ b/src/components/features/video/video-form.tsx
@@ -14,6 +14,7 @@ import type { ComboSummary } from "@/lib/queries/combos";
 import type { UnitSummary } from "@/lib/queries/units";
 import type { CastEntry } from "@/lib/types";
 import type { VideoInput } from "@/lib/types/video";
+import { extractYoutubeVideoId } from "@/lib/utils/youtube";
 
 type VideoFormAction = (
   prev: VideoFormState,
@@ -72,6 +73,7 @@ export function VideoForm({
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors: clientErrors },
     reset,
   } = useForm<VideoFormValues>({
@@ -83,6 +85,10 @@ export function VideoForm({
   }, [initialValues, reset]);
 
   const [casts, setCasts] = useState<CastEntry[]>(initialCasts ?? []);
+
+  useEffect(() => {
+    setCasts(initialCasts ?? []);
+  }, [initialCasts]);
 
   const onSubmit = handleSubmit((data) => {
     const formData = new FormData();
@@ -107,10 +113,14 @@ export function VideoForm({
 
   const fieldErrors = state.fieldErrors;
 
+  const inputClass =
+    "mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky";
+  const inputWithPlaceholderClass = `${inputClass} placeholder-brand-brown-light`;
+
   return (
     <form onSubmit={onSubmit} noValidate className="space-y-6">
       {state.error && (
-        <p className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+        <p className="rounded-md border border-brand-gold bg-brand-bg-light px-4 py-3 text-sm text-brand-brown-dark" role="alert">
           {state.error}
         </p>
       )}
@@ -126,7 +136,7 @@ export function VideoForm({
           id="title"
           type="text"
           {...register("title", { required: "タイトルを入力してください", maxLength: { value: 200, message: "200文字以内で入力してください" } })}
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className={inputClass}
         />
         {(clientErrors.title?.message || fieldErrors?.title) && (
           <p className="mt-1 text-xs text-brand-gold" role="alert">
@@ -145,9 +155,14 @@ export function VideoForm({
         <input
           id="youtube_url"
           type="url"
-          {...register("youtube_url")}
+          {...register("youtube_url", {
+            onBlur: (e) => {
+              const extracted = extractYoutubeVideoId(String(e.target.value ?? ""));
+              if (extracted) setValue("youtube_video_id", extracted, { shouldDirty: true });
+            },
+          })}
           placeholder="https://www.youtube.com/watch?v=..."
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className={inputWithPlaceholderClass}
         />
         <p className="mt-0.5 text-xs text-brand-brown-light">
           URLを入力すると動画IDが自動抽出されます
@@ -166,8 +181,13 @@ export function VideoForm({
           type="text"
           {...register("youtube_video_id")}
           placeholder="例: dQw4w9WgXcQ"
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className={inputWithPlaceholderClass}
         />
+        {fieldErrors?.youtube_video_id && (
+          <p className="mt-1 text-xs text-brand-gold" role="alert">
+            {fieldErrors.youtube_video_id}
+          </p>
+        )}
         <p className="mt-0.5 text-xs text-brand-brown-light">
           URLから自動抽出できない場合は直接入力してください
         </p>
@@ -185,7 +205,7 @@ export function VideoForm({
           type="text"
           {...register("youtube_channel_id")}
           placeholder="例: UCxxxxxxxxxx"
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className={inputWithPlaceholderClass}
         />
       </div>
 
@@ -201,7 +221,7 @@ export function VideoForm({
           type="url"
           {...register("thumbnail_url")}
           placeholder="https://..."
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className={inputWithPlaceholderClass}
         />
         <p className="mt-0.5 text-xs text-brand-brown-light">
           空欄の場合はYouTube動画IDからサムネイルURLが自動生成されます
@@ -219,7 +239,7 @@ export function VideoForm({
           id="published_at"
           type="datetime-local"
           {...register("published_at")}
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className={inputClass}
         />
       </div>
 
@@ -234,7 +254,7 @@ export function VideoForm({
           id="description"
           rows={4}
           {...register("description")}
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className={inputClass}
         />
       </div>
 
@@ -260,7 +280,7 @@ export function VideoForm({
         <button
           type="submit"
           disabled={isPending}
-          className="rounded-md bg-brand-sky px-5 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:opacity-50"
+          className="rounded-md bg-brand-sky px-5 py-2 text-sm font-medium text-brand-cream transition hover:bg-brand-sky-dark disabled:opacity-50"
         >
           {isPending ? "保存中..." : submitLabel}
         </button>

--- a/src/components/features/video/video-form.tsx
+++ b/src/components/features/video/video-form.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import {
+  useActionState,
+  useEffect,
+  useState,
+  useTransition,
+} from "react";
+import { useForm } from "react-hook-form";
+import { CastSelector } from "@/components/features/cast-selector/cast-selector";
+import type { VideoFormState } from "@/lib/actions/videos";
+import type { ArtistSummary } from "@/lib/queries/artists";
+import type { ComboSummary } from "@/lib/queries/combos";
+import type { UnitSummary } from "@/lib/queries/units";
+import type { CastEntry } from "@/lib/types";
+import type { VideoInput } from "@/lib/types/video";
+
+type VideoFormAction = (
+  prev: VideoFormState,
+  formData: FormData
+) => Promise<VideoFormState>;
+
+type VideoFormValues = {
+  title: string;
+  youtube_url: string;
+  youtube_video_id: string;
+  youtube_channel_id: string;
+  thumbnail_url: string;
+  published_at: string;
+  description: string;
+};
+
+type Props = {
+  action: VideoFormAction;
+  artists: ArtistSummary[];
+  combos: ComboSummary[];
+  units: UnitSummary[];
+  initialValues?: Partial<VideoInput>;
+  initialCasts?: CastEntry[];
+  submitLabel: string;
+};
+
+function toFormValues(initial?: Partial<VideoInput>): VideoFormValues {
+  return {
+    title: initial?.title ?? "",
+    youtube_url: initial?.youtube_url ?? "",
+    youtube_video_id: initial?.youtube_video_id ?? "",
+    youtube_channel_id: initial?.youtube_channel_id ?? "",
+    thumbnail_url: initial?.thumbnail_url ?? "",
+    published_at: initial?.published_at
+      ? initial.published_at.slice(0, 16)
+      : "",
+    description: initial?.description ?? "",
+  };
+}
+
+export function VideoForm({
+  action,
+  artists,
+  combos,
+  units,
+  initialValues,
+  initialCasts,
+  submitLabel,
+}: Props) {
+  const [state, formAction] = useActionState<VideoFormState, FormData>(
+    action,
+    {}
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors: clientErrors },
+    reset,
+  } = useForm<VideoFormValues>({
+    defaultValues: toFormValues(initialValues),
+  });
+
+  useEffect(() => {
+    reset(toFormValues(initialValues));
+  }, [initialValues, reset]);
+
+  const [casts, setCasts] = useState<CastEntry[]>(initialCasts ?? []);
+
+  const onSubmit = handleSubmit((data) => {
+    const formData = new FormData();
+    formData.set("title", data.title);
+    formData.set("youtube_url", data.youtube_url);
+    formData.set("youtube_video_id", data.youtube_video_id);
+    formData.set("youtube_channel_id", data.youtube_channel_id);
+    formData.set("thumbnail_url", data.thumbnail_url);
+    formData.set("published_at", data.published_at);
+    formData.set("description", data.description);
+
+    for (const cast of casts) {
+      formData.append("cast_type", cast.type);
+      formData.append("cast_id", cast.id);
+      formData.append("cast_name", cast.name);
+    }
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  });
+
+  const fieldErrors = state.fieldErrors;
+
+  return (
+    <form onSubmit={onSubmit} noValidate className="space-y-6">
+      {state.error && (
+        <p className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {state.error}
+        </p>
+      )}
+
+      <div>
+        <label
+          htmlFor="title"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          タイトル <span className="text-brand-gold">*</span>
+        </label>
+        <input
+          id="title"
+          type="text"
+          {...register("title", { required: "タイトルを入力してください", maxLength: { value: 200, message: "200文字以内で入力してください" } })}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+        {(clientErrors.title?.message || fieldErrors?.title) && (
+          <p className="mt-1 text-xs text-brand-gold" role="alert">
+            {clientErrors.title?.message ?? fieldErrors?.title}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="youtube_url"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          YouTube URL
+        </label>
+        <input
+          id="youtube_url"
+          type="url"
+          {...register("youtube_url")}
+          placeholder="https://www.youtube.com/watch?v=..."
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+        <p className="mt-0.5 text-xs text-brand-brown-light">
+          URLを入力すると動画IDが自動抽出されます
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor="youtube_video_id"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          YouTube 動画ID
+        </label>
+        <input
+          id="youtube_video_id"
+          type="text"
+          {...register("youtube_video_id")}
+          placeholder="例: dQw4w9WgXcQ"
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+        <p className="mt-0.5 text-xs text-brand-brown-light">
+          URLから自動抽出できない場合は直接入力してください
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor="youtube_channel_id"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          YouTube チャンネルID
+        </label>
+        <input
+          id="youtube_channel_id"
+          type="text"
+          {...register("youtube_channel_id")}
+          placeholder="例: UCxxxxxxxxxx"
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="thumbnail_url"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          サムネイルURL
+        </label>
+        <input
+          id="thumbnail_url"
+          type="url"
+          {...register("thumbnail_url")}
+          placeholder="https://..."
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+        <p className="mt-0.5 text-xs text-brand-brown-light">
+          空欄の場合はYouTube動画IDからサムネイルURLが自動生成されます
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor="published_at"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          公開日時
+        </label>
+        <input
+          id="published_at"
+          type="datetime-local"
+          {...register("published_at")}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="description"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          説明
+        </label>
+        <textarea
+          id="description"
+          rows={4}
+          {...register("description")}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <p className="mb-2 block text-sm font-medium text-brand-brown-dark">
+          出演者
+        </p>
+        {fieldErrors?.casts && (
+          <p className="mb-2 text-xs text-brand-gold" role="alert">
+            {fieldErrors.casts}
+          </p>
+        )}
+        <CastSelector
+          artists={artists}
+          combos={combos}
+          units={units}
+          value={casts}
+          onChange={setCasts}
+        />
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-brand-sky px-5 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:opacity-50"
+        >
+          {isPending ? "保存中..." : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/features/video/video-form.tsx
+++ b/src/components/features/video/video-form.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { useForm } from "react-hook-form";
 import { CastSelector } from "@/components/features/cast-selector/cast-selector";
-import type { VideoFormState } from "@/lib/actions/videos";
+import type { VideoFormState } from "@/lib/types/video";
 import type { ArtistSummary } from "@/lib/queries/artists";
 import type { ComboSummary } from "@/lib/queries/combos";
 import type { UnitSummary } from "@/lib/queries/units";

--- a/src/lib/actions/videos.ts
+++ b/src/lib/actions/videos.ts
@@ -4,18 +4,11 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
-import type { VideoInput } from "@/lib/types/video";
+import type { VideoFormState, VideoInput } from "@/lib/types/video";
 import { extractYoutubeVideoId, YOUTUBE_ID_PATTERN } from "@/lib/utils/youtube";
-
-export { extractYoutubeVideoId };
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-export type VideoFormState = {
-  error?: string;
-  fieldErrors?: Partial<Record<keyof VideoInput | "casts", string>>;
-};
 
 function toNullableString(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") return null;

--- a/src/lib/actions/videos.ts
+++ b/src/lib/actions/videos.ts
@@ -5,11 +5,12 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { VideoInput } from "@/lib/types/video";
+import { extractYoutubeVideoId, YOUTUBE_ID_PATTERN } from "@/lib/utils/youtube";
+
+export { extractYoutubeVideoId };
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-const YOUTUBE_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
 
 export type VideoFormState = {
   error?: string;
@@ -20,31 +21,6 @@ function toNullableString(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed === "" ? null : trimmed;
-}
-
-export function extractYoutubeVideoId(url: string): string | null {
-  try {
-    const parsed = new URL(url.trim());
-    const host = parsed.hostname.replace(/^www\./, "");
-
-    if (host === "youtu.be") {
-      const id = parsed.pathname.slice(1).split("/")[0];
-      return YOUTUBE_ID_PATTERN.test(id) ? id : null;
-    }
-
-    if (host === "youtube.com") {
-      const path = parsed.pathname;
-      if (path === "/watch") {
-        const id = parsed.searchParams.get("v") ?? "";
-        return YOUTUBE_ID_PATTERN.test(id) ? id : null;
-      }
-      const match = path.match(/^\/(embed|shorts|v)\/([A-Za-z0-9_-]{11})/);
-      if (match) return match[2];
-    }
-  } catch {
-    // invalid URL
-  }
-  return null;
 }
 
 function parseCasts(formData: FormData): {
@@ -99,6 +75,11 @@ function parseFormData(formData: FormData): {
 
   if (youtubeUrl && !youtubeVideoId) {
     youtubeVideoId = extractYoutubeVideoId(youtubeUrl);
+  }
+
+  if (youtubeVideoId && !YOUTUBE_ID_PATTERN.test(youtubeVideoId)) {
+    fieldErrors.youtube_video_id = "YouTube動画IDの形式が不正です（11文字の英数字）";
+    youtubeVideoId = null;
   }
 
   const values: VideoInput = {

--- a/src/lib/actions/videos.ts
+++ b/src/lib/actions/videos.ts
@@ -1,0 +1,255 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry } from "@/lib/types";
+import type { VideoInput } from "@/lib/types/video";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const YOUTUBE_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+export type VideoFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof VideoInput | "casts", string>>;
+};
+
+function toNullableString(value: FormDataEntryValue | null): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+export function extractYoutubeVideoId(url: string): string | null {
+  try {
+    const parsed = new URL(url.trim());
+    const host = parsed.hostname.replace(/^www\./, "");
+
+    if (host === "youtu.be") {
+      const id = parsed.pathname.slice(1).split("/")[0];
+      return YOUTUBE_ID_PATTERN.test(id) ? id : null;
+    }
+
+    if (host === "youtube.com") {
+      const path = parsed.pathname;
+      if (path === "/watch") {
+        const id = parsed.searchParams.get("v") ?? "";
+        return YOUTUBE_ID_PATTERN.test(id) ? id : null;
+      }
+      const match = path.match(/^\/(embed|shorts|v)\/([A-Za-z0-9_-]{11})/);
+      if (match) return match[2];
+    }
+  } catch {
+    // invalid URL
+  }
+  return null;
+}
+
+function parseCasts(formData: FormData): {
+  casts: CastEntry[];
+  error?: string;
+} {
+  const types = formData.getAll("cast_type").map((v) => String(v));
+  const ids = formData.getAll("cast_id").map((v) => String(v));
+  const names = formData.getAll("cast_name").map((v) => String(v));
+
+  const casts: CastEntry[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < types.length; i += 1) {
+    const type = types[i]?.trim();
+    const id = ids[i]?.trim();
+    const name = names[i]?.trim() ?? "";
+
+    if (!type || !id) continue;
+    if (type !== "artist" && type !== "comedy_group" && type !== "unit") {
+      return { casts: [], error: "出演者の種別が不正です" };
+    }
+
+    const key = `${type}:${id}`;
+    if (seen.has(key)) {
+      return { casts: [], error: "同じ出演者を複数回追加できません" };
+    }
+    seen.add(key);
+
+    casts.push({ type, id, name });
+  }
+
+  return { casts };
+}
+
+function parseFormData(formData: FormData): {
+  values: VideoInput;
+  casts: CastEntry[];
+  fieldErrors: VideoFormState["fieldErrors"];
+} {
+  const fieldErrors: VideoFormState["fieldErrors"] = {};
+
+  const title = String(formData.get("title") ?? "").trim();
+  if (!title) {
+    fieldErrors.title = "タイトルを入力してください";
+  } else if (title.length > 200) {
+    fieldErrors.title = "200文字以内で入力してください";
+  }
+
+  const youtubeUrl = toNullableString(formData.get("youtube_url"));
+  let youtubeVideoId = toNullableString(formData.get("youtube_video_id"));
+
+  if (youtubeUrl && !youtubeVideoId) {
+    youtubeVideoId = extractYoutubeVideoId(youtubeUrl);
+  }
+
+  const values: VideoInput = {
+    title,
+    youtube_url: youtubeUrl,
+    youtube_video_id: youtubeVideoId,
+    youtube_channel_id: toNullableString(formData.get("youtube_channel_id")),
+    thumbnail_url: toNullableString(formData.get("thumbnail_url")),
+    published_at: toNullableString(formData.get("published_at")),
+    description: toNullableString(formData.get("description")),
+  };
+
+  const { casts, error: castsError } = parseCasts(formData);
+  if (castsError) {
+    fieldErrors.casts = castsError;
+  }
+
+  return { values, casts, fieldErrors };
+}
+
+async function replaceCasts(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  videoId: string,
+  casts: CastEntry[]
+): Promise<{ error?: string }> {
+  const { error: deleteError } = await supabase
+    .from("video_casts")
+    .delete()
+    .eq("video_id", videoId);
+
+  if (deleteError) {
+    return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
+  }
+
+  if (casts.length === 0) return {};
+
+  const rows = casts.map((c) => ({
+    video_id: videoId,
+    artist_id: c.type === "artist" ? c.id : null,
+    comedy_group_id: c.type === "comedy_group" ? c.id : null,
+    unit_id: c.type === "unit" ? c.id : null,
+  }));
+
+  const { error: insertError } = await supabase
+    .from("video_casts")
+    .insert(rows);
+
+  if (insertError) {
+    return { error: `出演者の追加に失敗しました: ${insertError.message}` };
+  }
+
+  return {};
+}
+
+export async function createVideo(
+  _prev: VideoFormState,
+  formData: FormData
+): Promise<VideoFormState> {
+  const { values, casts, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
+  const { data, error } = await supabase
+    .from("videos")
+    .insert(values)
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    return {
+      error: `動画の登録に失敗しました: ${error?.message ?? "unknown"}`,
+    };
+  }
+
+  const castsResult = await replaceCasts(supabase, data.id, casts);
+  if (castsResult.error) {
+    return { error: castsResult.error };
+  }
+
+  revalidatePath("/admin/videos");
+  redirect("/admin/videos");
+}
+
+export async function updateVideo(
+  id: string,
+  _prev: VideoFormState,
+  formData: FormData
+): Promise<VideoFormState> {
+  if (!UUID_PATTERN.test(id)) {
+    return { error: "IDが不正です" };
+  }
+
+  const { values, casts, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
+  const { error } = await supabase
+    .from("videos")
+    .update({ ...values, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    return { error: `動画の更新に失敗しました: ${error.message}` };
+  }
+
+  const castsResult = await replaceCasts(supabase, id, casts);
+  if (castsResult.error) {
+    return { error: castsResult.error };
+  }
+
+  revalidatePath("/admin/videos");
+  revalidatePath(`/admin/videos/${id}/edit`);
+  redirect("/admin/videos");
+}
+
+export async function deleteVideo(formData: FormData): Promise<void> {
+  const id = String(formData.get("id") ?? "").trim();
+  if (!id) return;
+  if (!UUID_PATTERN.test(id)) {
+    throw new Error("IDが不正です");
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    throw new Error("認証が必要です");
+  }
+
+  const { error } = await supabase.from("videos").delete().eq("id", id);
+
+  if (error) {
+    throw new Error(`動画の削除に失敗しました: ${error.message}`);
+  }
+
+  revalidatePath("/admin/videos");
+  redirect("/admin/videos");
+}

--- a/src/lib/queries/videos.ts
+++ b/src/lib/queries/videos.ts
@@ -1,0 +1,83 @@
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry } from "@/lib/types";
+import type { Video, VideoWithCasts } from "@/lib/types/video";
+
+export async function listVideos(): Promise<Video[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("videos")
+    .select("*")
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`動画一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as Video[];
+}
+
+export async function getVideo(id: string): Promise<VideoWithCasts | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("videos")
+    .select(
+      `*,
+       video_casts(
+         id,
+         artist_id,
+         comedy_group_id,
+         unit_id,
+         artist:artists(id, name),
+         comedy_group:comedy_groups(id, name),
+         unit:units(id, name)
+       )`
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`動画情報の取得に失敗しました: ${error.message}`);
+  }
+
+  if (!data) return null;
+
+  type CastRow = {
+    artist_id: string | null;
+    comedy_group_id: string | null;
+    unit_id: string | null;
+    artist: { id: string; name: string } | null;
+    comedy_group: { id: string; name: string } | null;
+    unit: { id: string; name: string } | null;
+  };
+
+  const rawCasts = (data as Record<string, unknown>).video_casts as CastRow[];
+
+  const casts: CastEntry[] = (rawCasts ?? []).flatMap((c) => {
+    if (c.artist_id && c.artist) {
+      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
+    }
+    if (c.comedy_group_id && c.comedy_group) {
+      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
+    }
+    if (c.unit_id && c.unit) {
+      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
+    }
+    return [];
+  });
+
+  const videoBase: Video = {
+    id: (data as { id: string }).id,
+    title: (data as { title: string }).title,
+    youtube_url: (data as { youtube_url: string | null }).youtube_url,
+    youtube_video_id: (data as { youtube_video_id: string | null }).youtube_video_id,
+    youtube_channel_id: (data as { youtube_channel_id: string | null }).youtube_channel_id,
+    thumbnail_url: (data as { thumbnail_url: string | null }).thumbnail_url,
+    published_at: (data as { published_at: string | null }).published_at,
+    description: (data as { description: string | null }).description,
+    created_at: (data as { created_at: string }).created_at,
+    updated_at: (data as { updated_at: string }).updated_at,
+  };
+
+  return { ...videoBase, casts };
+}

--- a/src/lib/types/video.ts
+++ b/src/lib/types/video.ts
@@ -26,3 +26,8 @@ export type VideoInput = {
 export type VideoWithCasts = Video & {
   casts: CastEntry[];
 };
+
+export type VideoFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof VideoInput | "casts", string>>;
+};

--- a/src/lib/types/video.ts
+++ b/src/lib/types/video.ts
@@ -1,0 +1,28 @@
+import type { CastEntry } from "@/lib/types";
+
+export type Video = {
+  id: string;
+  title: string;
+  youtube_url: string | null;
+  youtube_video_id: string | null;
+  youtube_channel_id: string | null;
+  thumbnail_url: string | null;
+  published_at: string | null;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type VideoInput = {
+  title: string;
+  youtube_url: string | null;
+  youtube_video_id: string | null;
+  youtube_channel_id: string | null;
+  thumbnail_url: string | null;
+  published_at: string | null;
+  description: string | null;
+};
+
+export type VideoWithCasts = Video & {
+  casts: CastEntry[];
+};

--- a/src/lib/utils/youtube.ts
+++ b/src/lib/utils/youtube.ts
@@ -1,0 +1,28 @@
+const YOUTUBE_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+export function extractYoutubeVideoId(url: string): string | null {
+  try {
+    const parsed = new URL(url.trim());
+    const host = parsed.hostname.replace(/^www\./, "");
+
+    if (host === "youtu.be") {
+      const id = parsed.pathname.slice(1).split("/")[0];
+      return YOUTUBE_ID_PATTERN.test(id) ? id : null;
+    }
+
+    if (host === "youtube.com") {
+      const path = parsed.pathname;
+      if (path === "/watch") {
+        const id = parsed.searchParams.get("v") ?? "";
+        return YOUTUBE_ID_PATTERN.test(id) ? id : null;
+      }
+      const match = path.match(/^\/(embed|shorts|v)\/([A-Za-z0-9_-]{11})/);
+      if (match) return match[2];
+    }
+  } catch {
+    // invalid URL
+  }
+  return null;
+}
+
+export { YOUTUBE_ID_PATTERN };

--- a/src/lib/utils/youtube.ts
+++ b/src/lib/utils/youtube.ts
@@ -3,7 +3,7 @@ const YOUTUBE_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
 export function extractYoutubeVideoId(url: string): string | null {
   try {
     const parsed = new URL(url.trim());
-    const host = parsed.hostname.replace(/^www\./, "");
+    const host = parsed.hostname.replace(/^(www|m)\./, "");
 
     if (host === "youtu.be") {
       const id = parsed.pathname.slice(1).split("/")[0];


### PR DESCRIPTION
## 概要

issue #12 の実装です。管理画面で YouTube 動画の CRUD 操作と出演者紐付けを行えるようにします。

Closes #12

## 変更内容

- `src/lib/types/video.ts` — `Video`・`VideoInput`・`VideoWithCasts` 型を定義
- `src/lib/queries/videos.ts` — `listVideos`・`getVideo` クエリ（`video_casts` JOIN）
- `src/lib/actions/videos.ts` — `createVideo`・`updateVideo`・`deleteVideo` Server Actions、YouTube URL から動画IDを自動抽出する `extractYoutubeVideoId` ユーティリティ
- `src/components/features/video/video-form.tsx` — `VideoForm` コンポーネント（`CastSelector` 統合）
- `src/components/features/video/video-delete-button.tsx` — 削除ボタン
- `src/app/admin/videos/page.tsx` — 動画一覧
- `src/app/admin/videos/new/page.tsx` — 新規作成
- `src/app/admin/videos/[id]/edit/page.tsx` — 編集

## 主な仕様

- YouTube URL（youtube.com/watch、youtu.be、/shorts、/embed）から動画IDを自動抽出
- `video_casts` テーブルを使い、芸人・コンビ・ユニットのいずれかを出演者として紐付け
- 出演者の追加・削除は `CastSelector` コンポーネントで操作

## テスト手順

- [ ] `/admin/videos` で動画一覧が表示される
- [ ] `/admin/videos/new` で動画を新規作成できる（YouTube URL を貼ると動画IDが自動入力）
- [ ] 出演者（芸人・コンビ・ユニット）を追加して保存できる
- [ ] 編集ページで既存の情報・出演者が反映される
- [ ] 削除ボタンで確認ダイアログが表示され、削除できる

https://claude.ai/code/session_01XqW922zQD5cLvM4pkHtAf1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin video management: create, edit, list, and delete videos (with list and empty-state).
  * Improved video form: client-side validation, multiple cast entries, initial values, and submit/pending state.
  * YouTube URL parsing to auto-extract video IDs and populate the form.
  * Deletion confirmation prompt and contextual field/global error feedback.
  * Server-backed create/update/delete flows with data revalidation after changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->