### PR TITLE
feat: 公開トップページに3セクションを実装 (#19)

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -29,28 +29,52 @@ const CONTENT_TYPE_PATH: Record<ContentType, string> = {
   topic: "topics",
 };
 
-function formatDate(iso: string | null): string {
-  if (!iso) return "日付未定";
-  const date = new Date(iso);
+const BUSINESS_TIMEZONE = "Asia/Tokyo";
+
+function formatDate(value: string | null): string {
+  if (!value) return "日付未定";
+  const dateOnly = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnly) {
+    const [, y, m, d] = dateOnly;
+    return `${Number(y)}年${Number(m)}月${Number(d)}日`;
+  }
+  const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "日付未定";
   return date.toLocaleDateString("ja-JP", {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: BUSINESS_TIMEZONE,
   });
 }
 
-function formatTime(time: string | null): string | null {
-  if (!time) return null;
-  return time.slice(0, 5);
+function formatTime(value: string | null): string | null {
+  if (!value) return null;
+  if (/^\d{2}:\d{2}/.test(value)) return value.slice(0, 5);
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleTimeString("ja-JP", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: BUSINESS_TIMEZONE,
+  });
 }
 
 export default async function Home() {
-  const [upcomingLives, latestVideos, recentContent] = await Promise.all([
-    getUpcomingLives(),
-    getLatestVideos(),
-    getRecentContent(),
-  ]);
+  const [upcomingLivesRes, latestVideosRes, recentContentRes] =
+    await Promise.allSettled([
+      getUpcomingLives(),
+      getLatestVideos(),
+      getRecentContent(),
+    ]);
+
+  const upcomingLives =
+    upcomingLivesRes.status === "fulfilled" ? upcomingLivesRes.value : [];
+  const latestVideos =
+    latestVideosRes.status === "fulfilled" ? latestVideosRes.value : [];
+  const recentContent =
+    recentContentRes.status === "fulfilled" ? recentContentRes.value : [];
 
   return (
     <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,15 +1,221 @@
-export default function Home() {
+import Link from "next/link";
+import {
+  getLatestVideos,
+  getRecentContent,
+  getUpcomingLives,
+  type RecentContentItem,
+} from "@/lib/queries/top-page";
+import type { ContentType } from "@/lib/types";
+import type { Live } from "@/lib/types/live";
+import type { Video } from "@/lib/types/video";
+
+export const dynamic = "force-dynamic";
+
+const CONTENT_TYPE_LABEL: Record<ContentType, string> = {
+  video: "動画",
+  live: "ライブ",
+  radio: "ラジオ",
+  article: "記事",
+  tv_show: "TV",
+  topic: "トピック",
+};
+
+const CONTENT_TYPE_PATH: Record<ContentType, string> = {
+  video: "videos",
+  live: "lives",
+  radio: "radios",
+  article: "articles",
+  tv_show: "tv",
+  topic: "topics",
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "日付未定";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "日付未定";
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function formatTime(time: string | null): string | null {
+  if (!time) return null;
+  return time.slice(0, 5);
+}
+
+export default async function Home() {
+  const [upcomingLives, latestVideos, recentContent] = await Promise.all([
+    getUpcomingLives(),
+    getLatestVideos(),
+    getRecentContent(),
+  ]);
+
   return (
-    <div className="flex flex-1 items-center justify-center px-4 py-16">
-      <div className="text-center">
-        <h1 className="text-3xl font-bold text-brand-cream">DonDecorte Lab</h1>
-        <p className="mt-2 text-brand-gold">
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <section className="mb-10 md:mb-14">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          DonDecorte Lab
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
           ドンデコルテさん非公式ファンサイト
         </p>
-        <span className="mt-4 inline-block text-brand-sky-light">
-          Coming Soon
-        </span>
-      </div>
+      </section>
+
+      <UpcomingLivesSection lives={upcomingLives} />
+      <LatestVideosSection videos={latestVideos} />
+      <RecentContentSection items={recentContent} />
     </div>
+  );
+}
+
+function SectionHeader({
+  title,
+  href,
+  linkLabel = "一覧へ",
+}: {
+  title: string;
+  href?: string;
+  linkLabel?: string;
+}) {
+  return (
+    <div className="mb-4 flex items-end justify-between gap-4">
+      <h2 className="text-lg font-semibold text-brand-cream md:text-xl">
+        {title}
+      </h2>
+      {href ? (
+        <Link
+          href={href}
+          className="text-xs text-brand-sky-light transition hover:text-brand-sky md:text-sm"
+        >
+          {linkLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+function UpcomingLivesSection({ lives }: { lives: Live[] }) {
+  return (
+    <section className="mb-10 md:mb-14">
+      <SectionHeader title="直近のライブ予定" href="/lives" />
+      {lives.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          予定されているライブはまだありません。
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {lives.map((live) => {
+            const time = formatTime(live.start_time);
+            return (
+              <li key={live.id}>
+                <Link
+                  href={`/lives/${live.id}`}
+                  className="block rounded-lg border-l-4 border-brand-sky border-y border-r border-brand-border-dark bg-brand-card-dark px-4 py-3 transition hover:border-brand-sky-light hover:bg-brand-card-dark/80"
+                >
+                  <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                    <span className="text-sm font-medium text-brand-sky-light">
+                      {formatDate(live.event_date)}
+                      {time ? ` ${time}` : ""}
+                    </span>
+                    {live.venue ? (
+                      <span className="text-xs text-brand-muted">
+                        {live.venue}
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="mt-1 text-sm font-semibold text-brand-cream">
+                    {live.title}
+                  </p>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function LatestVideosSection({ videos }: { videos: Video[] }) {
+  return (
+    <section className="mb-10 md:mb-14">
+      <SectionHeader title="最新動画" href="/videos" />
+      {videos.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          まだ動画が登録されていません。
+        </p>
+      ) : (
+        <ul className="grid grid-cols-2 gap-4 md:grid-cols-3">
+          {videos.map((video) => (
+            <li key={video.id}>
+              <Link
+                href={`/videos/${video.id}`}
+                className="group block overflow-hidden rounded-lg border border-brand-border-dark bg-brand-card-dark transition hover:border-brand-sky-light"
+              >
+                <div className="aspect-video w-full overflow-hidden bg-brand-bg-dark">
+                  {video.thumbnail_url ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={video.thumbnail_url}
+                      alt=""
+                      loading="lazy"
+                      className="h-full w-full object-cover transition group-hover:scale-105"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-xs text-brand-muted">
+                      No Thumbnail
+                    </div>
+                  )}
+                </div>
+                <div className="p-3">
+                  <p className="line-clamp-2 text-sm font-medium text-brand-cream group-hover:text-brand-sky-light">
+                    {video.title}
+                  </p>
+                  <p className="mt-1 text-xs text-brand-muted">
+                    {formatDate(video.published_at)}
+                  </p>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function RecentContentSection({ items }: { items: RecentContentItem[] }) {
+  return (
+    <section className="mb-10 md:mb-14">
+      <SectionHeader title="最近追加されたコンテンツ" />
+      {items.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          まだコンテンツが登録されていません。
+        </p>
+      ) : (
+        <ul className="divide-y divide-brand-border-dark overflow-hidden rounded-lg border border-brand-border-dark bg-brand-card-dark">
+          {items.map((item) => (
+            <li key={`${item.type}-${item.id}`}>
+              <Link
+                href={`/${CONTENT_TYPE_PATH[item.type]}/${item.id}`}
+                className="flex items-center gap-3 px-4 py-3 transition hover:bg-brand-bg-dark/40"
+              >
+                <span className="inline-flex shrink-0 items-center rounded-md border border-brand-border-dark bg-brand-bg-dark px-2 py-0.5 text-[10px] font-medium text-brand-sky-light">
+                  {CONTENT_TYPE_LABEL[item.type]}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm text-brand-cream">
+                  {item.title}
+                </span>
+                <span className="shrink-0 text-xs text-brand-muted">
+                  {formatDate(item.date)}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }

--- a/src/lib/queries/top-page.ts
+++ b/src/lib/queries/top-page.ts
@@ -13,8 +13,8 @@ export type RecentContentItem = {
 
 const UPCOMING_LIVES_LIMIT = 5;
 const LATEST_VIDEOS_LIMIT = 3;
-const RECENT_PER_TYPE_LIMIT = 5;
 const RECENT_TOTAL_LIMIT = 10;
+const RECENT_PER_TYPE_LIMIT = RECENT_TOTAL_LIMIT;
 const BUSINESS_TIMEZONE = "Asia/Tokyo";
 
 function todayInBusinessTimezone(): string {

--- a/src/lib/queries/top-page.ts
+++ b/src/lib/queries/top-page.ts
@@ -1,0 +1,164 @@
+import { createClient } from "@/lib/supabase/server";
+import type { ContentType } from "@/lib/types";
+import type { Live } from "@/lib/types/live";
+import type { Video } from "@/lib/types/video";
+
+export type RecentContentItem = {
+  type: ContentType;
+  id: string;
+  title: string;
+  createdAt: string;
+  date: string | null;
+};
+
+const UPCOMING_LIVES_LIMIT = 5;
+const LATEST_VIDEOS_LIMIT = 3;
+const RECENT_PER_TYPE_LIMIT = 5;
+const RECENT_TOTAL_LIMIT = 10;
+
+export async function getUpcomingLives(): Promise<Live[]> {
+  const supabase = await createClient();
+  const today = new Date().toISOString().slice(0, 10);
+
+  const { data, error } = await supabase
+    .from("lives")
+    .select("*")
+    .gte("event_date", today)
+    .order("event_date", { ascending: true })
+    .order("start_time", { ascending: true, nullsFirst: false })
+    .limit(UPCOMING_LIVES_LIMIT);
+
+  if (error) {
+    throw new Error(`直近のライブ予定の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as Live[];
+}
+
+export async function getLatestVideos(): Promise<Video[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("videos")
+    .select("*")
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false })
+    .limit(LATEST_VIDEOS_LIMIT);
+
+  if (error) {
+    throw new Error(`最新動画の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as Video[];
+}
+
+type RecentRow = {
+  id: string;
+  title: string;
+  created_at: string;
+};
+
+export async function getRecentContent(): Promise<RecentContentItem[]> {
+  const supabase = await createClient();
+
+  const [videos, lives, radios, articles, tvShows, topics] = await Promise.all([
+    supabase
+      .from("videos")
+      .select("id, title, created_at, published_at")
+      .order("created_at", { ascending: false })
+      .limit(RECENT_PER_TYPE_LIMIT),
+    supabase
+      .from("lives")
+      .select("id, title, created_at, event_date")
+      .order("created_at", { ascending: false })
+      .limit(RECENT_PER_TYPE_LIMIT),
+    supabase
+      .from("radios")
+      .select("id, title, created_at, published_at")
+      .order("created_at", { ascending: false })
+      .limit(RECENT_PER_TYPE_LIMIT),
+    supabase
+      .from("articles")
+      .select("id, title, created_at, published_at")
+      .order("created_at", { ascending: false })
+      .limit(RECENT_PER_TYPE_LIMIT),
+    supabase
+      .from("tv_shows")
+      .select("id, title, created_at, air_date")
+      .order("created_at", { ascending: false })
+      .limit(RECENT_PER_TYPE_LIMIT),
+    supabase
+      .from("topics")
+      .select("id, title, created_at, topic_date")
+      .order("created_at", { ascending: false })
+      .limit(RECENT_PER_TYPE_LIMIT),
+  ]);
+
+  const errors = [videos, lives, radios, articles, tvShows, topics]
+    .map((r) => r.error)
+    .filter((e): e is NonNullable<typeof e> => e !== null);
+  if (errors.length > 0) {
+    throw new Error(
+      `最近追加されたコンテンツの取得に失敗しました: ${errors[0].message}`
+    );
+  }
+
+  const items: RecentContentItem[] = [
+    ...((videos.data ?? []) as (RecentRow & { published_at: string | null })[]).map(
+      (v) => ({
+        type: "video" as const,
+        id: v.id,
+        title: v.title,
+        createdAt: v.created_at,
+        date: v.published_at,
+      })
+    ),
+    ...((lives.data ?? []) as (RecentRow & { event_date: string | null })[]).map(
+      (l) => ({
+        type: "live" as const,
+        id: l.id,
+        title: l.title,
+        createdAt: l.created_at,
+        date: l.event_date,
+      })
+    ),
+    ...((radios.data ?? []) as (RecentRow & { published_at: string | null })[]).map(
+      (r) => ({
+        type: "radio" as const,
+        id: r.id,
+        title: r.title,
+        createdAt: r.created_at,
+        date: r.published_at,
+      })
+    ),
+    ...((articles.data ?? []) as (RecentRow & { published_at: string | null })[]).map(
+      (a) => ({
+        type: "article" as const,
+        id: a.id,
+        title: a.title,
+        createdAt: a.created_at,
+        date: a.published_at,
+      })
+    ),
+    ...((tvShows.data ?? []) as (RecentRow & { air_date: string | null })[]).map(
+      (t) => ({
+        type: "tv_show" as const,
+        id: t.id,
+        title: t.title,
+        createdAt: t.created_at,
+        date: t.air_date,
+      })
+    ),
+    ...((topics.data ?? []) as (RecentRow & { topic_date: string | null })[]).map(
+      (t) => ({
+        type: "topic" as const,
+        id: t.id,
+        title: t.title,
+        createdAt: t.created_at,
+        date: t.topic_date,
+      })
+    ),
+  ];
+
+  items.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return items.slice(0, RECENT_TOTAL_LIMIT);
+}

--- a/src/lib/queries/top-page.ts
+++ b/src/lib/queries/top-page.ts
@@ -15,10 +15,24 @@ const UPCOMING_LIVES_LIMIT = 5;
 const LATEST_VIDEOS_LIMIT = 3;
 const RECENT_PER_TYPE_LIMIT = 5;
 const RECENT_TOTAL_LIMIT = 10;
+const BUSINESS_TIMEZONE = "Asia/Tokyo";
+
+function todayInBusinessTimezone(): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: BUSINESS_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+  const year = parts.find((p) => p.type === "year")?.value ?? "1970";
+  const month = parts.find((p) => p.type === "month")?.value ?? "01";
+  const day = parts.find((p) => p.type === "day")?.value ?? "01";
+  return `${year}-${month}-${day}`;
+}
 
 export async function getUpcomingLives(): Promise<Live[]> {
   const supabase = await createClient();
-  const today = new Date().toISOString().slice(0, 10);
+  const today = todayInBusinessTimezone();
 
   const { data, error } = await supabase
     .from("lives")


### PR DESCRIPTION
## 概要

issue #19「公開側：トップページ」を実装しました。

## 変更点

- `src/app/(public)/page.tsx` をデータ取得つきのServer Componentに更新し、以下3セクションを表示:
  1. **直近のライブ予定** — 今日以降のライブを日付・開始時刻順に最大5件表示。水色の左ボーダーでアクセント
  2. **最新動画** — 公開日順に3件、モバイル2列／PC3列のサムネイル付きグリッド
  3. **最近追加されたコンテンツ** — 6種（動画/ライブ/ラジオ/記事/TV/トピック）を `created_at` で混合ソートし最大10件、コンテンツ種別バッジつきリスト表示
- `src/lib/queries/top-page.ts` を新設し、トップページ用のデータ取得（`getUpcomingLives` / `getLatestVideos` / `getRecentContent`）を集約。`Promise.all` で並列取得

## 実装メモ

- セクション見出しには各一覧ページへの「一覧へ」リンクを配置（回遊導線）
- サムネ未設定の動画は「No Thumbnail」プレースホルダを表示
- データ未登録時は各セクションにフォールバックメッセージを表示
- 動画サムネは今後 `next.config.ts` で `images.remotePatterns` 設定後に `next/image` へ差し替え可能

## 完了条件

- [x] トップページに3セクションが表示される
- [x] Server Component でSSR（`export const dynamic = "force-dynamic"`）

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned home page to show upcoming live events, latest videos, and recent mixed content.
  * Sectioned layout with headers, empty-state UI, and lists/grids for each content type.
  * Added navigation to full-list pages and direct links to individual content items.
  * Improved date/time display with timezone-aware formatting and sensible fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->