### PR TITLE
feat: 管理画面 ライブ CRUD + 出演者紐付け (#13)

### DIFF
--- a/src/app/admin/lives/[id]/edit/page.tsx
+++ b/src/app/admin/lives/[id]/edit/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { LiveForm } from "@/components/features/live/live-form";
+import { updateLive } from "@/lib/actions/lives";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+import { getLive } from "@/lib/queries/lives";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditLivePage({ params }: Props) {
+  const { id } = await params;
+  const [live, artists, combos, units] = await Promise.all([
+    getLive(id),
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  if (!live) {
+    notFound();
+  }
+
+  const action = updateLive.bind(null, id);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/lives"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← ライブ一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          {live.title} を編集
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <LiveForm
+          action={action}
+          artists={artists}
+          combos={combos}
+          units={units}
+          initialValues={live}
+          initialCasts={live.casts}
+          submitLabel="更新する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/lives/[id]/edit/page.tsx
+++ b/src/app/admin/lives/[id]/edit/page.tsx
@@ -44,6 +44,7 @@ export default async function EditLivePage({ params }: Props) {
 
       <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
         <LiveForm
+          key={live.id}
           action={action}
           artists={artists}
           combos={combos}

--- a/src/app/admin/lives/new/page.tsx
+++ b/src/app/admin/lives/new/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { LiveForm } from "@/components/features/live/live-form";
+import { createLive } from "@/lib/actions/lives";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewLivePage() {
+  const [artists, combos, units] = await Promise.all([
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/lives"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← ライブ一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          ライブを新規作成
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <LiveForm
+          action={createLive}
+          artists={artists}
+          combos={combos}
+          units={units}
+          submitLabel="作成する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/lives/page.tsx
+++ b/src/app/admin/lives/page.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+import { LiveDeleteButton } from "@/components/features/live/live-delete-button";
+import { deleteLive } from "@/lib/actions/lives";
+import { listLives } from "@/lib/queries/lives";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("ja-JP");
+}
+
+export default async function AdminLivesPage() {
+  const lives = await listLives();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-brand-brown-dark">ライブ</h1>
+          <p className="mt-1 text-sm text-brand-brown-light">
+            ライブ・イベントと出演者を管理します。
+          </p>
+        </div>
+        <Link
+          href="/admin/lives/new"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark"
+        >
+          新規作成
+        </Link>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+        {lives.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
+            まだライブが登録されていません。
+          </p>
+        ) : (
+          <table className="min-w-full divide-y divide-brand-border-light text-sm">
+            <thead className="bg-brand-bg-light text-xs text-brand-brown-light">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium">タイトル</th>
+                <th className="px-4 py-2 text-left font-medium">開催日</th>
+                <th className="px-4 py-2 text-left font-medium">会場</th>
+                <th className="px-4 py-2 text-right font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-border-light">
+              {lives.map((live) => (
+                <tr key={live.id} className="hover:bg-brand-bg-light">
+                  <td className="max-w-xs truncate px-4 py-2 font-medium text-brand-brown-dark">
+                    {live.title}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {formatDate(live.event_date)}
+                  </td>
+                  <td className="max-w-xs truncate px-4 py-2 text-brand-brown-light">
+                    {live.venue ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        href={`/admin/lives/${live.id}/edit`}
+                        className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
+                      >
+                        編集
+                      </Link>
+                      <form action={deleteLive}>
+                        <input type="hidden" name="id" value={live.id} />
+                        <LiveDeleteButton title={live.title} />
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/live/live-delete-button.tsx
+++ b/src/components/features/live/live-delete-button.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+type Props = {
+  title: string;
+};
+
+export function LiveDeleteButton({ title }: Props) {
+  return (
+    <button
+      type="submit"
+      onClick={(e) => {
+        if (!confirm(`「${title}」を削除しますか？`)) {
+          e.preventDefault();
+        }
+      }}
+      className="rounded-md border border-red-300 px-3 py-1 text-xs text-red-600 transition hover:bg-red-50"
+    >
+      削除
+    </button>
+  );
+}

--- a/src/components/features/live/live-delete-button.tsx
+++ b/src/components/features/live/live-delete-button.tsx
@@ -13,7 +13,7 @@ export function LiveDeleteButton({ title }: Props) {
           e.preventDefault();
         }
       }}
-      className="rounded-md border border-red-300 px-3 py-1 text-xs text-red-600 transition hover:bg-red-50"
+      className="rounded-md border border-brand-gold px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-cream"
     >
       削除
     </button>

--- a/src/components/features/live/live-form.tsx
+++ b/src/components/features/live/live-form.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  useActionState,
-  useEffect,
-  useState,
-  useTransition,
-} from "react";
+import { useActionState, useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { CastSelector } from "@/components/features/cast-selector/cast-selector";
 import type { LiveFormState } from "@/lib/types/live";
@@ -71,20 +66,11 @@ export function LiveForm({
     register,
     handleSubmit,
     formState: { errors: clientErrors },
-    reset,
   } = useForm<LiveFormValues>({
     defaultValues: toFormValues(initialValues),
   });
 
-  useEffect(() => {
-    reset(toFormValues(initialValues));
-  }, [initialValues, reset]);
-
   const [casts, setCasts] = useState<CastEntry[]>(initialCasts ?? []);
-
-  useEffect(() => {
-    setCasts(initialCasts ?? []);
-  }, [initialCasts]);
 
   const onSubmit = handleSubmit((data) => {
     const formData = new FormData();
@@ -112,7 +98,7 @@ export function LiveForm({
   return (
     <form onSubmit={onSubmit} noValidate className="space-y-6">
       {state.error && (
-        <p className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+        <p className="rounded-md bg-brand-bg-light px-4 py-3 text-sm text-brand-brown-dark" role="alert">
           {state.error}
         </p>
       )}
@@ -128,7 +114,7 @@ export function LiveForm({
           id="title"
           type="text"
           {...register("title", { required: "タイトルを入力してください", maxLength: { value: 200, message: "200文字以内で入力してください" } })}
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
         />
         {(clientErrors.title?.message || fieldErrors?.title) && (
           <p className="mt-1 text-xs text-brand-gold" role="alert">
@@ -148,7 +134,7 @@ export function LiveForm({
           id="event_date"
           type="date"
           {...register("event_date")}
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
         />
       </div>
 
@@ -163,7 +149,7 @@ export function LiveForm({
           id="start_time"
           type="datetime-local"
           {...register("start_time")}
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
         />
       </div>
 
@@ -178,7 +164,7 @@ export function LiveForm({
           id="venue"
           type="text"
           {...register("venue")}
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
         />
       </div>
 
@@ -194,7 +180,7 @@ export function LiveForm({
           type="url"
           {...register("url")}
           placeholder="https://..."
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
         />
       </div>
 
@@ -209,7 +195,7 @@ export function LiveForm({
           id="description"
           rows={4}
           {...register("description")}
-          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
         />
       </div>
 
@@ -250,7 +236,7 @@ export function LiveForm({
         <button
           type="submit"
           disabled={isPending}
-          className="rounded-md bg-brand-sky px-5 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:opacity-50"
+          className="rounded-md bg-brand-sky px-5 py-2 text-sm font-medium text-brand-cream transition hover:bg-brand-sky-dark disabled:opacity-50"
         >
           {isPending ? "保存中..." : submitLabel}
         </button>

--- a/src/components/features/live/live-form.tsx
+++ b/src/components/features/live/live-form.tsx
@@ -39,7 +39,7 @@ function toFormValues(initial?: Partial<LiveInput>): LiveFormValues {
   return {
     title: initial?.title ?? "",
     event_date: initial?.event_date ?? "",
-    start_time: initial?.start_time ? initial.start_time.slice(0, 16) : "",
+    start_time: initial?.start_time ? initial.start_time.slice(11, 16) : "",
     venue: initial?.venue ?? "",
     description: initial?.description ?? "",
     url: initial?.url ?? "",
@@ -143,11 +143,11 @@ export function LiveForm({
           htmlFor="start_time"
           className="block text-sm font-medium text-brand-brown-dark"
         >
-          開演日時
+          開演時刻
         </label>
         <input
           id="start_time"
-          type="datetime-local"
+          type="time"
           {...register("start_time")}
           className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
         />

--- a/src/components/features/live/live-form.tsx
+++ b/src/components/features/live/live-form.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { useForm } from "react-hook-form";
 import { CastSelector } from "@/components/features/cast-selector/cast-selector";
-import type { LiveFormState } from "@/lib/actions/lives";
+import type { LiveFormState } from "@/lib/types/live";
 import type { ArtistSummary } from "@/lib/queries/artists";
 import type { ComboSummary } from "@/lib/queries/combos";
 import type { UnitSummary } from "@/lib/queries/units";

--- a/src/components/features/live/live-form.tsx
+++ b/src/components/features/live/live-form.tsx
@@ -82,6 +82,10 @@ export function LiveForm({
 
   const [casts, setCasts] = useState<CastEntry[]>(initialCasts ?? []);
 
+  useEffect(() => {
+    setCasts(initialCasts ?? []);
+  }, [initialCasts]);
+
   const onSubmit = handleSubmit((data) => {
     const formData = new FormData();
     formData.set("title", data.title);

--- a/src/components/features/live/live-form.tsx
+++ b/src/components/features/live/live-form.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import {
+  useActionState,
+  useEffect,
+  useState,
+  useTransition,
+} from "react";
+import { useForm } from "react-hook-form";
+import { CastSelector } from "@/components/features/cast-selector/cast-selector";
+import type { LiveFormState } from "@/lib/actions/lives";
+import type { ArtistSummary } from "@/lib/queries/artists";
+import type { ComboSummary } from "@/lib/queries/combos";
+import type { UnitSummary } from "@/lib/queries/units";
+import type { CastEntry } from "@/lib/types";
+import type { LiveInput } from "@/lib/types/live";
+
+type LiveFormAction = (
+  prev: LiveFormState,
+  formData: FormData
+) => Promise<LiveFormState>;
+
+type LiveFormValues = {
+  title: string;
+  event_date: string;
+  start_time: string;
+  venue: string;
+  description: string;
+  url: string;
+  is_notified: boolean;
+};
+
+type Props = {
+  action: LiveFormAction;
+  artists: ArtistSummary[];
+  combos: ComboSummary[];
+  units: UnitSummary[];
+  initialValues?: Partial<LiveInput>;
+  initialCasts?: CastEntry[];
+  submitLabel: string;
+};
+
+function toFormValues(initial?: Partial<LiveInput>): LiveFormValues {
+  return {
+    title: initial?.title ?? "",
+    event_date: initial?.event_date ?? "",
+    start_time: initial?.start_time ? initial.start_time.slice(0, 16) : "",
+    venue: initial?.venue ?? "",
+    description: initial?.description ?? "",
+    url: initial?.url ?? "",
+    is_notified: initial?.is_notified ?? false,
+  };
+}
+
+export function LiveForm({
+  action,
+  artists,
+  combos,
+  units,
+  initialValues,
+  initialCasts,
+  submitLabel,
+}: Props) {
+  const [state, formAction] = useActionState<LiveFormState, FormData>(
+    action,
+    {}
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors: clientErrors },
+    reset,
+  } = useForm<LiveFormValues>({
+    defaultValues: toFormValues(initialValues),
+  });
+
+  useEffect(() => {
+    reset(toFormValues(initialValues));
+  }, [initialValues, reset]);
+
+  const [casts, setCasts] = useState<CastEntry[]>(initialCasts ?? []);
+
+  const onSubmit = handleSubmit((data) => {
+    const formData = new FormData();
+    formData.set("title", data.title);
+    formData.set("event_date", data.event_date);
+    formData.set("start_time", data.start_time);
+    formData.set("venue", data.venue);
+    formData.set("description", data.description);
+    formData.set("url", data.url);
+    formData.set("is_notified", String(data.is_notified));
+
+    for (const cast of casts) {
+      formData.append("cast_type", cast.type);
+      formData.append("cast_id", cast.id);
+      formData.append("cast_name", cast.name);
+    }
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  });
+
+  const fieldErrors = state.fieldErrors;
+
+  return (
+    <form onSubmit={onSubmit} noValidate className="space-y-6">
+      {state.error && (
+        <p className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {state.error}
+        </p>
+      )}
+
+      <div>
+        <label
+          htmlFor="title"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          タイトル <span className="text-brand-gold">*</span>
+        </label>
+        <input
+          id="title"
+          type="text"
+          {...register("title", { required: "タイトルを入力してください", maxLength: { value: 200, message: "200文字以内で入力してください" } })}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+        {(clientErrors.title?.message || fieldErrors?.title) && (
+          <p className="mt-1 text-xs text-brand-gold" role="alert">
+            {clientErrors.title?.message ?? fieldErrors?.title}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="event_date"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          開催日
+        </label>
+        <input
+          id="event_date"
+          type="date"
+          {...register("event_date")}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="start_time"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          開演日時
+        </label>
+        <input
+          id="start_time"
+          type="datetime-local"
+          {...register("start_time")}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="venue"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          会場
+        </label>
+        <input
+          id="venue"
+          type="text"
+          {...register("venue")}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="url"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          URL（チケットサイト等）
+        </label>
+        <input
+          id="url"
+          type="url"
+          {...register("url")}
+          placeholder="https://..."
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="description"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          説明
+        </label>
+        <textarea
+          id="description"
+          rows={4}
+          {...register("description")}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          id="is_notified"
+          type="checkbox"
+          {...register("is_notified")}
+          className="h-4 w-4 rounded border-brand-border-light text-brand-sky focus:ring-brand-sky"
+        />
+        <label
+          htmlFor="is_notified"
+          className="text-sm text-brand-brown-dark"
+        >
+          通知済み
+        </label>
+      </div>
+
+      <div>
+        <p className="mb-2 block text-sm font-medium text-brand-brown-dark">
+          出演者
+        </p>
+        {fieldErrors?.casts && (
+          <p className="mb-2 text-xs text-brand-gold" role="alert">
+            {fieldErrors.casts}
+          </p>
+        )}
+        <CastSelector
+          artists={artists}
+          combos={combos}
+          units={units}
+          value={casts}
+          onChange={setCasts}
+        />
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-brand-sky px-5 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:opacity-50"
+        >
+          {isPending ? "保存中..." : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/actions/lives.ts
+++ b/src/lib/actions/lives.ts
@@ -4,15 +4,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
-import type { LiveInput } from "@/lib/types/live";
+import type { LiveFormState, LiveInput } from "@/lib/types/live";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-export type LiveFormState = {
-  error?: string;
-  fieldErrors?: Partial<Record<keyof LiveInput | "casts", string>>;
-};
 
 function toNullableString(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") return null;

--- a/src/lib/actions/lives.ts
+++ b/src/lib/actions/lives.ts
@@ -1,0 +1,221 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry } from "@/lib/types";
+import type { LiveInput } from "@/lib/types/live";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type LiveFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof LiveInput | "casts", string>>;
+};
+
+function toNullableString(value: FormDataEntryValue | null): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function parseCasts(formData: FormData): {
+  casts: CastEntry[];
+  error?: string;
+} {
+  const types = formData.getAll("cast_type").map((v) => String(v));
+  const ids = formData.getAll("cast_id").map((v) => String(v));
+  const names = formData.getAll("cast_name").map((v) => String(v));
+
+  const casts: CastEntry[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < types.length; i += 1) {
+    const type = types[i]?.trim();
+    const id = ids[i]?.trim();
+    const name = names[i]?.trim() ?? "";
+
+    if (!type || !id) continue;
+    if (type !== "artist" && type !== "comedy_group" && type !== "unit") {
+      return { casts: [], error: "出演者の種別が不正です" };
+    }
+
+    const key = `${type}:${id}`;
+    if (seen.has(key)) {
+      return { casts: [], error: "同じ出演者を複数回追加できません" };
+    }
+    seen.add(key);
+
+    casts.push({ type, id, name });
+  }
+
+  return { casts };
+}
+
+function parseFormData(formData: FormData): {
+  values: LiveInput;
+  casts: CastEntry[];
+  fieldErrors: LiveFormState["fieldErrors"];
+} {
+  const fieldErrors: LiveFormState["fieldErrors"] = {};
+
+  const title = String(formData.get("title") ?? "").trim();
+  if (!title) {
+    fieldErrors.title = "タイトルを入力してください";
+  } else if (title.length > 200) {
+    fieldErrors.title = "200文字以内で入力してください";
+  }
+
+  const values: LiveInput = {
+    title,
+    event_date: toNullableString(formData.get("event_date")),
+    start_time: toNullableString(formData.get("start_time")),
+    venue: toNullableString(formData.get("venue")),
+    description: toNullableString(formData.get("description")),
+    url: toNullableString(formData.get("url")),
+    is_notified: formData.get("is_notified") === "true",
+  };
+
+  const { casts, error: castsError } = parseCasts(formData);
+  if (castsError) {
+    fieldErrors.casts = castsError;
+  }
+
+  return { values, casts, fieldErrors };
+}
+
+async function replaceCasts(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  liveId: string,
+  casts: CastEntry[]
+): Promise<{ error?: string }> {
+  const { error: deleteError } = await supabase
+    .from("live_casts")
+    .delete()
+    .eq("live_id", liveId);
+
+  if (deleteError) {
+    return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
+  }
+
+  if (casts.length === 0) return {};
+
+  const rows = casts.map((c) => ({
+    live_id: liveId,
+    artist_id: c.type === "artist" ? c.id : null,
+    comedy_group_id: c.type === "comedy_group" ? c.id : null,
+    unit_id: c.type === "unit" ? c.id : null,
+  }));
+
+  const { error: insertError } = await supabase
+    .from("live_casts")
+    .insert(rows);
+
+  if (insertError) {
+    return { error: `出演者の追加に失敗しました: ${insertError.message}` };
+  }
+
+  return {};
+}
+
+export async function createLive(
+  _prev: LiveFormState,
+  formData: FormData
+): Promise<LiveFormState> {
+  const { values, casts, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
+  const { data, error } = await supabase
+    .from("lives")
+    .insert(values)
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    return {
+      error: `ライブの登録に失敗しました: ${error?.message ?? "unknown"}`,
+    };
+  }
+
+  const castsResult = await replaceCasts(supabase, data.id, casts);
+  if (castsResult.error) {
+    return { error: castsResult.error };
+  }
+
+  revalidatePath("/admin/lives");
+  redirect("/admin/lives");
+}
+
+export async function updateLive(
+  id: string,
+  _prev: LiveFormState,
+  formData: FormData
+): Promise<LiveFormState> {
+  if (!UUID_PATTERN.test(id)) {
+    return { error: "IDが不正です" };
+  }
+
+  const { values, casts, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
+  const { error } = await supabase
+    .from("lives")
+    .update({ ...values, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    return { error: `ライブの更新に失敗しました: ${error.message}` };
+  }
+
+  const castsResult = await replaceCasts(supabase, id, casts);
+  if (castsResult.error) {
+    return { error: castsResult.error };
+  }
+
+  revalidatePath("/admin/lives");
+  revalidatePath(`/admin/lives/${id}/edit`);
+  redirect("/admin/lives");
+}
+
+export async function deleteLive(formData: FormData): Promise<void> {
+  const id = String(formData.get("id") ?? "").trim();
+  if (!id) return;
+  if (!UUID_PATTERN.test(id)) {
+    throw new Error("IDが不正です");
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    throw new Error("認証が必要です");
+  }
+
+  const { error } = await supabase.from("lives").delete().eq("id", id);
+
+  if (error) {
+    throw new Error(`ライブの削除に失敗しました: ${error.message}`);
+  }
+
+  revalidatePath("/admin/lives");
+  redirect("/admin/lives");
+}

--- a/src/lib/actions/lives.ts
+++ b/src/lib/actions/lives.ts
@@ -62,10 +62,15 @@ function parseFormData(formData: FormData): {
     fieldErrors.title = "200文字以内で入力してください";
   }
 
+  const event_date = toNullableString(formData.get("event_date"));
+  const startTimeInput = String(formData.get("start_time") ?? "").trim();
+  const start_time =
+    event_date && startTimeInput ? `${event_date}T${startTimeInput}:00` : null;
+
   const values: LiveInput = {
     title,
-    event_date: toNullableString(formData.get("event_date")),
-    start_time: toNullableString(formData.get("start_time")),
+    event_date,
+    start_time,
     venue: toNullableString(formData.get("venue")),
     description: toNullableString(formData.get("description")),
     url: toNullableString(formData.get("url")),
@@ -172,13 +177,17 @@ export async function updateLive(
     return { error: "認証が必要です" };
   }
 
-  const { error } = await supabase
+  const { error, count } = await supabase
     .from("lives")
     .update({ ...values, updated_at: new Date().toISOString() })
-    .eq("id", id);
+    .eq("id", id)
+    .count("exact");
 
   if (error) {
     return { error: `ライブの更新に失敗しました: ${error.message}` };
+  }
+  if (count !== 1) {
+    return { error: "指定されたライブが見つかりません" };
   }
 
   const castsResult = await replaceCasts(supabase, id, casts);
@@ -205,10 +214,17 @@ export async function deleteLive(formData: FormData): Promise<void> {
     throw new Error("認証が必要です");
   }
 
-  const { error } = await supabase.from("lives").delete().eq("id", id);
+  const { error, count } = await supabase
+    .from("lives")
+    .delete()
+    .eq("id", id)
+    .count("exact");
 
   if (error) {
     throw new Error(`ライブの削除に失敗しました: ${error.message}`);
+  }
+  if (count !== 1) {
+    throw new Error("指定されたライブが見つかりません");
   }
 
   revalidatePath("/admin/lives");

--- a/src/lib/actions/lives.ts
+++ b/src/lib/actions/lives.ts
@@ -179,9 +179,11 @@ export async function updateLive(
 
   const { error, count } = await supabase
     .from("lives")
-    .update({ ...values, updated_at: new Date().toISOString() })
-    .eq("id", id)
-    .count("exact");
+    .update(
+      { ...values, updated_at: new Date().toISOString() },
+      { count: "exact" }
+    )
+    .eq("id", id);
 
   if (error) {
     return { error: `ライブの更新に失敗しました: ${error.message}` };
@@ -216,9 +218,8 @@ export async function deleteLive(formData: FormData): Promise<void> {
 
   const { error, count } = await supabase
     .from("lives")
-    .delete()
-    .eq("id", id)
-    .count("exact");
+    .delete({ count: "exact" })
+    .eq("id", id);
 
   if (error) {
     throw new Error(`ライブの削除に失敗しました: ${error.message}`);

--- a/src/lib/queries/lives.ts
+++ b/src/lib/queries/lives.ts
@@ -1,0 +1,83 @@
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry } from "@/lib/types";
+import type { Live, LiveWithCasts } from "@/lib/types/live";
+
+export async function listLives(): Promise<Live[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("lives")
+    .select("*")
+    .order("event_date", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`ライブ一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as Live[];
+}
+
+export async function getLive(id: string): Promise<LiveWithCasts | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("lives")
+    .select(
+      `*,
+       live_casts(
+         id,
+         artist_id,
+         comedy_group_id,
+         unit_id,
+         artist:artists(id, name),
+         comedy_group:comedy_groups(id, name),
+         unit:units(id, name)
+       )`
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`ライブ情報の取得に失敗しました: ${error.message}`);
+  }
+
+  if (!data) return null;
+
+  type CastRow = {
+    artist_id: string | null;
+    comedy_group_id: string | null;
+    unit_id: string | null;
+    artist: { id: string; name: string } | null;
+    comedy_group: { id: string; name: string } | null;
+    unit: { id: string; name: string } | null;
+  };
+
+  const rawCasts = (data as Record<string, unknown>).live_casts as CastRow[];
+
+  const casts: CastEntry[] = (rawCasts ?? []).flatMap((c) => {
+    if (c.artist_id && c.artist) {
+      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
+    }
+    if (c.comedy_group_id && c.comedy_group) {
+      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
+    }
+    if (c.unit_id && c.unit) {
+      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
+    }
+    return [];
+  });
+
+  const liveBase: Live = {
+    id: (data as { id: string }).id,
+    title: (data as { title: string }).title,
+    event_date: (data as { event_date: string | null }).event_date,
+    start_time: (data as { start_time: string | null }).start_time,
+    venue: (data as { venue: string | null }).venue,
+    description: (data as { description: string | null }).description,
+    url: (data as { url: string | null }).url,
+    is_notified: (data as { is_notified: boolean }).is_notified,
+    created_at: (data as { created_at: string }).created_at,
+    updated_at: (data as { updated_at: string }).updated_at,
+  };
+
+  return { ...liveBase, casts };
+}

--- a/src/lib/types/live.ts
+++ b/src/lib/types/live.ts
@@ -1,0 +1,28 @@
+import type { CastEntry } from "@/lib/types";
+
+export type Live = {
+  id: string;
+  title: string;
+  event_date: string | null;
+  start_time: string | null;
+  venue: string | null;
+  description: string | null;
+  url: string | null;
+  is_notified: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type LiveInput = {
+  title: string;
+  event_date: string | null;
+  start_time: string | null;
+  venue: string | null;
+  description: string | null;
+  url: string | null;
+  is_notified: boolean;
+};
+
+export type LiveWithCasts = Live & {
+  casts: CastEntry[];
+};

--- a/src/lib/types/live.ts
+++ b/src/lib/types/live.ts
@@ -26,3 +26,8 @@ export type LiveInput = {
 export type LiveWithCasts = Live & {
   casts: CastEntry[];
 };
+
+export type LiveFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof LiveInput | "casts", string>>;
+};


### PR DESCRIPTION
## 概要

issue #13 の実装です。管理画面でライブ・イベントの CRUD 操作と出演者紐付けを行えるようにします。

Closes #13

## 変更内容

- `src/lib/types/live.ts` — `Live`・`LiveInput`・`LiveWithCasts` 型を定義
- `src/lib/queries/lives.ts` — `listLives`・`getLive` クエリ（`live_casts` JOIN）
- `src/lib/actions/lives.ts` — `createLive`・`updateLive`・`deleteLive` Server Actions
- `src/components/features/live/live-form.tsx` — `LiveForm` コンポーネント（`CastSelector` 統合、通知済みチェックボックス）
- `src/components/features/live/live-delete-button.tsx` — 削除ボタン
- `src/app/admin/lives/page.tsx` — ライブ一覧
- `src/app/admin/lives/new/page.tsx` — 新規作成
- `src/app/admin/lives/[id]/edit/page.tsx` — 編集

## テスト手順

- [ ] `/admin/lives` でライブ一覧が表示される
- [ ] `/admin/lives/new` でライブを新規作成できる
- [ ] 開催日・開演日時・会場・URL・通知済みフラグを設定できる
- [ ] 出演者（芸人・コンビ・ユニット）を追加して保存できる
- [ ] 編集ページで既存の情報・出演者が反映される
- [ ] 削除ボタンで確認ダイアログが表示され、削除できる

https://claude.ai/code/session_01XqW922zQD5cLvM4pkHtAf1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI to list, create, and edit live events (separate pages for new/edit); edit form pre-populates existing data
  * Live event form with client- and server-side validation, per-field error messages, submit/pending states, and repeated cast entries
  * Delete action includes a confirmation prompt and removes events, returning to the admin list after changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->