### PR TITLE
feat: 公開側レイアウト（ヘッダー + フッター + ボトムナビ）

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+import { PublicHeader } from "@/components/layout/header";
+import { PublicFooter } from "@/components/layout/footer";
+import { PublicBottomNav } from "@/components/layout/bottom-nav";
+
+export default function PublicLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-1 flex-col bg-brand-bg-dark text-brand-cream">
+      <PublicHeader />
+      <main className="flex flex-1 flex-col pb-16 md:pb-0">{children}</main>
+      <PublicFooter />
+      <PublicBottomNav />
+    </div>
+  );
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,10 +1,8 @@
 export default function Home() {
   return (
-    <div className="flex flex-1 items-center justify-center bg-brand-bg-dark">
+    <div className="flex flex-1 items-center justify-center px-4 py-16">
       <div className="text-center">
-        <h1 className="text-3xl font-bold text-brand-cream">
-          DonDecorte Lab
-        </h1>
+        <h1 className="text-3xl font-bold text-brand-cream">DonDecorte Lab</h1>
         <p className="mt-2 text-brand-gold">
           ドンデコルテさん非公式ファンサイト
         </p>

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+type NavItem = {
+  href: string;
+  label: string;
+};
+
+const PRIMARY_ITEMS: NavItem[] = [
+  { href: "/", label: "Home" },
+  { href: "/videos", label: "Videos" },
+  { href: "/lives", label: "Lives" },
+  { href: "/artists", label: "Artists" },
+];
+
+const MORE_ITEMS: NavItem[] = [
+  { href: "/combos", label: "コンビ" },
+  { href: "/units", label: "ユニット" },
+  { href: "/radios", label: "ラジオ" },
+  { href: "/articles", label: "記事" },
+  { href: "/tv", label: "TV" },
+  { href: "/topics", label: "トピック" },
+];
+
+function isActive(pathname: string, href: string) {
+  if (href === "/") return pathname === "/";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function PublicBottomNav() {
+  const pathname = usePathname();
+  const [moreOpen, setMoreOpen] = useState(false);
+  const [lastPathname, setLastPathname] = useState(pathname);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  if (lastPathname !== pathname) {
+    setLastPathname(pathname);
+    setMoreOpen(false);
+  }
+
+  useEffect(() => {
+    if (!moreOpen) return;
+    function handleClick(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setMoreOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [moreOpen]);
+
+  const moreActive = MORE_ITEMS.some((item) => isActive(pathname, item.href));
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed inset-x-0 bottom-0 z-40 md:hidden"
+    >
+      {moreOpen ? (
+        <div
+          id="public-bottom-nav-more"
+          className="border-t border-brand-border-dark bg-brand-card-dark px-4 py-3 shadow-lg"
+        >
+          <ul className="grid grid-cols-3 gap-2">
+            {MORE_ITEMS.map((item) => {
+              const active = isActive(pathname, item.href);
+              return (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className={
+                      active
+                        ? "block rounded-md bg-brand-sky-pale/10 px-3 py-2 text-center text-xs font-medium text-brand-sky-light"
+                        : "block rounded-md px-3 py-2 text-center text-xs text-brand-gold transition hover:text-brand-sky-light"
+                    }
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+      <nav className="border-t border-brand-border-dark bg-brand-bg-dark/95 backdrop-blur">
+        <ul className="mx-auto grid max-w-6xl grid-cols-5">
+          {PRIMARY_ITEMS.map((item) => {
+            const active = isActive(pathname, item.href);
+            return (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  aria-current={active ? "page" : undefined}
+                  className={
+                    active
+                      ? "flex h-14 items-center justify-center text-xs font-semibold text-brand-sky-light"
+                      : "flex h-14 items-center justify-center text-xs text-brand-gold transition hover:text-brand-sky-light"
+                  }
+                >
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+          <li>
+            <button
+              type="button"
+              onClick={() => setMoreOpen((v) => !v)}
+              aria-expanded={moreOpen}
+              aria-controls="public-bottom-nav-more"
+              className={
+                moreActive || moreOpen
+                  ? "flex h-14 w-full items-center justify-center text-xs font-semibold text-brand-sky-light"
+                  : "flex h-14 w-full items-center justify-center text-xs text-brand-gold transition hover:text-brand-sky-light"
+              }
+            >
+              More
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  );
+}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,0 +1,17 @@
+export function PublicFooter() {
+  return (
+    <footer className="border-t border-brand-border-dark bg-brand-card-dark px-4 py-6 text-xs leading-relaxed text-brand-muted">
+      <div className="mx-auto max-w-6xl space-y-2">
+        <p>
+          本サイトはドンデコルテおよび吉本興業とは無関係の非公式ファンサイトです。
+        </p>
+        <p>
+          掲載情報の正確性は保証しません。権利者様からの削除要請には速やかに対応いたします。
+        </p>
+        <p className="pt-2 text-brand-brown-light">
+          &copy; {new Date().getFullYear()} DonDecorte Lab
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+
+const NAV_ITEMS = [
+  { href: "/videos", label: "動画" },
+  { href: "/lives", label: "ライブ" },
+  { href: "/radios", label: "ラジオ" },
+  { href: "/articles", label: "記事" },
+  { href: "/tv", label: "TV" },
+  { href: "/topics", label: "トピック" },
+  { href: "/combos", label: "コンビ" },
+  { href: "/artists", label: "芸人" },
+];
+
+export async function PublicHeader() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return (
+    <header className="sticky top-0 z-30 border-b border-brand-border-dark bg-brand-bg-dark/95 backdrop-blur">
+      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between gap-4 px-4">
+        <Link
+          href="/"
+          className="text-base font-bold tracking-wide text-brand-cream transition hover:text-brand-sky-light md:text-lg"
+        >
+          DonDecorte Lab
+        </Link>
+        <nav className="hidden md:block">
+          <ul className="flex items-center gap-5 text-sm">
+            {NAV_ITEMS.map((item) => (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  className="text-brand-gold transition hover:text-brand-sky-light"
+                >
+                  {item.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        {user ? (
+          <Link
+            href="/admin"
+            className="rounded-md border border-brand-border-dark bg-brand-card-dark px-3 py-1.5 text-xs font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"
+          >
+            管理画面
+          </Link>
+        ) : null}
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #18 の対応です。公開側のレイアウト（ヘッダー + フッター + ボトムナビ）を実装しました。

## 変更点

- `src/app/(public)/layout.tsx` を新設し、既存のトップページを Route Group (`(public)`) 配下に移動（URL は変わらず `/`）
- `src/components/layout/header.tsx`: ロゴ + デスクトップ用ナビ。ログイン状態のときのみ管理画面リンクを表示し、公開 UI にログインボタンは出さない
- `src/components/layout/footer.tsx`: 非公式ファンサイトである旨の免責文を表示
- `src/components/layout/bottom-nav.tsx`: モバイル専用の固定ボトムナビ。Home/Videos/Lives/Artists/More の 5 項目で、More を開くとそれ以外の公開ルート（コンビ・ユニット・ラジオ・記事・TV・トピック）を一覧表示
- ダークモードのブランドトークン（茶色ベース + 水色アクセント）を適用

## 完了条件

- [x] ヘッダー + フッターが表示される
- [x] モバイルでボトムナビが表示される（`md` 未満で固定表示 / デスクトップでは非表示）
- [x] ログインボタンが公開 UI に存在しない（管理画面リンクはログイン時のみ）

## 動作確認

- `pnpm lint`: 本 PR で追加したコードに関する指摘なし（既存の未解消 warning/error は別件）
- `pnpm build`: Next.js のコンパイルは成功（型エラーは `actions/achievements.ts` 等の既存箇所のみで本 PR 外）

Closes #18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a public-facing layout with header, footer, and responsive bottom navigation menu
* Introduced primary navigation sections (Home, Videos, Lives, Artists) with expandable "More" menu for additional options
* Implemented authentication-based access to the admin panel
* Updated home page styling with improved spacing and layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->