### PR TITLE
feat: 公開側のライブ一覧ページを実装

### DIFF
--- a/src/app/(public)/lives/page.tsx
+++ b/src/app/(public)/lives/page.tsx
@@ -1,0 +1,23 @@
+import { LiveList } from "@/components/features/live/live-list";
+import { listLivesWithCasts } from "@/lib/queries/lives";
+
+export const dynamic = "force-dynamic";
+
+export default async function LivesPage() {
+  const lives = await listLivesWithCasts();
+
+  return (
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          ライブ
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          ドンデコルテさん関連のライブ情報一覧。
+        </p>
+      </header>
+
+      <LiveList lives={lives} />
+    </div>
+  );
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -8,6 +8,10 @@ import {
 import type { ContentType } from "@/lib/types";
 import type { Live } from "@/lib/types/live";
 import type { Video } from "@/lib/types/video";
+import {
+  formatDate as formatDateRaw,
+  formatTime,
+} from "@/lib/utils/date";
 
 export const dynamic = "force-dynamic";
 
@@ -29,36 +33,8 @@ const CONTENT_TYPE_PATH: Record<ContentType, string> = {
   topic: "topics",
 };
 
-const BUSINESS_TIMEZONE = "Asia/Tokyo";
-
 function formatDate(value: string | null): string {
-  if (!value) return "日付未定";
-  const dateOnly = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (dateOnly) {
-    const [, y, m, d] = dateOnly;
-    return `${Number(y)}年${Number(m)}月${Number(d)}日`;
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "日付未定";
-  return date.toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    timeZone: BUSINESS_TIMEZONE,
-  });
-}
-
-function formatTime(value: string | null): string | null {
-  if (!value) return null;
-  if (/^\d{2}:\d{2}/.test(value)) return value.slice(0, 5);
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleTimeString("ja-JP", {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-    timeZone: BUSINESS_TIMEZONE,
-  });
+  return formatDateRaw(value) ?? "日付未定";
 }
 
 export default async function Home() {

--- a/src/components/features/live/live-card.tsx
+++ b/src/components/features/live/live-card.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import type { CastEntry, CastType } from "@/lib/types";
+import type { LiveWithCasts } from "@/lib/types/live";
+import { formatDate } from "@/lib/utils/date";
+
+const CAST_PATH: Record<CastType, string> = {
+  artist: "/artists",
+  comedy_group: "/combos",
+  unit: "/units",
+};
+
+function formatTime(value: string | null): string | null {
+  if (!value) return null;
+  const match = value.match(/^(\d{2}):(\d{2})/);
+  return match ? `${match[1]}:${match[2]}` : null;
+}
+
+function CastTag({ cast }: { cast: CastEntry }) {
+  return (
+    <Link
+      href={`${CAST_PATH[cast.type]}/${cast.id}`}
+      className="inline-flex items-center rounded-full border border-brand-border-dark bg-brand-bg-dark px-2 py-0.5 text-xs text-brand-gold transition hover:border-brand-sky-light hover:text-brand-sky-light"
+    >
+      {cast.name}
+    </Link>
+  );
+}
+
+export function LiveCard({
+  live,
+  variant,
+}: {
+  live: LiveWithCasts;
+  variant: "upcoming" | "past";
+}) {
+  const eventDate = formatDate(live.event_date);
+  const startTime = formatTime(live.start_time);
+  const dateLine = eventDate
+    ? `${eventDate}${startTime ? ` ${startTime}` : ""}`
+    : "日付未定";
+
+  const borderClass =
+    variant === "upcoming"
+      ? "border-l-4 border-brand-sky border-y border-r border-brand-border-dark"
+      : "border border-brand-border-dark";
+  const dateColor =
+    variant === "upcoming" ? "text-brand-sky-light" : "text-brand-gold";
+
+  return (
+    <article
+      className={`rounded-lg ${borderClass} bg-brand-card-dark px-4 py-3 transition hover:border-brand-sky-light`}
+    >
+      <Link href={`/lives/${live.id}`} className="block group">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span className={`text-sm font-medium ${dateColor}`}>{dateLine}</span>
+          {live.venue ? (
+            <span className="text-xs text-brand-muted">{live.venue}</span>
+          ) : null}
+        </div>
+        <p className="mt-1 text-sm font-semibold text-brand-cream group-hover:text-brand-sky-light">
+          {live.title}
+        </p>
+      </Link>
+      {live.casts.length > 0 ? (
+        <ul className="mt-2 flex flex-wrap gap-1.5">
+          {live.casts.map((cast) => (
+            <li key={`${cast.type}-${cast.id}`}>
+              <CastTag cast={cast} />
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </article>
+  );
+}

--- a/src/components/features/live/live-card.tsx
+++ b/src/components/features/live/live-card.tsx
@@ -9,10 +9,19 @@ const CAST_PATH: Record<CastType, string> = {
   unit: "/units",
 };
 
+const BUSINESS_TIMEZONE = "Asia/Tokyo";
+
 function formatTime(value: string | null): string | null {
   if (!value) return null;
-  const match = value.match(/^(\d{2}):(\d{2})/);
-  return match ? `${match[1]}:${match[2]}` : null;
+  if (/^\d{2}:\d{2}/.test(value)) return value.slice(0, 5);
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleTimeString("ja-JP", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: BUSINESS_TIMEZONE,
+  });
 }
 
 function CastTag({ cast }: { cast: CastEntry }) {

--- a/src/components/features/live/live-card.tsx
+++ b/src/components/features/live/live-card.tsx
@@ -1,28 +1,13 @@
 import Link from "next/link";
 import type { CastEntry, CastType } from "@/lib/types";
 import type { LiveWithCasts } from "@/lib/types/live";
-import { formatDate } from "@/lib/utils/date";
+import { formatDate, formatTime } from "@/lib/utils/date";
 
 const CAST_PATH: Record<CastType, string> = {
   artist: "/artists",
   comedy_group: "/combos",
   unit: "/units",
 };
-
-const BUSINESS_TIMEZONE = "Asia/Tokyo";
-
-function formatTime(value: string | null): string | null {
-  if (!value) return null;
-  if (/^\d{2}:\d{2}/.test(value)) return value.slice(0, 5);
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleTimeString("ja-JP", {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-    timeZone: BUSINESS_TIMEZONE,
-  });
-}
 
 function CastTag({ cast }: { cast: CastEntry }) {
   return (

--- a/src/components/features/live/live-list.tsx
+++ b/src/components/features/live/live-list.tsx
@@ -32,7 +32,10 @@ function partition(
   upcoming.sort((a, b) => {
     const dateDiff = (a.event_date ?? "").localeCompare(b.event_date ?? "");
     if (dateDiff !== 0) return dateDiff;
-    return (a.start_time ?? "").localeCompare(b.start_time ?? "");
+    if (a.start_time === b.start_time) return 0;
+    if (!a.start_time) return 1;
+    if (!b.start_time) return -1;
+    return a.start_time.localeCompare(b.start_time);
   });
   return { upcoming, past };
 }

--- a/src/components/features/live/live-list.tsx
+++ b/src/components/features/live/live-list.tsx
@@ -1,0 +1,92 @@
+import type { LiveWithCasts } from "@/lib/types/live";
+import { LiveCard } from "./live-card";
+
+const BUSINESS_TIMEZONE = "Asia/Tokyo";
+
+function todayInBusinessTimezone(): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: BUSINESS_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+  const year = parts.find((p) => p.type === "year")?.value ?? "1970";
+  const month = parts.find((p) => p.type === "month")?.value ?? "01";
+  const day = parts.find((p) => p.type === "day")?.value ?? "01";
+  return `${year}-${month}-${day}`;
+}
+
+function partition(
+  lives: LiveWithCasts[],
+  today: string
+): { upcoming: LiveWithCasts[]; past: LiveWithCasts[] } {
+  const upcoming: LiveWithCasts[] = [];
+  const past: LiveWithCasts[] = [];
+  for (const live of lives) {
+    if (live.event_date && live.event_date >= today) {
+      upcoming.push(live);
+    } else {
+      past.push(live);
+    }
+  }
+  upcoming.sort((a, b) => {
+    const dateDiff = (a.event_date ?? "").localeCompare(b.event_date ?? "");
+    if (dateDiff !== 0) return dateDiff;
+    return (a.start_time ?? "").localeCompare(b.start_time ?? "");
+  });
+  return { upcoming, past };
+}
+
+export function LiveList({ lives }: { lives: LiveWithCasts[] }) {
+  if (lives.length === 0) {
+    return (
+      <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+        まだライブが登録されていません。
+      </p>
+    );
+  }
+
+  const { upcoming, past } = partition(lives, todayInBusinessTimezone());
+
+  return (
+    <div className="space-y-10">
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-brand-cream md:text-xl">
+          Upcoming
+        </h2>
+        {upcoming.length === 0 ? (
+          <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+            予定されているライブはまだありません。
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {upcoming.map((live) => (
+              <li key={live.id}>
+                <LiveCard live={live} variant="upcoming" />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-brand-cream md:text-xl">
+          Past
+        </h2>
+        {past.length === 0 ? (
+          <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+            過去のライブはありません。
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {past.map((live) => (
+              <li key={live.id}>
+                <LiveCard live={live} variant="past" />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/lib/queries/lives.ts
+++ b/src/lib/queries/lives.ts
@@ -2,6 +2,45 @@ import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { Live, LiveWithCasts } from "@/lib/types/live";
 
+type CastRow = {
+  artist_id: string | null;
+  comedy_group_id: string | null;
+  unit_id: string | null;
+  artist: { id: string; name: string } | null;
+  comedy_group: { id: string; name: string } | null;
+  unit: { id: string; name: string } | null;
+};
+
+function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
+  return (rows ?? []).flatMap((c) => {
+    if (c.artist_id && c.artist) {
+      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
+    }
+    if (c.comedy_group_id && c.comedy_group) {
+      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
+    }
+    if (c.unit_id && c.unit) {
+      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
+    }
+    return [];
+  });
+}
+
+function toLiveBase(row: Record<string, unknown>): Live {
+  return {
+    id: row.id as string,
+    title: row.title as string,
+    event_date: (row.event_date as string | null) ?? null,
+    start_time: (row.start_time as string | null) ?? null,
+    venue: (row.venue as string | null) ?? null,
+    description: (row.description as string | null) ?? null,
+    url: (row.url as string | null) ?? null,
+    is_notified: row.is_notified as boolean,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
 export async function listLives(): Promise<Live[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
@@ -15,6 +54,37 @@ export async function listLives(): Promise<Live[]> {
   }
 
   return (data ?? []) as Live[];
+}
+
+export async function listLivesWithCasts(): Promise<LiveWithCasts[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("lives")
+    .select(
+      `*,
+       live_casts(
+         id,
+         artist_id,
+         comedy_group_id,
+         unit_id,
+         artist:artists(id, name),
+         comedy_group:comedy_groups(id, name),
+         unit:units(id, name)
+       )`
+    )
+    .order("event_date", { ascending: false, nullsFirst: false })
+    .order("start_time", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`ライブ一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []).map((row) => {
+    const record = row as Record<string, unknown>;
+    const casts = mapCasts(record.live_casts as CastRow[] | null | undefined);
+    return { ...toLiveBase(record), casts };
+  });
 }
 
 export async function getLive(id: string): Promise<LiveWithCasts | null> {
@@ -42,42 +112,7 @@ export async function getLive(id: string): Promise<LiveWithCasts | null> {
 
   if (!data) return null;
 
-  type CastRow = {
-    artist_id: string | null;
-    comedy_group_id: string | null;
-    unit_id: string | null;
-    artist: { id: string; name: string } | null;
-    comedy_group: { id: string; name: string } | null;
-    unit: { id: string; name: string } | null;
-  };
-
-  const rawCasts = (data as Record<string, unknown>).live_casts as CastRow[];
-
-  const casts: CastEntry[] = (rawCasts ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
-
-  const liveBase: Live = {
-    id: (data as { id: string }).id,
-    title: (data as { title: string }).title,
-    event_date: (data as { event_date: string | null }).event_date,
-    start_time: (data as { start_time: string | null }).start_time,
-    venue: (data as { venue: string | null }).venue,
-    description: (data as { description: string | null }).description,
-    url: (data as { url: string | null }).url,
-    is_notified: (data as { is_notified: boolean }).is_notified,
-    created_at: (data as { created_at: string }).created_at,
-    updated_at: (data as { updated_at: string }).updated_at,
-  };
-
-  return { ...liveBase, casts };
+  const record = data as Record<string, unknown>;
+  const casts = mapCasts(record.live_casts as CastRow[] | null | undefined);
+  return { ...toLiveBase(record), casts };
 }

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -19,7 +19,7 @@ export function formatDate(value: string | null): string | null {
 
 export function formatTime(value: string | null): string | null {
   if (!value) return null;
-  if (/^\d{2}:\d{2}/.test(value)) return value.slice(0, 5);
+  if (/^\d{2}:\d{2}(:\d{2})?$/.test(value)) return value.slice(0, 5);
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return null;
   return date.toLocaleTimeString("ja-JP", {

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,4 +1,4 @@
-const BUSINESS_TIMEZONE = "Asia/Tokyo";
+export const BUSINESS_TIMEZONE = "Asia/Tokyo";
 
 export function formatDate(value: string | null): string | null {
   if (!value) return null;
@@ -13,6 +13,19 @@ export function formatDate(value: string | null): string | null {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: BUSINESS_TIMEZONE,
+  });
+}
+
+export function formatTime(value: string | null): string | null {
+  if (!value) return null;
+  if (/^\d{2}:\d{2}/.test(value)) return value.slice(0, 5);
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleTimeString("ja-JP", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
     timeZone: BUSINESS_TIMEZONE,
   });
 }


### PR DESCRIPTION
## 概要

issue #21「公開側：ライブ一覧」の実装です。`/lives` で **Upcoming**（水色左ボーダー）と **Past** にライブを分割表示します。

Closes #21

## 変更点

### 追加
- `src/app/(public)/lives/page.tsx` — ライブ一覧ページ本体（Server Component）
- `src/components/features/live/live-card.tsx` — 日付・開演時刻・タイトル・会場・出演者タグを表示するカード
- `src/components/features/live/live-list.tsx` — 今日以降を Upcoming、それ以外を Past に分割して表示
- `src/lib/queries/lives.ts::listLivesWithCasts()` — 出演者（artist / comedy_group / unit）込みでライブを取得するクエリ

### リファクタリング
- `getLive` 内のキャストマッピング処理を `mapCasts` / `toLiveBase` ヘルパーに共通化し、`listLivesWithCasts` と重複なしで共有。
- `formatTime` / `BUSINESS_TIMEZONE` を `src/lib/utils/date.ts` に集約し、`(public)/page.tsx` の重複を解消。

## 表示ロジック

- **Upcoming**: `event_date >= 今日（JST）` を近い順（日付 asc → 開演時刻 asc、時刻 null は末尾）で表示。カードは水色の左ボーダー付き。
- **Past**: 日付なし or 過去日のライブを新しい順（日付 desc）で表示。
- 出演者タグは `/artists/[id]` / `/combos/[id]` / `/units/[id]` にリンク（対象ページは後続 issue #22 で実装予定）。
- ライブ詳細ページ `/lives/[id]` へのリンクも含む（詳細ページ自体は別 issue）。
- `start_time` は `timestamptz` で ISO 文字列として返るため、`Date` パース経由で JST 表示。

## 動作確認

- [x] `pnpm run lint` — 追加コードに新規エラーなし（既存の `video-form.tsx` の warn のみ）
- [x] `pnpm exec tsc --noEmit` — 追加・変更分で新規エラーなし（既存の `flatMap` 型推論の警告および `achievements.ts` の型エラーは本 PR のスコープ外）
- [ ] 手動動作確認（Supabase 環境が必要なためローカル未実施）

## 補足

- 既存 `listLives()` は管理画面が使用しているためシグネチャを維持し、公開ページ用に新規関数 `listLivesWithCasts()` を追加しました。
- 今日判定は `Asia/Tokyo` で行います。

https://claude.ai/code/session_01D1AHBptLRohXPMVUKr3HC7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public "Lives" page with localized header and centered layout.
  * Live list with Upcoming and Past sections, empty-state messages, timezone-aware date handling, and stable sorting.
  * Interactive live cards showing formatted date/time, title, optional venue, and clickable cast tags linking to cast pages.
  * Improved date/time formatting across pages for consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->