### PR TITLE
feat: メタタグ動的生成とsitemap/robots対応 (#29)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
+
+# 公開サイトのURL（sitemap / canonical / OGP の絶対URL生成に使用）
+# 例: https://dondecorte-lab.vercel.app
+NEXT_PUBLIC_SITE_URL=

--- a/src/app/(public)/lives/page.tsx
+++ b/src/app/(public)/lives/page.tsx
@@ -1,7 +1,19 @@
+import type { Metadata } from "next";
 import { LiveList } from "@/components/features/live/live-list";
 import { listLivesWithCasts } from "@/lib/queries/lives";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "ライブ",
+  description: "ドンデコルテさん関連のライブ情報一覧。",
+  alternates: { canonical: "/lives" },
+  openGraph: {
+    title: "ライブ",
+    description: "ドンデコルテさん関連のライブ情報一覧。",
+    url: "/lives",
+  },
+};
 
 export default async function LivesPage() {
   const lives = await listLivesWithCasts();

--- a/src/app/(public)/videos/[id]/page.tsx
+++ b/src/app/(public)/videos/[id]/page.tsx
@@ -1,13 +1,19 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { cache } from "react";
 import { VideoGrid } from "@/components/features/video/video-grid";
 import { VideoPlayer } from "@/components/features/video/video-player";
-import { getVideo, listRelatedVideos } from "@/lib/queries/videos";
+import {
+  getVideo as fetchVideo,
+  listRelatedVideos,
+} from "@/lib/queries/videos";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
 
 export const dynamic = "force-dynamic";
+
+const getVideo = cache(fetchVideo);
 
 type Props = {
   params: Promise<{ id: string }>;

--- a/src/app/(public)/videos/[id]/page.tsx
+++ b/src/app/(public)/videos/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { VideoGrid } from "@/components/features/video/video-grid";
@@ -13,6 +14,50 @@ type Props = {
 };
 
 const RELATED_LIMIT = 6;
+const DESCRIPTION_MAX_LENGTH = 160;
+
+function buildDescription(video: {
+  description: string | null;
+  casts: CastEntry[];
+  title: string;
+}): string {
+  const performerNames = video.casts.map((c) => c.name).join("、");
+  const performerText = performerNames ? `出演: ${performerNames}。` : "";
+  const raw = (video.description ?? "").replace(/\s+/g, " ").trim();
+  const fallback = `${performerText}ドンデコルテさん関連動画「${video.title}」の詳細ページ。`;
+  const base = raw ? `${performerText}${raw}` : fallback;
+  if (base.length <= DESCRIPTION_MAX_LENGTH) return base;
+  return `${base.slice(0, DESCRIPTION_MAX_LENGTH - 1)}…`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const video = await getVideo(id);
+  if (!video) return {};
+
+  const description = buildDescription(video);
+  const url = `/videos/${video.id}`;
+  const images = video.thumbnail_url ? [{ url: video.thumbnail_url }] : undefined;
+
+  return {
+    title: video.title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      type: "video.other",
+      title: video.title,
+      description,
+      url,
+      images,
+    },
+    twitter: {
+      card: images ? "summary_large_image" : "summary",
+      title: video.title,
+      description,
+      images: video.thumbnail_url ? [video.thumbnail_url] : undefined,
+    },
+  };
+}
 
 function castHref(cast: CastEntry): string {
   switch (cast.type) {

--- a/src/app/(public)/videos/page.tsx
+++ b/src/app/(public)/videos/page.tsx
@@ -1,7 +1,19 @@
+import type { Metadata } from "next";
 import { VideoGrid } from "@/components/features/video/video-grid";
 import { listVideos } from "@/lib/queries/videos";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "動画",
+  description: "ドンデコルテさん関連のYouTube動画一覧。",
+  alternates: { canonical: "/videos" },
+  openGraph: {
+    title: "動画",
+    description: "ドンデコルテさん関連のYouTube動画一覧。",
+    url: "/videos",
+  },
+};
 
 export default async function VideosPage() {
   const videos = await listVideos();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Noto_Sans_JP, Inter } from "next/font/google";
+import { getSiteUrl } from "@/lib/utils/site-url";
 import "./globals.css";
 
 const notoSansJP = Noto_Sans_JP({
@@ -15,9 +16,34 @@ const inter = Inter({
   display: "swap",
 });
 
+const SITE_NAME = "DonDecorte Lab";
+const SITE_DESCRIPTION =
+  "お笑いコンビ・ドンデコルテさんの非公式ファンサイト。動画・ライブ・ラジオ・記事・TV出演を一元管理するデータベース。";
+
 export const metadata: Metadata = {
-  title: "DonDecorte Lab",
-  description: "ドンデコルテさん非公式ファンサイト兼データベース",
+  metadataBase: new URL(getSiteUrl()),
+  title: {
+    default: SITE_NAME,
+    template: `%s | ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
+  applicationName: SITE_NAME,
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    locale: "ja_JP",
+  },
+  twitter: {
+    card: "summary",
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,7 +8,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
-        disallow: ["/admin", "/auth"],
+        disallow: ["/admin", "/admin/", "/auth", "/auth/"],
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,7 +8,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
-        disallow: ["/admin/", "/auth/"],
+        disallow: ["/admin", "/auth"],
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+import { getSiteUrl } from "@/lib/utils/site-url";
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = getSiteUrl();
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/admin/", "/auth/"],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,26 +4,27 @@ import { getSiteUrl } from "@/lib/utils/site-url";
 
 export const dynamic = "force-dynamic";
 
+const STATIC_ENTRY_LAST_MODIFIED = new Date();
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = getSiteUrl();
-  const now = new Date();
 
   const staticEntries: MetadataRoute.Sitemap = [
     {
       url: `${baseUrl}/`,
-      lastModified: now,
+      lastModified: STATIC_ENTRY_LAST_MODIFIED,
       changeFrequency: "daily",
       priority: 1,
     },
     {
       url: `${baseUrl}/videos`,
-      lastModified: now,
+      lastModified: STATIC_ENTRY_LAST_MODIFIED,
       changeFrequency: "daily",
       priority: 0.8,
     },
     {
       url: `${baseUrl}/lives`,
-      lastModified: now,
+      lastModified: STATIC_ENTRY_LAST_MODIFIED,
       changeFrequency: "daily",
       priority: 0.8,
     },
@@ -34,7 +35,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const videos = await listVideos();
     videoEntries = videos.map((video) => ({
       url: `${baseUrl}/videos/${video.id}`,
-      lastModified: video.updated_at ? new Date(video.updated_at) : now,
+      lastModified: video.updated_at
+        ? new Date(video.updated_at)
+        : STATIC_ENTRY_LAST_MODIFIED,
       changeFrequency: "weekly",
       priority: 0.6,
     }));

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,46 @@
+import type { MetadataRoute } from "next";
+import { listVideos } from "@/lib/queries/videos";
+import { getSiteUrl } from "@/lib/utils/site-url";
+
+export const dynamic = "force-dynamic";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = getSiteUrl();
+  const now = new Date();
+
+  const staticEntries: MetadataRoute.Sitemap = [
+    {
+      url: `${baseUrl}/`,
+      lastModified: now,
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/videos`,
+      lastModified: now,
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/lives`,
+      lastModified: now,
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
+  ];
+
+  let videoEntries: MetadataRoute.Sitemap = [];
+  try {
+    const videos = await listVideos();
+    videoEntries = videos.map((video) => ({
+      url: `${baseUrl}/videos/${video.id}`,
+      lastModified: video.updated_at ? new Date(video.updated_at) : now,
+      changeFrequency: "weekly",
+      priority: 0.6,
+    }));
+  } catch {
+    videoEntries = [];
+  }
+
+  return [...staticEntries, ...videoEntries];
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -38,7 +38,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 0.6,
     }));
-  } catch {
+  } catch (error) {
+    console.warn("sitemap: failed to load video entries", error);
     videoEntries = [];
   }
 

--- a/src/lib/utils/site-url.ts
+++ b/src/lib/utils/site-url.ts
@@ -1,0 +1,11 @@
+const DEFAULT_SITE_URL = "http://localhost:3000";
+
+export function getSiteUrl(): string {
+  const explicit = process.env.NEXT_PUBLIC_SITE_URL;
+  if (explicit) return explicit.replace(/\/$/, "");
+
+  const vercel = process.env.VERCEL_URL;
+  if (vercel) return `https://${vercel}`;
+
+  return DEFAULT_SITE_URL;
+}

--- a/src/lib/utils/site-url.ts
+++ b/src/lib/utils/site-url.ts
@@ -1,11 +1,28 @@
 const DEFAULT_SITE_URL = "http://localhost:3000";
 
+function normalize(raw: string): string | null {
+  const trimmed = raw.trim().replace(/\/+$/, "");
+  if (!trimmed) return null;
+  const candidate = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    return new URL(candidate).origin;
+  } catch {
+    return null;
+  }
+}
+
 export function getSiteUrl(): string {
   const explicit = process.env.NEXT_PUBLIC_SITE_URL;
-  if (explicit) return explicit.replace(/\/$/, "");
+  if (explicit) {
+    const normalized = normalize(explicit);
+    if (normalized) return normalized;
+  }
 
   const vercel = process.env.VERCEL_URL;
-  if (vercel) return `https://${vercel}`;
+  if (vercel) {
+    const normalized = normalize(vercel);
+    if (normalized) return normalized;
+  }
 
   return DEFAULT_SITE_URL;
 }


### PR DESCRIPTION
## 概要

issue #29 「2-3 SEO対応」のうち、現状実装済みの公開ページに対するメタタグ動的生成と sitemap.xml / robots.txt の自動生成を対応した。OGP画像は別Issueでフォローアップ予定。

## 変更内容

### メタタグ
- `src/app/layout.tsx`
  - `metadataBase` を追加（`getSiteUrl()` で `NEXT_PUBLIC_SITE_URL` → `VERCEL_URL` → `localhost:3000` の順に解決）
  - `title.template` を `%s | DonDecorte Lab` に設定（子ページが `title` を上書きしてもサイト名が付与される）
  - サイト全体の OpenGraph / Twitter Card / robots を初期値として設定
- `src/app/(public)/videos/page.tsx`, `src/app/(public)/lives/page.tsx`
  - 静的 `metadata` を追加（title / description / canonical / OGP）
- `src/app/(public)/videos/[id]/page.tsx`
  - `generateMetadata` を実装。動画タイトル・出演者・説明を組み合わせて 160 文字以内に整形し、サムネを OGP 画像として出力

### sitemap / robots
- `src/app/sitemap.ts` — トップ・`/videos`・`/lives` と動画詳細を列挙（DB取得失敗時は静的ルートのみ返す）
- `src/app/robots.ts` — `/admin/` `/auth/` をクロール除外、`sitemap.xml` を案内

### その他
- `src/lib/utils/site-url.ts` — サイトURL解決ユーティリティ
- `.env.example` に `NEXT_PUBLIC_SITE_URL` を追加

## スコープ外（フォローアップ）

- **OGP画像の自動生成**: ロゴや背景デザインの確定後、`next/og` の `ImageResponse` で実装する想定。現状は動画詳細のみサムネを OGP 画像として再利用。
- **未実装ページ（`/radios` `/articles` `/tv` `/topics` `/combos` `/artists` `/units`）のメタデータと sitemap 登録**: 各公開ページ実装時に同パターンで追加する。

## 動作確認

- `pnpm exec tsc --noEmit` — 追加・変更ファイルは型エラーなし（既存の `lib/queries` 配下の `flatMap` 型エラーは本PR範囲外）
- `pnpm exec eslint <変更ファイル>` — エラーなし

Refs #29

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh3o3ubieu3Ea6kkV4n5CT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sitemap including per-video entries
  * robots.txt route with crawl rules and sitemap reference
  * Centralized site metadata (Open Graph, Twitter, canonical) plus page-specific metadata for videos, lives, and video detail pages with dynamic descriptions and thumbnails

* **Chores**
  * Added public environment variable to configure the site base URL
  * Added site URL resolution utility used by metadata, sitemap, and robots
<!-- end of auto-generated comment: release notes by coderabbit.ai -->