### PR TITLE
feat: 管理画面 記事 CRUD + 出演者紐付け (#15)

### DIFF
--- a/src/app/admin/articles/[id]/edit/page.tsx
+++ b/src/app/admin/articles/[id]/edit/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArticleForm } from "@/components/features/article/article-form";
+import { updateArticle } from "@/lib/actions/articles";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+import { getArticle } from "@/lib/queries/articles";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditArticlePage({ params }: Props) {
+  const { id } = await params;
+  const [article, artists, combos, units] = await Promise.all([
+    getArticle(id),
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  if (!article) {
+    notFound();
+  }
+
+  const action = updateArticle.bind(null, id);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/articles"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← 記事一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          {article.title} を編集
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <ArticleForm
+          action={action}
+          artists={artists}
+          combos={combos}
+          units={units}
+          initialValues={article}
+          initialCasts={article.casts}
+          submitLabel="更新する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/articles/[id]/edit/page.tsx
+++ b/src/app/admin/articles/[id]/edit/page.tsx
@@ -44,6 +44,7 @@ export default async function EditArticlePage({ params }: Props) {
 
       <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
         <ArticleForm
+          key={article.id}
           action={action}
           artists={artists}
           combos={combos}

--- a/src/app/admin/articles/new/page.tsx
+++ b/src/app/admin/articles/new/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { ArticleForm } from "@/components/features/article/article-form";
+import { createArticle } from "@/lib/actions/articles";
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewArticlePage() {
+  const [artists, combos, units] = await Promise.all([
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/articles"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← 記事一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          記事を新規作成
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <ArticleForm
+          action={createArticle}
+          artists={artists}
+          combos={combos}
+          units={units}
+          submitLabel="作成する"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/articles/page.tsx
+++ b/src/app/admin/articles/page.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+import { ArticleDeleteButton } from "@/components/features/article/article-delete-button";
+import { deleteArticle } from "@/lib/actions/articles";
+import { listArticles } from "@/lib/queries/articles";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("ja-JP");
+}
+
+export default async function AdminArticlesPage() {
+  const articles = await listArticles();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-brand-brown-dark">記事</h1>
+          <p className="mt-1 text-sm text-brand-brown-light">
+            インタビュー・記事と出演者を管理します。
+          </p>
+        </div>
+        <Link
+          href="/admin/articles/new"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-brand-cream transition hover:bg-brand-sky-dark"
+        >
+          新規作成
+        </Link>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+        {articles.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
+            まだ記事が登録されていません。
+          </p>
+        ) : (
+          <table className="min-w-full divide-y divide-brand-border-light text-sm">
+            <thead className="bg-brand-bg-light text-xs text-brand-brown-light">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium">タイトル</th>
+                <th className="px-4 py-2 text-left font-medium">媒体</th>
+                <th className="px-4 py-2 text-left font-medium">公開日</th>
+                <th className="px-4 py-2 text-right font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-border-light">
+              {articles.map((article) => (
+                <tr key={article.id} className="hover:bg-brand-bg-light">
+                  <td className="max-w-xs truncate px-4 py-2 font-medium text-brand-brown-dark">
+                    {article.title}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {article.source ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {formatDate(article.published_at)}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        href={`/admin/articles/${article.id}/edit`}
+                        className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
+                      >
+                        編集
+                      </Link>
+                      <form action={deleteArticle}>
+                        <input type="hidden" name="id" value={article.id} />
+                        <ArticleDeleteButton title={article.title} />
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/article/article-delete-button.tsx
+++ b/src/components/features/article/article-delete-button.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+type Props = {
+  title: string;
+};
+
+export function ArticleDeleteButton({ title }: Props) {
+  return (
+    <button
+      type="submit"
+      onClick={(e) => {
+        if (!confirm(`「${title}」を削除しますか？`)) {
+          e.preventDefault();
+        }
+      }}
+      className="rounded-md border border-brand-gold px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-cream"
+    >
+      削除
+    </button>
+  );
+}

--- a/src/components/features/article/article-form.tsx
+++ b/src/components/features/article/article-form.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { useForm } from "react-hook-form";
 import { CastSelector } from "@/components/features/cast-selector/cast-selector";
-import type { ArticleFormState } from "@/lib/actions/articles";
+import type { ArticleFormState } from "@/lib/types/article";
 import type { ArtistSummary } from "@/lib/queries/artists";
 import type { ComboSummary } from "@/lib/queries/combos";
 import type { UnitSummary } from "@/lib/queries/units";

--- a/src/components/features/article/article-form.tsx
+++ b/src/components/features/article/article-form.tsx
@@ -80,10 +80,6 @@ export function ArticleForm({
 
   const [casts, setCasts] = useState<CastEntry[]>(initialCasts ?? []);
 
-  useEffect(() => {
-    setCasts(initialCasts ?? []);
-  }, [initialCasts]);
-
   const onSubmit = handleSubmit((data) => {
     const formData = new FormData();
     formData.set("title", data.title);

--- a/src/components/features/article/article-form.tsx
+++ b/src/components/features/article/article-form.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import {
+  useActionState,
+  useEffect,
+  useState,
+  useTransition,
+} from "react";
+import { useForm } from "react-hook-form";
+import { CastSelector } from "@/components/features/cast-selector/cast-selector";
+import type { ArticleFormState } from "@/lib/actions/articles";
+import type { ArtistSummary } from "@/lib/queries/artists";
+import type { ComboSummary } from "@/lib/queries/combos";
+import type { UnitSummary } from "@/lib/queries/units";
+import type { CastEntry } from "@/lib/types";
+import type { ArticleInput } from "@/lib/types/article";
+
+type ArticleFormAction = (
+  prev: ArticleFormState,
+  formData: FormData
+) => Promise<ArticleFormState>;
+
+type ArticleFormValues = {
+  title: string;
+  url: string;
+  source: string;
+  published_at: string;
+  content: string;
+};
+
+type Props = {
+  action: ArticleFormAction;
+  artists: ArtistSummary[];
+  combos: ComboSummary[];
+  units: UnitSummary[];
+  initialValues?: Partial<ArticleInput>;
+  initialCasts?: CastEntry[];
+  submitLabel: string;
+};
+
+function toFormValues(initial?: Partial<ArticleInput>): ArticleFormValues {
+  return {
+    title: initial?.title ?? "",
+    url: initial?.url ?? "",
+    source: initial?.source ?? "",
+    published_at: initial?.published_at
+      ? initial.published_at.slice(0, 16)
+      : "",
+    content: initial?.content ?? "",
+  };
+}
+
+export function ArticleForm({
+  action,
+  artists,
+  combos,
+  units,
+  initialValues,
+  initialCasts,
+  submitLabel,
+}: Props) {
+  const [state, formAction] = useActionState<ArticleFormState, FormData>(
+    action,
+    {}
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors: clientErrors },
+    reset,
+  } = useForm<ArticleFormValues>({
+    defaultValues: toFormValues(initialValues),
+  });
+
+  useEffect(() => {
+    reset(toFormValues(initialValues));
+  }, [initialValues, reset]);
+
+  const [casts, setCasts] = useState<CastEntry[]>(initialCasts ?? []);
+
+  useEffect(() => {
+    setCasts(initialCasts ?? []);
+  }, [initialCasts]);
+
+  const onSubmit = handleSubmit((data) => {
+    const formData = new FormData();
+    formData.set("title", data.title);
+    formData.set("url", data.url);
+    formData.set("source", data.source);
+    formData.set("published_at", data.published_at);
+    formData.set("content", data.content);
+
+    for (const cast of casts) {
+      formData.append("cast_type", cast.type);
+      formData.append("cast_id", cast.id);
+      formData.append("cast_name", cast.name);
+    }
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  });
+
+  const fieldErrors = state.fieldErrors;
+
+  const inputClass =
+    "mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky";
+  const inputWithPlaceholderClass = `${inputClass} placeholder-brand-brown-light`;
+
+  return (
+    <form onSubmit={onSubmit} noValidate className="space-y-6">
+      {state.error && (
+        <p className="rounded-md border border-brand-gold bg-brand-bg-light px-4 py-3 text-sm text-brand-brown-dark" role="alert">
+          {state.error}
+        </p>
+      )}
+
+      <div>
+        <label
+          htmlFor="title"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          タイトル <span className="text-brand-gold">*</span>
+        </label>
+        <input
+          id="title"
+          type="text"
+          {...register("title", { required: "タイトルを入力してください", maxLength: { value: 200, message: "200文字以内で入力してください" } })}
+          className={inputClass}
+        />
+        {(clientErrors.title?.message || fieldErrors?.title) && (
+          <p className="mt-1 text-xs text-brand-gold" role="alert">
+            {clientErrors.title?.message ?? fieldErrors?.title}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="url"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          URL
+        </label>
+        <input
+          id="url"
+          type="url"
+          {...register("url")}
+          placeholder="https://..."
+          className={inputWithPlaceholderClass}
+        />
+        <p className="mt-0.5 text-xs text-brand-brown-light">
+          記事本文の転載不可。元記事へのリンクのみ登録してください。
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor="source"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          媒体名
+        </label>
+        <input
+          id="source"
+          type="text"
+          {...register("source")}
+          placeholder="例: 週刊お笑い、ナタリー"
+          className={inputWithPlaceholderClass}
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="published_at"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          公開日時
+        </label>
+        <input
+          id="published_at"
+          type="datetime-local"
+          {...register("published_at")}
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="content"
+          className="block text-sm font-medium text-brand-brown-dark"
+        >
+          メモ・要約
+        </label>
+        <textarea
+          id="content"
+          rows={4}
+          {...register("content")}
+          className={inputClass}
+        />
+        <p className="mt-0.5 text-xs text-brand-brown-light">
+          本文転載不可。自分用のメモや要約のみ記入可能です。
+        </p>
+      </div>
+
+      <div>
+        <p className="mb-2 block text-sm font-medium text-brand-brown-dark">
+          出演者
+        </p>
+        {fieldErrors?.casts && (
+          <p className="mb-2 text-xs text-brand-gold" role="alert">
+            {fieldErrors.casts}
+          </p>
+        )}
+        <CastSelector
+          artists={artists}
+          combos={combos}
+          units={units}
+          value={casts}
+          onChange={setCasts}
+        />
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-brand-sky px-5 py-2 text-sm font-medium text-brand-cream transition hover:bg-brand-sky-dark disabled:opacity-50"
+        >
+          {isPending ? "保存中..." : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/actions/articles.ts
+++ b/src/lib/actions/articles.ts
@@ -1,0 +1,219 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry } from "@/lib/types";
+import type { ArticleInput } from "@/lib/types/article";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type ArticleFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof ArticleInput | "casts", string>>;
+};
+
+function toNullableString(value: FormDataEntryValue | null): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function parseCasts(formData: FormData): {
+  casts: CastEntry[];
+  error?: string;
+} {
+  const types = formData.getAll("cast_type").map((v) => String(v));
+  const ids = formData.getAll("cast_id").map((v) => String(v));
+  const names = formData.getAll("cast_name").map((v) => String(v));
+
+  const casts: CastEntry[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < types.length; i += 1) {
+    const type = types[i]?.trim();
+    const id = ids[i]?.trim();
+    const name = names[i]?.trim() ?? "";
+
+    if (!type || !id) continue;
+    if (type !== "artist" && type !== "comedy_group" && type !== "unit") {
+      return { casts: [], error: "出演者の種別が不正です" };
+    }
+
+    const key = `${type}:${id}`;
+    if (seen.has(key)) {
+      return { casts: [], error: "同じ出演者を複数回追加できません" };
+    }
+    seen.add(key);
+
+    casts.push({ type, id, name });
+  }
+
+  return { casts };
+}
+
+function parseFormData(formData: FormData): {
+  values: ArticleInput;
+  casts: CastEntry[];
+  fieldErrors: ArticleFormState["fieldErrors"];
+} {
+  const fieldErrors: ArticleFormState["fieldErrors"] = {};
+
+  const title = String(formData.get("title") ?? "").trim();
+  if (!title) {
+    fieldErrors.title = "タイトルを入力してください";
+  } else if (title.length > 200) {
+    fieldErrors.title = "200文字以内で入力してください";
+  }
+
+  const values: ArticleInput = {
+    title,
+    url: toNullableString(formData.get("url")),
+    source: toNullableString(formData.get("source")),
+    published_at: toNullableString(formData.get("published_at")),
+    content: toNullableString(formData.get("content")),
+  };
+
+  const { casts, error: castsError } = parseCasts(formData);
+  if (castsError) {
+    fieldErrors.casts = castsError;
+  }
+
+  return { values, casts, fieldErrors };
+}
+
+async function replaceCasts(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  articleId: string,
+  casts: CastEntry[]
+): Promise<{ error?: string }> {
+  const { error: deleteError } = await supabase
+    .from("article_casts")
+    .delete()
+    .eq("article_id", articleId);
+
+  if (deleteError) {
+    return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
+  }
+
+  if (casts.length === 0) return {};
+
+  const rows = casts.map((c) => ({
+    article_id: articleId,
+    artist_id: c.type === "artist" ? c.id : null,
+    comedy_group_id: c.type === "comedy_group" ? c.id : null,
+    unit_id: c.type === "unit" ? c.id : null,
+  }));
+
+  const { error: insertError } = await supabase
+    .from("article_casts")
+    .insert(rows);
+
+  if (insertError) {
+    return { error: `出演者の追加に失敗しました: ${insertError.message}` };
+  }
+
+  return {};
+}
+
+export async function createArticle(
+  _prev: ArticleFormState,
+  formData: FormData
+): Promise<ArticleFormState> {
+  const { values, casts, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
+  const { data, error } = await supabase
+    .from("articles")
+    .insert(values)
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    return {
+      error: `記事の登録に失敗しました: ${error?.message ?? "unknown"}`,
+    };
+  }
+
+  const castsResult = await replaceCasts(supabase, data.id, casts);
+  if (castsResult.error) {
+    return { error: castsResult.error };
+  }
+
+  revalidatePath("/admin/articles");
+  redirect("/admin/articles");
+}
+
+export async function updateArticle(
+  id: string,
+  _prev: ArticleFormState,
+  formData: FormData
+): Promise<ArticleFormState> {
+  if (!UUID_PATTERN.test(id)) {
+    return { error: "IDが不正です" };
+  }
+
+  const { values, casts, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
+  const { error } = await supabase
+    .from("articles")
+    .update({ ...values, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    return { error: `記事の更新に失敗しました: ${error.message}` };
+  }
+
+  const castsResult = await replaceCasts(supabase, id, casts);
+  if (castsResult.error) {
+    return { error: castsResult.error };
+  }
+
+  revalidatePath("/admin/articles");
+  revalidatePath(`/admin/articles/${id}/edit`);
+  redirect("/admin/articles");
+}
+
+export async function deleteArticle(formData: FormData): Promise<void> {
+  const id = String(formData.get("id") ?? "").trim();
+  if (!id) return;
+  if (!UUID_PATTERN.test(id)) {
+    throw new Error("IDが不正です");
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    throw new Error("認証が必要です");
+  }
+
+  const { error } = await supabase.from("articles").delete().eq("id", id);
+
+  if (error) {
+    throw new Error(`記事の削除に失敗しました: ${error.message}`);
+  }
+
+  revalidatePath("/admin/articles");
+  redirect("/admin/articles");
+}

--- a/src/lib/actions/articles.ts
+++ b/src/lib/actions/articles.ts
@@ -4,15 +4,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
-import type { ArticleInput } from "@/lib/types/article";
+import type { ArticleFormState, ArticleInput } from "@/lib/types/article";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-export type ArticleFormState = {
-  error?: string;
-  fieldErrors?: Partial<Record<keyof ArticleInput | "casts", string>>;
-};
 
 function toNullableString(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") return null;

--- a/src/lib/queries/articles.ts
+++ b/src/lib/queries/articles.ts
@@ -1,0 +1,81 @@
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry } from "@/lib/types";
+import type { Article, ArticleWithCasts } from "@/lib/types/article";
+
+export async function listArticles(): Promise<Article[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("articles")
+    .select("*")
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`記事一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as Article[];
+}
+
+export async function getArticle(id: string): Promise<ArticleWithCasts | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("articles")
+    .select(
+      `*,
+       article_casts(
+         id,
+         artist_id,
+         comedy_group_id,
+         unit_id,
+         artist:artists(id, name),
+         comedy_group:comedy_groups(id, name),
+         unit:units(id, name)
+       )`
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`記事情報の取得に失敗しました: ${error.message}`);
+  }
+
+  if (!data) return null;
+
+  type CastRow = {
+    artist_id: string | null;
+    comedy_group_id: string | null;
+    unit_id: string | null;
+    artist: { id: string; name: string } | null;
+    comedy_group: { id: string; name: string } | null;
+    unit: { id: string; name: string } | null;
+  };
+
+  const rawCasts = (data as Record<string, unknown>).article_casts as CastRow[];
+
+  const casts: CastEntry[] = (rawCasts ?? []).flatMap((c) => {
+    if (c.artist_id && c.artist) {
+      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
+    }
+    if (c.comedy_group_id && c.comedy_group) {
+      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
+    }
+    if (c.unit_id && c.unit) {
+      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
+    }
+    return [];
+  });
+
+  const articleBase: Article = {
+    id: (data as { id: string }).id,
+    title: (data as { title: string }).title,
+    url: (data as { url: string | null }).url,
+    source: (data as { source: string | null }).source,
+    published_at: (data as { published_at: string | null }).published_at,
+    content: (data as { content: string | null }).content,
+    created_at: (data as { created_at: string }).created_at,
+    updated_at: (data as { updated_at: string }).updated_at,
+  };
+
+  return { ...articleBase, casts };
+}

--- a/src/lib/types/article.ts
+++ b/src/lib/types/article.ts
@@ -22,3 +22,8 @@ export type ArticleInput = {
 export type ArticleWithCasts = Article & {
   casts: CastEntry[];
 };
+
+export type ArticleFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof ArticleInput | "casts", string>>;
+};

--- a/src/lib/types/article.ts
+++ b/src/lib/types/article.ts
@@ -1,0 +1,24 @@
+import type { CastEntry } from "@/lib/types";
+
+export type Article = {
+  id: string;
+  title: string;
+  url: string | null;
+  source: string | null;
+  published_at: string | null;
+  content: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ArticleInput = {
+  title: string;
+  url: string | null;
+  source: string | null;
+  published_at: string | null;
+  content: string | null;
+};
+
+export type ArticleWithCasts = Article & {
+  casts: CastEntry[];
+};


### PR DESCRIPTION
## 概要

issue #15 の実装です。管理画面で記事・インタビューの CRUD 操作と出演者紐付けを行えるようにします。

Closes #15

## 変更内容

- `src/lib/types/article.ts` — `Article`・`ArticleInput`・`ArticleWithCasts` 型を定義
- `src/lib/queries/articles.ts` — `listArticles`・`getArticle` クエリ（`article_casts` JOIN）
- `src/lib/actions/articles.ts` — `createArticle`・`updateArticle`・`deleteArticle` Server Actions
- `src/components/features/article/article-form.tsx` — `ArticleForm` コンポーネント（`CastSelector` 統合、brand-* トークン使用）
- `src/components/features/article/article-delete-button.tsx` — 削除ボタン（brand-gold スタイル）
- `src/app/admin/articles/page.tsx` — 記事一覧
- `src/app/admin/articles/new/page.tsx` — 新規作成
- `src/app/admin/articles/[id]/edit/page.tsx` — 編集

## テスト手順

- [ ] `/admin/articles` で記事一覧が表示される
- [ ] `/admin/articles/new` で記事を新規作成できる
- [ ] URL・媒体名・公開日時を設定できる
- [ ] 出演者（芸人・コンビ・ユニット）を追加して保存できる
- [ ] 編集ページで既存の情報・出演者が反映される
- [ ] 削除ボタンで確認ダイアログが表示され、削除できる

https://claude.ai/code/session_01XqW922zQD5cLvM4pkHtAf1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin article management: create, edit, and delete articles.
  * Article listing with source and localized publication dates.
  * Article creation and edit forms pre-filled for editing and supporting cast management.
  * Field-level validation and server-backed error handling for submissions.
  * Confirmation dialog for deletes and smooth redirect/update of the admin list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->