### PR TITLE
feat: 管理画面 ラジオ CRUD + 出演者紐付け (#14)

### DIFF
--- a/src/app/admin/radios/[id]/edit/page.tsx
+++ b/src/app/admin/radios/[id]/edit/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { RadioForm } from "@/components/features/radio/radio-form";
+import { updateRadio } from "@/lib/actions/radios";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+import { getRadio } from "@/lib/queries/radios";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditRadioPage({ params }: Props) {
+  const { id } = await params;
+  const [radio, artists, combos, units] = await Promise.all([
+    getRadio(id),
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  if (!radio) {
+    notFound();
+  }
+
+  const action = updateRadio.bind(null, id);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/radios"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← ラジオ一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          {radio.title} を編集
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <RadioForm
+          action={action}
+          artists={artists}
+          combos={combos}
+          units={units}
+          initialValues={radio}
+          initialCasts={radio.casts}
+          submitLabel="更新する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/radios/new/page.tsx
+++ b/src/app/admin/radios/new/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { RadioForm } from "@/components/features/radio/radio-form";
+import { createRadio } from "@/lib/actions/radios";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewRadioPage() {
+  const [artists, combos, units] = await Promise.all([
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/radios"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← ラジオ一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          ラジオを新規作成
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <RadioForm
+          action={createRadio}
+          artists={artists}
+          combos={combos}
+          units={units}
+          submitLabel="作成する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/radios/page.tsx
+++ b/src/app/admin/radios/page.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+import { RadioDeleteButton } from "@/components/features/radio/radio-delete-button";
+import { deleteRadio } from "@/lib/actions/radios";
+import { listRadios } from "@/lib/queries/radios";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("ja-JP");
+}
+
+export default async function AdminRadiosPage() {
+  const radios = await listRadios();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-brand-brown-dark">ラジオ</h1>
+          <p className="mt-1 text-sm text-brand-brown-light">
+            ラジオと出演者を管理します。
+          </p>
+        </div>
+        <Link
+          href="/admin/radios/new"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark"
+        >
+          新規作成
+        </Link>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+        {radios.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
+            まだラジオが登録されていません。
+          </p>
+        ) : (
+          <table className="min-w-full divide-y divide-brand-border-light text-sm">
+            <thead className="bg-brand-bg-light text-xs text-brand-brown-light">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium">タイトル</th>
+                <th className="px-4 py-2 text-left font-medium">プラットフォーム</th>
+                <th className="px-4 py-2 text-left font-medium">公開日</th>
+                <th className="px-4 py-2 text-right font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-border-light">
+              {radios.map((radio) => (
+                <tr key={radio.id} className="hover:bg-brand-bg-light">
+                  <td className="max-w-xs truncate px-4 py-2 font-medium text-brand-brown-dark">
+                    {radio.title}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {radio.platform ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {formatDate(radio.published_at)}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        href={`/admin/radios/${radio.id}/edit`}
+                        className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
+                      >
+                        編集
+                      </Link>
+                      <form action={deleteRadio}>
+                        <input type="hidden" name="id" value={radio.id} />
+                        <RadioDeleteButton title={radio.title} />
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/radio/radio-delete-button.tsx
+++ b/src/components/features/radio/radio-delete-button.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+type Props = {
+  title: string;
+};
+
+export function RadioDeleteButton({ title }: Props) {
+  return (
+    <button
+      type="submit"
+      onClick={(e) => {
+        if (!confirm(`「${title}」を削除しますか？`)) {
+          e.preventDefault();
+        }
+      }}
+      className="rounded-md border border-red-300 px-3 py-1 text-xs text-red-600 transition hover:bg-red-50"
+    >
+      削除
+    </button>
+  );
+}

--- a/src/components/features/radio/radio-form.tsx
+++ b/src/components/features/radio/radio-form.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { useForm } from "react-hook-form";
 import { CastSelector } from "@/components/features/cast-selector/cast-selector";
-import type { RadioFormState } from "@/lib/actions/radios";
+import type { RadioFormState } from "@/lib/types/radio";
 import type { ArtistSummary } from "@/lib/queries/artists";
 import type { ComboSummary } from "@/lib/queries/combos";
 import type { UnitSummary } from "@/lib/queries/units";

--- a/src/components/features/radio/radio-form.tsx
+++ b/src/components/features/radio/radio-form.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import {
+  useActionState,
+  useEffect,
+  useState,
+  useTransition,
+} from "react";
+import { useForm } from "react-hook-form";
+import { CastSelector } from "@/components/features/cast-selector/cast-selector";
+import type { RadioFormState } from "@/lib/actions/radios";
+import type { ArtistSummary } from "@/lib/queries/artists";
+import type { ComboSummary } from "@/lib/queries/combos";
+import type { UnitSummary } from "@/lib/queries/units";
+import type { CastEntry } from "@/lib/types";
+import type { RadioInput } from "@/lib/types/radio";
+
+type RadioFormAction = (
+  prev: RadioFormState,
+  formData: FormData
+) => Promise<RadioFormState>;
+
+type RadioFormValues = {
+  title: string;
+  platform: string;
+  url: string;
+  published_at: string;
+  description: string;
+};
+
+type Props = {
+  action: RadioFormAction;
+  artists: ArtistSummary[];
+  combos: ComboSummary[];
+  units: UnitSummary[];
+  initialValues?: Partial<RadioInput>;
+  initialCasts?: CastEntry[];
+  submitLabel: string;
+};
+
+function toFormValues(initial?: Partial<RadioInput>): RadioFormValues {
+  return {
+    title: initial?.title ?? "",
+    platform: initial?.platform ?? "",
+    url: initial?.url ?? "",
+    published_at: initial?.published_at
+      ? initial.published_at.slice(0, 16)
+      : "",
+    description: initial?.description ?? "",
+  };
+}
+
+export function RadioForm({
+  action,
+  artists,
+  combos,
+  units,
+  initialValues,
+  initialCasts,
+  submitLabel,
+}: Props) {
+  const [state, formAction] = useActionState<RadioFormState, FormData>(
+    action,
+    {}
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors: clientErrors },
+    reset,
+  } = useForm<RadioFormValues>({
+    defaultValues: toFormValues(initialValues),
+  });
+
+  useEffect(() => {
+    reset(toFormValues(initialValues));
+  }, [initialValues, reset]);
+
+  const [casts, setCasts] = useState<CastEntry[]>(initialCasts ?? []);
+
+  const onSubmit = handleSubmit((data) => {
+    const formData = new FormData();
+    formData.set("title", data.title);
+    formData.set("platform", data.platform);
+    formData.set("url", data.url);
+    formData.set("published_at", data.published_at);
+    formData.set("description", data.description);
+
+    for (const cast of casts) {
+      formData.append("cast_type", cast.type);
+      formData.append("cast_id", cast.id);
+      formData.append("cast_name", cast.name);
+    }
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  });
+
+  const fieldErrors = state.fieldErrors;
+
+  return (
+    <form onSubmit={onSubmit} noValidate className="space-y-6">
+      {state.error && (
+        <p className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+          {state.error}
+        </p>
+      )}
+
+      <div>
+        <label
+          htmlFor="title"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          タイトル <span className="text-brand-gold">*</span>
+        </label>
+        <input
+          id="title"
+          type="text"
+          {...register("title", { required: "タイトルを入力してください", maxLength: { value: 200, message: "200文字以内で入力してください" } })}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+        {(clientErrors.title?.message || fieldErrors?.title) && (
+          <p className="mt-1 text-xs text-brand-gold" role="alert">
+            {clientErrors.title?.message ?? fieldErrors?.title}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="platform"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          プラットフォーム
+        </label>
+        <input
+          id="platform"
+          type="text"
+          {...register("platform")}
+          placeholder="例: Spotify, YouTube, stand.fm"
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="url"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          URL
+        </label>
+        <input
+          id="url"
+          type="url"
+          {...register("url")}
+          placeholder="https://..."
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="published_at"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          公開日時
+        </label>
+        <input
+          id="published_at"
+          type="datetime-local"
+          {...register("published_at")}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="description"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          説明
+        </label>
+        <textarea
+          id="description"
+          rows={4}
+          {...register("description")}
+          className="mt-1 block w-full rounded-md border border-brand-border-light bg-white px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
+        />
+      </div>
+
+      <div>
+        <p className="mb-2 block text-sm font-medium text-brand-brown-dark">
+          出演者
+        </p>
+        {fieldErrors?.casts && (
+          <p className="mb-2 text-xs text-brand-gold" role="alert">
+            {fieldErrors.casts}
+          </p>
+        )}
+        <CastSelector
+          artists={artists}
+          combos={combos}
+          units={units}
+          value={casts}
+          onChange={setCasts}
+        />
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-brand-sky px-5 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:opacity-50"
+        >
+          {isPending ? "保存中..." : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/actions/radios.ts
+++ b/src/lib/actions/radios.ts
@@ -4,15 +4,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
-import type { RadioInput } from "@/lib/types/radio";
+import type { RadioFormState, RadioInput } from "@/lib/types/radio";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-export type RadioFormState = {
-  error?: string;
-  fieldErrors?: Partial<Record<keyof RadioInput | "casts", string>>;
-};
 
 function toNullableString(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") return null;

--- a/src/lib/actions/radios.ts
+++ b/src/lib/actions/radios.ts
@@ -1,0 +1,219 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry } from "@/lib/types";
+import type { RadioInput } from "@/lib/types/radio";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type RadioFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof RadioInput | "casts", string>>;
+};
+
+function toNullableString(value: FormDataEntryValue | null): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function parseCasts(formData: FormData): {
+  casts: CastEntry[];
+  error?: string;
+} {
+  const types = formData.getAll("cast_type").map((v) => String(v));
+  const ids = formData.getAll("cast_id").map((v) => String(v));
+  const names = formData.getAll("cast_name").map((v) => String(v));
+
+  const casts: CastEntry[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < types.length; i += 1) {
+    const type = types[i]?.trim();
+    const id = ids[i]?.trim();
+    const name = names[i]?.trim() ?? "";
+
+    if (!type || !id) continue;
+    if (type !== "artist" && type !== "comedy_group" && type !== "unit") {
+      return { casts: [], error: "出演者の種別が不正です" };
+    }
+
+    const key = `${type}:${id}`;
+    if (seen.has(key)) {
+      return { casts: [], error: "同じ出演者を複数回追加できません" };
+    }
+    seen.add(key);
+
+    casts.push({ type, id, name });
+  }
+
+  return { casts };
+}
+
+function parseFormData(formData: FormData): {
+  values: RadioInput;
+  casts: CastEntry[];
+  fieldErrors: RadioFormState["fieldErrors"];
+} {
+  const fieldErrors: RadioFormState["fieldErrors"] = {};
+
+  const title = String(formData.get("title") ?? "").trim();
+  if (!title) {
+    fieldErrors.title = "タイトルを入力してください";
+  } else if (title.length > 200) {
+    fieldErrors.title = "200文字以内で入力してください";
+  }
+
+  const values: RadioInput = {
+    title,
+    platform: toNullableString(formData.get("platform")),
+    url: toNullableString(formData.get("url")),
+    published_at: toNullableString(formData.get("published_at")),
+    description: toNullableString(formData.get("description")),
+  };
+
+  const { casts, error: castsError } = parseCasts(formData);
+  if (castsError) {
+    fieldErrors.casts = castsError;
+  }
+
+  return { values, casts, fieldErrors };
+}
+
+async function replaceCasts(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  radioId: string,
+  casts: CastEntry[]
+): Promise<{ error?: string }> {
+  const { error: deleteError } = await supabase
+    .from("radio_casts")
+    .delete()
+    .eq("radio_id", radioId);
+
+  if (deleteError) {
+    return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
+  }
+
+  if (casts.length === 0) return {};
+
+  const rows = casts.map((c) => ({
+    radio_id: radioId,
+    artist_id: c.type === "artist" ? c.id : null,
+    comedy_group_id: c.type === "comedy_group" ? c.id : null,
+    unit_id: c.type === "unit" ? c.id : null,
+  }));
+
+  const { error: insertError } = await supabase
+    .from("radio_casts")
+    .insert(rows);
+
+  if (insertError) {
+    return { error: `出演者の追加に失敗しました: ${insertError.message}` };
+  }
+
+  return {};
+}
+
+export async function createRadio(
+  _prev: RadioFormState,
+  formData: FormData
+): Promise<RadioFormState> {
+  const { values, casts, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
+  const { data, error } = await supabase
+    .from("radios")
+    .insert(values)
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    return {
+      error: `ラジオの登録に失敗しました: ${error?.message ?? "unknown"}`,
+    };
+  }
+
+  const castsResult = await replaceCasts(supabase, data.id, casts);
+  if (castsResult.error) {
+    return { error: castsResult.error };
+  }
+
+  revalidatePath("/admin/radios");
+  redirect("/admin/radios");
+}
+
+export async function updateRadio(
+  id: string,
+  _prev: RadioFormState,
+  formData: FormData
+): Promise<RadioFormState> {
+  if (!UUID_PATTERN.test(id)) {
+    return { error: "IDが不正です" };
+  }
+
+  const { values, casts, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
+  const { error } = await supabase
+    .from("radios")
+    .update({ ...values, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    return { error: `ラジオの更新に失敗しました: ${error.message}` };
+  }
+
+  const castsResult = await replaceCasts(supabase, id, casts);
+  if (castsResult.error) {
+    return { error: castsResult.error };
+  }
+
+  revalidatePath("/admin/radios");
+  revalidatePath(`/admin/radios/${id}/edit`);
+  redirect("/admin/radios");
+}
+
+export async function deleteRadio(formData: FormData): Promise<void> {
+  const id = String(formData.get("id") ?? "").trim();
+  if (!id) return;
+  if (!UUID_PATTERN.test(id)) {
+    throw new Error("IDが不正です");
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    throw new Error("認証が必要です");
+  }
+
+  const { error } = await supabase.from("radios").delete().eq("id", id);
+
+  if (error) {
+    throw new Error(`ラジオの削除に失敗しました: ${error.message}`);
+  }
+
+  revalidatePath("/admin/radios");
+  redirect("/admin/radios");
+}

--- a/src/lib/queries/radios.ts
+++ b/src/lib/queries/radios.ts
@@ -1,0 +1,81 @@
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry } from "@/lib/types";
+import type { Radio, RadioWithCasts } from "@/lib/types/radio";
+
+export async function listRadios(): Promise<Radio[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("radios")
+    .select("*")
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`ラジオ一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as Radio[];
+}
+
+export async function getRadio(id: string): Promise<RadioWithCasts | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("radios")
+    .select(
+      `*,
+       radio_casts(
+         id,
+         artist_id,
+         comedy_group_id,
+         unit_id,
+         artist:artists(id, name),
+         comedy_group:comedy_groups(id, name),
+         unit:units(id, name)
+       )`
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`ラジオ情報の取得に失敗しました: ${error.message}`);
+  }
+
+  if (!data) return null;
+
+  type CastRow = {
+    artist_id: string | null;
+    comedy_group_id: string | null;
+    unit_id: string | null;
+    artist: { id: string; name: string } | null;
+    comedy_group: { id: string; name: string } | null;
+    unit: { id: string; name: string } | null;
+  };
+
+  const rawCasts = (data as Record<string, unknown>).radio_casts as CastRow[];
+
+  const casts: CastEntry[] = (rawCasts ?? []).flatMap((c) => {
+    if (c.artist_id && c.artist) {
+      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
+    }
+    if (c.comedy_group_id && c.comedy_group) {
+      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
+    }
+    if (c.unit_id && c.unit) {
+      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
+    }
+    return [];
+  });
+
+  const radioBase: Radio = {
+    id: (data as { id: string }).id,
+    title: (data as { title: string }).title,
+    platform: (data as { platform: string | null }).platform,
+    url: (data as { url: string | null }).url,
+    published_at: (data as { published_at: string | null }).published_at,
+    description: (data as { description: string | null }).description,
+    created_at: (data as { created_at: string }).created_at,
+    updated_at: (data as { updated_at: string }).updated_at,
+  };
+
+  return { ...radioBase, casts };
+}

--- a/src/lib/types/radio.ts
+++ b/src/lib/types/radio.ts
@@ -22,3 +22,8 @@ export type RadioInput = {
 export type RadioWithCasts = Radio & {
   casts: CastEntry[];
 };
+
+export type RadioFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof RadioInput | "casts", string>>;
+};

--- a/src/lib/types/radio.ts
+++ b/src/lib/types/radio.ts
@@ -1,0 +1,24 @@
+import type { CastEntry } from "@/lib/types";
+
+export type Radio = {
+  id: string;
+  title: string;
+  platform: string | null;
+  url: string | null;
+  published_at: string | null;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type RadioInput = {
+  title: string;
+  platform: string | null;
+  url: string | null;
+  published_at: string | null;
+  description: string | null;
+};
+
+export type RadioWithCasts = Radio & {
+  casts: CastEntry[];
+};


### PR DESCRIPTION
## 概要

issue #14 の実装です。管理画面でラジオの CRUD 操作と出演者紐付けを行えるようにします。

Closes #14

## 変更内容

- `src/lib/types/radio.ts` — `Radio`・`RadioInput`・`RadioWithCasts` 型を定義
- `src/lib/queries/radios.ts` — `listRadios`・`getRadio` クエリ（`radio_casts` JOIN）
- `src/lib/actions/radios.ts` — `createRadio`・`updateRadio`・`deleteRadio` Server Actions
- `src/components/features/radio/radio-form.tsx` — `RadioForm` コンポーネント（`CastSelector` 統合）
- `src/components/features/radio/radio-delete-button.tsx` — 削除ボタン
- `src/app/admin/radios/page.tsx` — ラジオ一覧
- `src/app/admin/radios/new/page.tsx` — 新規作成
- `src/app/admin/radios/[id]/edit/page.tsx` — 編集

## テスト手順

- [ ] `/admin/radios` でラジオ一覧が表示される
- [ ] `/admin/radios/new` でラジオを新規作成できる
- [ ] プラットフォーム・URL・公開日時を設定できる
- [ ] 出演者（芸人・コンビ・ユニット）を追加して保存できる
- [ ] 編集ページで既存の情報・出演者が反映される
- [ ] 削除ボタンで確認ダイアログが表示され、削除できる

https://claude.ai/code/session_01XqW922zQD5cLvM4pkHtAf1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added radio management system to the admin interface
  * Create, view, edit, and delete radio entries with details including title, platform, URL, publication date, description, and cast information
  * Admin dashboard displays all radios with publication dates and provides quick access to edit or delete entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->