### PR TITLE
feat: 公開側のラジオ・記事・TV・トピック一覧と詳細を追加

### DIFF
--- a/src/app/(public)/articles/[id]/page.tsx
+++ b/src/app/(public)/articles/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
-import { CastTag } from "@/components/shared/cast-tag";
+import { CastTagList } from "@/components/shared/cast-tag";
 import { getArticle as fetchArticle } from "@/lib/queries/articles";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
@@ -82,10 +82,8 @@ export default async function ArticleDetailPage({ params }: Props) {
       </div>
 
       {article.casts.length > 0 ? (
-        <div className="mt-4 flex flex-wrap gap-2">
-          {article.casts.map((cast) => (
-            <CastTag key={`${cast.type}-${cast.id}`} cast={cast} />
-          ))}
+        <div className="mt-4">
+          <CastTagList casts={article.casts} />
         </div>
       ) : null}
 

--- a/src/app/(public)/articles/[id]/page.tsx
+++ b/src/app/(public)/articles/[id]/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { CastTag } from "@/components/shared/cast-tag";
+import { getArticle as fetchArticle } from "@/lib/queries/articles";
+import type { CastEntry } from "@/lib/types";
+import { formatDate } from "@/lib/utils/date";
+
+export const dynamic = "force-dynamic";
+
+const getArticle = cache(fetchArticle);
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+const DESCRIPTION_MAX_LENGTH = 160;
+
+function buildDescription(article: {
+  casts: CastEntry[];
+  title: string;
+  source: string | null;
+}): string {
+  const performerNames = article.casts.map((c) => c.name).join("、");
+  const performerText = performerNames ? `出演: ${performerNames}。` : "";
+  const sourceText = article.source ? `出典: ${article.source}。` : "";
+  const fallback = `${performerText}${sourceText}ドンデコルテさん関連記事「${article.title}」のリンク。`;
+  if (fallback.length <= DESCRIPTION_MAX_LENGTH) return fallback;
+  return `${fallback.slice(0, DESCRIPTION_MAX_LENGTH - 1)}…`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const article = await getArticle(id);
+  if (!article) return {};
+
+  const description = buildDescription(article);
+  const url = `/articles/${article.id}`;
+
+  return {
+    title: article.title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: article.title,
+      description,
+      url,
+    },
+  };
+}
+
+export default async function ArticleDetailPage({ params }: Props) {
+  const { id } = await params;
+  const article = await getArticle(id);
+  if (!article) notFound();
+
+  const published = formatDate(article.published_at);
+
+  return (
+    <div className="mx-auto w-full max-w-4xl flex-1 px-4 py-6 md:py-10">
+      <div className="mb-4">
+        <Link
+          href="/articles"
+          className="text-xs text-brand-muted transition hover:text-brand-sky-light"
+        >
+          ← 記事一覧
+        </Link>
+      </div>
+
+      <h1 className="text-xl font-bold text-brand-cream md:text-2xl">
+        {article.title}
+      </h1>
+
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-brand-muted md:text-sm">
+        {published ? <span>{published}</span> : null}
+        {article.source ? (
+          <span className="inline-flex items-center rounded border border-brand-border-dark bg-brand-card-dark px-1.5 py-0.5">
+            出典: {article.source}
+          </span>
+        ) : null}
+      </div>
+
+      {article.casts.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {article.casts.map((cast) => (
+            <CastTag key={`${cast.type}-${cast.id}`} cast={cast} />
+          ))}
+        </div>
+      ) : null}
+
+      {article.url ? (
+        <div className="mt-6">
+          <a
+            href={article.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center rounded-md border border-brand-border-dark bg-brand-card-dark px-4 py-2 text-sm font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"
+          >
+            記事を読む ↗
+          </a>
+        </div>
+      ) : null}
+
+      <p className="mt-6 text-xs text-brand-muted">
+        ※ 著作権保護のため本文は転載せず、出典元へのリンクのみを掲載しています。
+      </p>
+    </div>
+  );
+}

--- a/src/app/(public)/articles/page.tsx
+++ b/src/app/(public)/articles/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import { ArticleCard } from "@/components/features/article/article-card";
+import { listArticlesWithCasts } from "@/lib/queries/articles";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "記事",
+  description:
+    "ドンデコルテさん関連の記事・インタビュー一覧。本文は転載していません。各記事の出典元へのリンクのみ掲載しています。",
+  alternates: { canonical: "/articles" },
+  openGraph: {
+    title: "記事",
+    description: "ドンデコルテさん関連の記事・インタビュー一覧。",
+    url: "/articles",
+  },
+};
+
+export default async function ArticlesPage() {
+  const articles = await listArticlesWithCasts();
+
+  return (
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          記事
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          ドンデコルテさん関連の記事・インタビュー。本文は転載せず、出典元へのリンクのみ掲載しています。
+        </p>
+      </header>
+
+      {articles.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          まだ記事が登録されていません。
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {articles.map((article) => (
+            <li key={article.id}>
+              <ArticleCard article={article} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(public)/radios/[id]/page.tsx
+++ b/src/app/(public)/radios/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
-import { CastTag } from "@/components/shared/cast-tag";
+import { CastTagList } from "@/components/shared/cast-tag";
 import { getRadio as fetchRadio } from "@/lib/queries/radios";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
@@ -83,10 +83,8 @@ export default async function RadioDetailPage({ params }: Props) {
       </div>
 
       {radio.casts.length > 0 ? (
-        <div className="mt-4 flex flex-wrap gap-2">
-          {radio.casts.map((cast) => (
-            <CastTag key={`${cast.type}-${cast.id}`} cast={cast} />
-          ))}
+        <div className="mt-4">
+          <CastTagList casts={radio.casts} />
         </div>
       ) : null}
 

--- a/src/app/(public)/radios/[id]/page.tsx
+++ b/src/app/(public)/radios/[id]/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { CastTag } from "@/components/shared/cast-tag";
+import { getRadio as fetchRadio } from "@/lib/queries/radios";
+import type { CastEntry } from "@/lib/types";
+import { formatDate } from "@/lib/utils/date";
+
+export const dynamic = "force-dynamic";
+
+const getRadio = cache(fetchRadio);
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+const DESCRIPTION_MAX_LENGTH = 160;
+
+function buildDescription(radio: {
+  description: string | null;
+  casts: CastEntry[];
+  title: string;
+}): string {
+  const performerNames = radio.casts.map((c) => c.name).join("、");
+  const performerText = performerNames ? `出演: ${performerNames}。` : "";
+  const raw = (radio.description ?? "").replace(/\s+/g, " ").trim();
+  const fallback = `${performerText}ドンデコルテさん関連ラジオ「${radio.title}」の詳細ページ。`;
+  const base = raw ? `${performerText}${raw}` : fallback;
+  if (base.length <= DESCRIPTION_MAX_LENGTH) return base;
+  return `${base.slice(0, DESCRIPTION_MAX_LENGTH - 1)}…`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const radio = await getRadio(id);
+  if (!radio) return {};
+
+  const description = buildDescription(radio);
+  const url = `/radios/${radio.id}`;
+
+  return {
+    title: radio.title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: radio.title,
+      description,
+      url,
+    },
+  };
+}
+
+export default async function RadioDetailPage({ params }: Props) {
+  const { id } = await params;
+  const radio = await getRadio(id);
+  if (!radio) notFound();
+
+  const published = formatDate(radio.published_at);
+
+  return (
+    <div className="mx-auto w-full max-w-4xl flex-1 px-4 py-6 md:py-10">
+      <div className="mb-4">
+        <Link
+          href="/radios"
+          className="text-xs text-brand-muted transition hover:text-brand-sky-light"
+        >
+          ← ラジオ一覧
+        </Link>
+      </div>
+
+      <h1 className="text-xl font-bold text-brand-cream md:text-2xl">
+        {radio.title}
+      </h1>
+
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-brand-muted md:text-sm">
+        {published ? <span>{published}</span> : null}
+        {radio.platform ? (
+          <span className="inline-flex items-center rounded border border-brand-border-dark bg-brand-card-dark px-1.5 py-0.5">
+            {radio.platform}
+          </span>
+        ) : null}
+      </div>
+
+      {radio.casts.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {radio.casts.map((cast) => (
+            <CastTag key={`${cast.type}-${cast.id}`} cast={cast} />
+          ))}
+        </div>
+      ) : null}
+
+      {radio.url ? (
+        <div className="mt-6">
+          <a
+            href={radio.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center rounded-md border border-brand-border-dark bg-brand-card-dark px-4 py-2 text-sm font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"
+          >
+            ラジオを聴く ↗
+          </a>
+        </div>
+      ) : null}
+
+      {radio.description ? (
+        <section className="mt-6 rounded-lg border border-brand-border-dark bg-brand-card-dark p-4">
+          <p className="whitespace-pre-wrap text-sm leading-relaxed text-brand-cream">
+            {radio.description}
+          </p>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/(public)/radios/page.tsx
+++ b/src/app/(public)/radios/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { RadioCard } from "@/components/features/radio/radio-card";
+import { listRadiosWithCasts } from "@/lib/queries/radios";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "ラジオ",
+  description: "ドンデコルテさんのラジオ出演情報一覧。",
+  alternates: { canonical: "/radios" },
+  openGraph: {
+    title: "ラジオ",
+    description: "ドンデコルテさんのラジオ出演情報一覧。",
+    url: "/radios",
+  },
+};
+
+export default async function RadiosPage() {
+  const radios = await listRadiosWithCasts();
+
+  return (
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          ラジオ
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          ドンデコルテさんのラジオ出演情報一覧。
+        </p>
+      </header>
+
+      {radios.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          まだラジオが登録されていません。
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {radios.map((radio) => (
+            <li key={radio.id}>
+              <RadioCard radio={radio} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(public)/topics/[id]/page.tsx
+++ b/src/app/(public)/topics/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
-import { CastTag } from "@/components/shared/cast-tag";
+import { CastTagList } from "@/components/shared/cast-tag";
 import { getTopic as fetchTopic } from "@/lib/queries/topics";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
@@ -85,10 +85,8 @@ export default async function TopicDetailPage({ params }: Props) {
       </div>
 
       {topic.casts.length > 0 ? (
-        <div className="mt-4 flex flex-wrap gap-2">
-          {topic.casts.map((cast) => (
-            <CastTag key={`${cast.type}-${cast.id}`} cast={cast} />
-          ))}
+        <div className="mt-4">
+          <CastTagList casts={topic.casts} />
         </div>
       ) : null}
 

--- a/src/app/(public)/topics/[id]/page.tsx
+++ b/src/app/(public)/topics/[id]/page.tsx
@@ -1,0 +1,117 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { CastTag } from "@/components/shared/cast-tag";
+import { getTopic as fetchTopic } from "@/lib/queries/topics";
+import type { CastEntry } from "@/lib/types";
+import { formatDate } from "@/lib/utils/date";
+
+export const dynamic = "force-dynamic";
+
+const getTopic = cache(fetchTopic);
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+const DESCRIPTION_MAX_LENGTH = 160;
+
+function buildDescription(topic: {
+  content: string | null;
+  casts: CastEntry[];
+  title: string;
+  source: string | null;
+}): string {
+  const performerNames = topic.casts.map((c) => c.name).join("、");
+  const performerText = performerNames ? `出演: ${performerNames}。` : "";
+  const sourceText = topic.source ? `情報源: ${topic.source}。` : "";
+  const raw = (topic.content ?? "").replace(/\s+/g, " ").trim();
+  const fallback = `${performerText}${sourceText}ドンデコルテさん関連トピック「${topic.title}」の詳細ページ。`;
+  const base = raw ? `${performerText}${sourceText}${raw}` : fallback;
+  if (base.length <= DESCRIPTION_MAX_LENGTH) return base;
+  return `${base.slice(0, DESCRIPTION_MAX_LENGTH - 1)}…`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const topic = await getTopic(id);
+  if (!topic) return {};
+
+  const description = buildDescription(topic);
+  const url = `/topics/${topic.id}`;
+
+  return {
+    title: topic.title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: topic.title,
+      description,
+      url,
+    },
+  };
+}
+
+export default async function TopicDetailPage({ params }: Props) {
+  const { id } = await params;
+  const topic = await getTopic(id);
+  if (!topic) notFound();
+
+  const topicDate = formatDate(topic.topic_date);
+
+  return (
+    <div className="mx-auto w-full max-w-4xl flex-1 px-4 py-6 md:py-10">
+      <div className="mb-4">
+        <Link
+          href="/topics"
+          className="text-xs text-brand-muted transition hover:text-brand-sky-light"
+        >
+          ← トピック一覧
+        </Link>
+      </div>
+
+      <h1 className="text-xl font-bold text-brand-cream md:text-2xl">
+        {topic.title}
+      </h1>
+
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-brand-muted md:text-sm">
+        {topicDate ? <span>{topicDate}</span> : null}
+        {topic.source ? (
+          <span className="inline-flex items-center rounded border border-brand-border-dark bg-brand-card-dark px-1.5 py-0.5">
+            情報源: {topic.source}
+          </span>
+        ) : null}
+      </div>
+
+      {topic.casts.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {topic.casts.map((cast) => (
+            <CastTag key={`${cast.type}-${cast.id}`} cast={cast} />
+          ))}
+        </div>
+      ) : null}
+
+      {topic.url ? (
+        <div className="mt-6">
+          <a
+            href={topic.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center rounded-md border border-brand-border-dark bg-brand-card-dark px-4 py-2 text-sm font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"
+          >
+            関連リンクを見る ↗
+          </a>
+        </div>
+      ) : null}
+
+      {topic.content ? (
+        <section className="mt-6 rounded-lg border border-brand-border-dark bg-brand-card-dark p-4">
+          <p className="whitespace-pre-wrap text-sm leading-relaxed text-brand-cream">
+            {topic.content}
+          </p>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/(public)/topics/page.tsx
+++ b/src/app/(public)/topics/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import { TopicCard } from "@/components/features/topic/topic-card";
+import { listTopicsWithCasts } from "@/lib/queries/topics";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "トピック",
+  description:
+    "ドンデコルテさん関連のトピック一覧。写真撮影会、X投稿、CM情報などの雑多な情報をまとめています。",
+  alternates: { canonical: "/topics" },
+  openGraph: {
+    title: "トピック",
+    description: "ドンデコルテさん関連のトピック一覧。",
+    url: "/topics",
+  },
+};
+
+export default async function TopicsPage() {
+  const topics = await listTopicsWithCasts();
+
+  return (
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          トピック
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          写真撮影会・X投稿・CM情報など、ドンデコルテさんに関する雑多な情報。
+        </p>
+      </header>
+
+      {topics.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          まだトピックが登録されていません。
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {topics.map((topic) => (
+            <li key={topic.id}>
+              <TopicCard topic={topic} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(public)/tv/[id]/page.tsx
+++ b/src/app/(public)/tv/[id]/page.tsx
@@ -1,0 +1,125 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { CastTag } from "@/components/shared/cast-tag";
+import { getTvShow as fetchTvShow } from "@/lib/queries/tv-shows";
+import type { CastEntry } from "@/lib/types";
+import { formatDate, formatTime } from "@/lib/utils/date";
+
+export const dynamic = "force-dynamic";
+
+const getTvShow = cache(fetchTvShow);
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+const DESCRIPTION_MAX_LENGTH = 160;
+
+function buildDescription(tvShow: {
+  description: string | null;
+  casts: CastEntry[];
+  title: string;
+  network: string | null;
+}): string {
+  const performerNames = tvShow.casts.map((c) => c.name).join("、");
+  const performerText = performerNames ? `出演: ${performerNames}。` : "";
+  const networkText = tvShow.network ? `${tvShow.network}。` : "";
+  const raw = (tvShow.description ?? "").replace(/\s+/g, " ").trim();
+  const fallback = `${performerText}${networkText}ドンデコルテさん関連TV番組「${tvShow.title}」の詳細ページ。`;
+  const base = raw ? `${performerText}${networkText}${raw}` : fallback;
+  if (base.length <= DESCRIPTION_MAX_LENGTH) return base;
+  return `${base.slice(0, DESCRIPTION_MAX_LENGTH - 1)}…`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const tvShow = await getTvShow(id);
+  if (!tvShow) return {};
+
+  const description = buildDescription(tvShow);
+  const url = `/tv/${tvShow.id}`;
+
+  return {
+    title: tvShow.title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: tvShow.title,
+      description,
+      url,
+    },
+  };
+}
+
+export default async function TvDetailPage({ params }: Props) {
+  const { id } = await params;
+  const tvShow = await getTvShow(id);
+  if (!tvShow) notFound();
+
+  const airDate = formatDate(tvShow.air_date);
+  const airTime = formatTime(tvShow.air_time);
+
+  return (
+    <div className="mx-auto w-full max-w-4xl flex-1 px-4 py-6 md:py-10">
+      <div className="mb-4">
+        <Link
+          href="/tv"
+          className="text-xs text-brand-muted transition hover:text-brand-sky-light"
+        >
+          ← TV一覧
+        </Link>
+      </div>
+
+      <h1 className="text-xl font-bold text-brand-cream md:text-2xl">
+        {tvShow.title}
+      </h1>
+
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-brand-muted md:text-sm">
+        {airDate ? (
+          <span>
+            {airDate}
+            {airTime ? ` ${airTime}` : ""}
+          </span>
+        ) : (
+          <span>放送日未定</span>
+        )}
+        {tvShow.network ? (
+          <span className="inline-flex items-center rounded border border-brand-sky/40 bg-brand-card-dark px-1.5 py-0.5 text-brand-sky-light">
+            {tvShow.network}
+          </span>
+        ) : null}
+      </div>
+
+      {tvShow.casts.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {tvShow.casts.map((cast) => (
+            <CastTag key={`${cast.type}-${cast.id}`} cast={cast} />
+          ))}
+        </div>
+      ) : null}
+
+      {tvShow.url ? (
+        <div className="mt-6">
+          <a
+            href={tvShow.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center rounded-md border border-brand-border-dark bg-brand-card-dark px-4 py-2 text-sm font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"
+          >
+            番組情報を見る ↗
+          </a>
+        </div>
+      ) : null}
+
+      {tvShow.description ? (
+        <section className="mt-6 rounded-lg border border-brand-border-dark bg-brand-card-dark p-4">
+          <p className="whitespace-pre-wrap text-sm leading-relaxed text-brand-cream">
+            {tvShow.description}
+          </p>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/(public)/tv/[id]/page.tsx
+++ b/src/app/(public)/tv/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
-import { CastTag } from "@/components/shared/cast-tag";
+import { CastTagList } from "@/components/shared/cast-tag";
 import { getTvShow as fetchTvShow } from "@/lib/queries/tv-shows";
 import type { CastEntry } from "@/lib/types";
 import { formatDate, formatTime } from "@/lib/utils/date";
@@ -93,10 +93,8 @@ export default async function TvDetailPage({ params }: Props) {
       </div>
 
       {tvShow.casts.length > 0 ? (
-        <div className="mt-4 flex flex-wrap gap-2">
-          {tvShow.casts.map((cast) => (
-            <CastTag key={`${cast.type}-${cast.id}`} cast={cast} />
-          ))}
+        <div className="mt-4">
+          <CastTagList casts={tvShow.casts} />
         </div>
       ) : null}
 

--- a/src/app/(public)/tv/page.tsx
+++ b/src/app/(public)/tv/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import { TvShowCard } from "@/components/features/tv-show/tv-show-card";
+import { listTvShowsWithCasts } from "@/lib/queries/tv-shows";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "TV",
+  description: "ドンデコルテさんのテレビ出演情報一覧。",
+  alternates: { canonical: "/tv" },
+  openGraph: {
+    title: "TV",
+    description: "ドンデコルテさんのテレビ出演情報一覧。",
+    url: "/tv",
+  },
+};
+
+export default async function TvPage() {
+  const tvShows = await listTvShowsWithCasts();
+
+  return (
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">TV</h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          ドンデコルテさんのテレビ出演情報一覧。
+        </p>
+      </header>
+
+      {tvShows.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          まだTV番組が登録されていません。
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {tvShows.map((tvShow) => (
+            <li key={tvShow.id}>
+              <TvShowCard tvShow={tvShow} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/article/article-card.tsx
+++ b/src/components/features/article/article-card.tsx
@@ -25,6 +25,18 @@ export function ArticleCard({ article }: { article: ArticleWithCasts }) {
           {article.title}
         </p>
       </Link>
+      {article.url ? (
+        <div className="mt-2">
+          <a
+            href={article.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center text-xs font-medium text-brand-sky-light transition hover:text-brand-sky"
+          >
+            出典元を開く ↗
+          </a>
+        </div>
+      ) : null}
       {article.casts.length > 0 ? (
         <div className="mt-2">
           <CastTagList casts={article.casts} />

--- a/src/components/features/article/article-card.tsx
+++ b/src/components/features/article/article-card.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { CastTagList } from "@/components/shared/cast-tag";
+import type { ArticleWithCasts } from "@/lib/types/article";
+import { formatDate } from "@/lib/utils/date";
+
+export function ArticleCard({ article }: { article: ArticleWithCasts }) {
+  const published = formatDate(article.published_at);
+
+  return (
+    <article className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-3 transition hover:border-brand-sky-light">
+      <Link href={`/articles/${article.id}`} className="block group">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          {published ? (
+            <span className="text-sm font-medium text-brand-gold">
+              {published}
+            </span>
+          ) : null}
+          {article.source ? (
+            <span className="inline-flex items-center rounded border border-brand-border-dark bg-brand-bg-dark px-1.5 py-0.5 text-[11px] text-brand-muted">
+              {article.source}
+            </span>
+          ) : null}
+        </div>
+        <p className="mt-1 text-sm font-semibold text-brand-cream group-hover:text-brand-sky-light">
+          {article.title}
+        </p>
+      </Link>
+      {article.casts.length > 0 ? (
+        <div className="mt-2">
+          <CastTagList casts={article.casts} />
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/src/components/features/radio/radio-card.tsx
+++ b/src/components/features/radio/radio-card.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { CastTagList } from "@/components/shared/cast-tag";
+import type { RadioWithCasts } from "@/lib/types/radio";
+import { formatDate } from "@/lib/utils/date";
+
+export function RadioCard({ radio }: { radio: RadioWithCasts }) {
+  const published = formatDate(radio.published_at);
+
+  return (
+    <article className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-3 transition hover:border-brand-sky-light">
+      <Link href={`/radios/${radio.id}`} className="block group">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          {published ? (
+            <span className="text-sm font-medium text-brand-gold">
+              {published}
+            </span>
+          ) : null}
+          {radio.platform ? (
+            <span className="inline-flex items-center rounded border border-brand-border-dark bg-brand-bg-dark px-1.5 py-0.5 text-[11px] text-brand-muted">
+              {radio.platform}
+            </span>
+          ) : null}
+        </div>
+        <p className="mt-1 text-sm font-semibold text-brand-cream group-hover:text-brand-sky-light">
+          {radio.title}
+        </p>
+      </Link>
+      {radio.casts.length > 0 ? (
+        <div className="mt-2">
+          <CastTagList casts={radio.casts} />
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/src/components/features/radio/radio-card.tsx
+++ b/src/components/features/radio/radio-card.tsx
@@ -25,6 +25,18 @@ export function RadioCard({ radio }: { radio: RadioWithCasts }) {
           {radio.title}
         </p>
       </Link>
+      {radio.url ? (
+        <div className="mt-2">
+          <a
+            href={radio.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center text-xs font-medium text-brand-sky-light transition hover:text-brand-sky"
+          >
+            ラジオを聴く ↗
+          </a>
+        </div>
+      ) : null}
       {radio.casts.length > 0 ? (
         <div className="mt-2">
           <CastTagList casts={radio.casts} />

--- a/src/components/features/topic/topic-card.tsx
+++ b/src/components/features/topic/topic-card.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { CastTagList } from "@/components/shared/cast-tag";
+import type { TopicWithCasts } from "@/lib/types/topic";
+import { formatDate } from "@/lib/utils/date";
+
+export function TopicCard({ topic }: { topic: TopicWithCasts }) {
+  const topicDate = formatDate(topic.topic_date);
+
+  return (
+    <article className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-3 transition hover:border-brand-sky-light">
+      <Link href={`/topics/${topic.id}`} className="block group">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          {topicDate ? (
+            <span className="text-sm font-medium text-brand-gold">
+              {topicDate}
+            </span>
+          ) : null}
+          {topic.source ? (
+            <span className="inline-flex items-center rounded border border-brand-border-dark bg-brand-bg-dark px-1.5 py-0.5 text-[11px] text-brand-muted">
+              {topic.source}
+            </span>
+          ) : null}
+        </div>
+        <p className="mt-1 text-sm font-semibold text-brand-cream group-hover:text-brand-sky-light">
+          {topic.title}
+        </p>
+      </Link>
+      {topic.casts.length > 0 ? (
+        <div className="mt-2">
+          <CastTagList casts={topic.casts} />
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/src/components/features/topic/topic-card.tsx
+++ b/src/components/features/topic/topic-card.tsx
@@ -25,6 +25,18 @@ export function TopicCard({ topic }: { topic: TopicWithCasts }) {
           {topic.title}
         </p>
       </Link>
+      {topic.url ? (
+        <div className="mt-2">
+          <a
+            href={topic.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center text-xs font-medium text-brand-sky-light transition hover:text-brand-sky"
+          >
+            関連URL ↗
+          </a>
+        </div>
+      ) : null}
       {topic.casts.length > 0 ? (
         <div className="mt-2">
           <CastTagList casts={topic.casts} />

--- a/src/components/features/tv-show/tv-show-card.tsx
+++ b/src/components/features/tv-show/tv-show-card.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { CastTagList } from "@/components/shared/cast-tag";
+import type { TvShowWithCasts } from "@/lib/types/tv-show";
+import { formatDate, formatTime } from "@/lib/utils/date";
+
+export function TvShowCard({ tvShow }: { tvShow: TvShowWithCasts }) {
+  const airDate = formatDate(tvShow.air_date);
+  const airTime = formatTime(tvShow.air_time);
+  const dateLine = airDate
+    ? `${airDate}${airTime ? ` ${airTime}` : ""}`
+    : "放送日未定";
+
+  return (
+    <article className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-3 transition hover:border-brand-sky-light">
+      <Link href={`/tv/${tvShow.id}`} className="block group">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span className="text-sm font-medium text-brand-gold">
+            {dateLine}
+          </span>
+          {tvShow.network ? (
+            <span className="inline-flex items-center rounded border border-brand-sky/40 bg-brand-bg-dark px-1.5 py-0.5 text-[11px] text-brand-sky-light">
+              {tvShow.network}
+            </span>
+          ) : null}
+        </div>
+        <p className="mt-1 text-sm font-semibold text-brand-cream group-hover:text-brand-sky-light">
+          {tvShow.title}
+        </p>
+      </Link>
+      {tvShow.casts.length > 0 ? (
+        <div className="mt-2">
+          <CastTagList casts={tvShow.casts} />
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/server";
 
 const NAV_ITEMS = [
   { href: "/videos", label: "動画" },
@@ -12,12 +11,7 @@ const NAV_ITEMS = [
   { href: "/artists", label: "芸人" },
 ];
 
-export async function PublicHeader() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
+export function PublicHeader() {
   return (
     <header className="sticky top-0 z-30 border-b border-brand-border-dark bg-brand-bg-dark/95 backdrop-blur">
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between gap-4 px-4">
@@ -41,14 +35,6 @@ export async function PublicHeader() {
             ))}
           </ul>
         </nav>
-        {user ? (
-          <Link
-            href="/admin"
-            className="rounded-md border border-brand-border-dark bg-brand-card-dark px-3 py-1.5 text-xs font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"
-          >
-            管理画面
-          </Link>
-        ) : null}
       </div>
     </header>
   );

--- a/src/components/shared/cast-tag.tsx
+++ b/src/components/shared/cast-tag.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import type { CastEntry, CastType } from "@/lib/types";
+
+const CAST_PATH: Record<CastType, string> = {
+  artist: "/artists",
+  comedy_group: "/combos",
+  unit: "/units",
+};
+
+export function CastTag({ cast }: { cast: CastEntry }) {
+  return (
+    <Link
+      href={`${CAST_PATH[cast.type]}/${cast.id}`}
+      className="inline-flex items-center rounded-full border border-brand-border-dark bg-brand-bg-dark px-2 py-0.5 text-xs text-brand-gold transition hover:border-brand-sky-light hover:text-brand-sky-light"
+    >
+      {cast.name}
+    </Link>
+  );
+}
+
+export function CastTagList({ casts }: { casts: CastEntry[] }) {
+  if (casts.length === 0) return null;
+  return (
+    <ul className="flex flex-wrap gap-1.5">
+      {casts.map((cast) => (
+        <li key={`${cast.type}-${cast.id}`}>
+          <CastTag cast={cast} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/queries/_casts.ts
+++ b/src/lib/queries/_casts.ts
@@ -1,0 +1,25 @@
+import type { CastEntry } from "@/lib/types";
+
+export type CastRow = {
+  artist_id: string | null;
+  comedy_group_id: string | null;
+  unit_id: string | null;
+  artist: { id: string; name: string } | null;
+  comedy_group: { id: string; name: string } | null;
+  unit: { id: string; name: string } | null;
+};
+
+export function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
+  return (rows ?? []).flatMap((c) => {
+    if (c.artist_id && c.artist) {
+      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
+    }
+    if (c.comedy_group_id && c.comedy_group) {
+      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
+    }
+    if (c.unit_id && c.unit) {
+      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
+    }
+    return [];
+  });
+}

--- a/src/lib/queries/articles.ts
+++ b/src/lib/queries/articles.ts
@@ -2,6 +2,43 @@ import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { Article, ArticleWithCasts } from "@/lib/types/article";
 
+type CastRow = {
+  artist_id: string | null;
+  comedy_group_id: string | null;
+  unit_id: string | null;
+  artist: { id: string; name: string } | null;
+  comedy_group: { id: string; name: string } | null;
+  unit: { id: string; name: string } | null;
+};
+
+function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
+  return (rows ?? []).flatMap((c) => {
+    if (c.artist_id && c.artist) {
+      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
+    }
+    if (c.comedy_group_id && c.comedy_group) {
+      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
+    }
+    if (c.unit_id && c.unit) {
+      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
+    }
+    return [];
+  });
+}
+
+function toArticleBase(row: Record<string, unknown>): Article {
+  return {
+    id: row.id as string,
+    title: row.title as string,
+    url: (row.url as string | null) ?? null,
+    source: (row.source as string | null) ?? null,
+    published_at: (row.published_at as string | null) ?? null,
+    content: (row.content as string | null) ?? null,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
 export async function listArticles(): Promise<Article[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
@@ -15,6 +52,36 @@ export async function listArticles(): Promise<Article[]> {
   }
 
   return (data ?? []) as Article[];
+}
+
+export async function listArticlesWithCasts(): Promise<ArticleWithCasts[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("articles")
+    .select(
+      `*,
+       article_casts(
+         id,
+         artist_id,
+         comedy_group_id,
+         unit_id,
+         artist:artists(id, name),
+         comedy_group:comedy_groups(id, name),
+         unit:units(id, name)
+       )`
+    )
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`記事一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []).map((row) => {
+    const record = row as Record<string, unknown>;
+    const casts = mapCasts(record.article_casts as CastRow[] | null | undefined);
+    return { ...toArticleBase(record), casts };
+  });
 }
 
 export async function getArticle(id: string): Promise<ArticleWithCasts | null> {
@@ -42,40 +109,7 @@ export async function getArticle(id: string): Promise<ArticleWithCasts | null> {
 
   if (!data) return null;
 
-  type CastRow = {
-    artist_id: string | null;
-    comedy_group_id: string | null;
-    unit_id: string | null;
-    artist: { id: string; name: string } | null;
-    comedy_group: { id: string; name: string } | null;
-    unit: { id: string; name: string } | null;
-  };
-
-  const rawCasts = (data as Record<string, unknown>).article_casts as CastRow[];
-
-  const casts: CastEntry[] = (rawCasts ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
-
-  const articleBase: Article = {
-    id: (data as { id: string }).id,
-    title: (data as { title: string }).title,
-    url: (data as { url: string | null }).url,
-    source: (data as { source: string | null }).source,
-    published_at: (data as { published_at: string | null }).published_at,
-    content: (data as { content: string | null }).content,
-    created_at: (data as { created_at: string }).created_at,
-    updated_at: (data as { updated_at: string }).updated_at,
-  };
-
-  return { ...articleBase, casts };
+  const record = data as Record<string, unknown>;
+  const casts = mapCasts(record.article_casts as CastRow[] | null | undefined);
+  return { ...toArticleBase(record), casts };
 }

--- a/src/lib/queries/articles.ts
+++ b/src/lib/queries/articles.ts
@@ -1,30 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
-import type { CastEntry } from "@/lib/types";
+import { mapCasts, type CastRow } from "@/lib/queries/_casts";
 import type { Article, ArticleWithCasts } from "@/lib/types/article";
-
-type CastRow = {
-  artist_id: string | null;
-  comedy_group_id: string | null;
-  unit_id: string | null;
-  artist: { id: string; name: string } | null;
-  comedy_group: { id: string; name: string } | null;
-  unit: { id: string; name: string } | null;
-};
-
-function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
-  return (rows ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
-}
 
 function toArticleBase(row: Record<string, unknown>): Article {
   return {

--- a/src/lib/queries/lives.ts
+++ b/src/lib/queries/lives.ts
@@ -1,30 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
-import type { CastEntry } from "@/lib/types";
+import { mapCasts, type CastRow } from "@/lib/queries/_casts";
 import type { Live, LiveWithCasts } from "@/lib/types/live";
-
-type CastRow = {
-  artist_id: string | null;
-  comedy_group_id: string | null;
-  unit_id: string | null;
-  artist: { id: string; name: string } | null;
-  comedy_group: { id: string; name: string } | null;
-  unit: { id: string; name: string } | null;
-};
-
-function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
-  return (rows ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
-}
 
 function toLiveBase(row: Record<string, unknown>): Live {
   return {

--- a/src/lib/queries/radios.ts
+++ b/src/lib/queries/radios.ts
@@ -1,30 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
-import type { CastEntry } from "@/lib/types";
+import { mapCasts, type CastRow } from "@/lib/queries/_casts";
 import type { Radio, RadioWithCasts } from "@/lib/types/radio";
-
-type CastRow = {
-  artist_id: string | null;
-  comedy_group_id: string | null;
-  unit_id: string | null;
-  artist: { id: string; name: string } | null;
-  comedy_group: { id: string; name: string } | null;
-  unit: { id: string; name: string } | null;
-};
-
-function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
-  return (rows ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
-}
 
 function toRadioBase(row: Record<string, unknown>): Radio {
   return {

--- a/src/lib/queries/radios.ts
+++ b/src/lib/queries/radios.ts
@@ -2,6 +2,43 @@ import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { Radio, RadioWithCasts } from "@/lib/types/radio";
 
+type CastRow = {
+  artist_id: string | null;
+  comedy_group_id: string | null;
+  unit_id: string | null;
+  artist: { id: string; name: string } | null;
+  comedy_group: { id: string; name: string } | null;
+  unit: { id: string; name: string } | null;
+};
+
+function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
+  return (rows ?? []).flatMap((c) => {
+    if (c.artist_id && c.artist) {
+      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
+    }
+    if (c.comedy_group_id && c.comedy_group) {
+      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
+    }
+    if (c.unit_id && c.unit) {
+      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
+    }
+    return [];
+  });
+}
+
+function toRadioBase(row: Record<string, unknown>): Radio {
+  return {
+    id: row.id as string,
+    title: row.title as string,
+    platform: (row.platform as string | null) ?? null,
+    url: (row.url as string | null) ?? null,
+    published_at: (row.published_at as string | null) ?? null,
+    description: (row.description as string | null) ?? null,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
 export async function listRadios(): Promise<Radio[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
@@ -15,6 +52,36 @@ export async function listRadios(): Promise<Radio[]> {
   }
 
   return (data ?? []) as Radio[];
+}
+
+export async function listRadiosWithCasts(): Promise<RadioWithCasts[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("radios")
+    .select(
+      `*,
+       radio_casts(
+         id,
+         artist_id,
+         comedy_group_id,
+         unit_id,
+         artist:artists(id, name),
+         comedy_group:comedy_groups(id, name),
+         unit:units(id, name)
+       )`
+    )
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`ラジオ一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []).map((row) => {
+    const record = row as Record<string, unknown>;
+    const casts = mapCasts(record.radio_casts as CastRow[] | null | undefined);
+    return { ...toRadioBase(record), casts };
+  });
 }
 
 export async function getRadio(id: string): Promise<RadioWithCasts | null> {
@@ -42,40 +109,7 @@ export async function getRadio(id: string): Promise<RadioWithCasts | null> {
 
   if (!data) return null;
 
-  type CastRow = {
-    artist_id: string | null;
-    comedy_group_id: string | null;
-    unit_id: string | null;
-    artist: { id: string; name: string } | null;
-    comedy_group: { id: string; name: string } | null;
-    unit: { id: string; name: string } | null;
-  };
-
-  const rawCasts = (data as Record<string, unknown>).radio_casts as CastRow[];
-
-  const casts: CastEntry[] = (rawCasts ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
-
-  const radioBase: Radio = {
-    id: (data as { id: string }).id,
-    title: (data as { title: string }).title,
-    platform: (data as { platform: string | null }).platform,
-    url: (data as { url: string | null }).url,
-    published_at: (data as { published_at: string | null }).published_at,
-    description: (data as { description: string | null }).description,
-    created_at: (data as { created_at: string }).created_at,
-    updated_at: (data as { updated_at: string }).updated_at,
-  };
-
-  return { ...radioBase, casts };
+  const record = data as Record<string, unknown>;
+  const casts = mapCasts(record.radio_casts as CastRow[] | null | undefined);
+  return { ...toRadioBase(record), casts };
 }

--- a/src/lib/queries/topics.ts
+++ b/src/lib/queries/topics.ts
@@ -1,30 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
-import type { CastEntry } from "@/lib/types";
+import { mapCasts, type CastRow } from "@/lib/queries/_casts";
 import type { Topic, TopicWithCasts } from "@/lib/types/topic";
-
-type CastRow = {
-  artist_id: string | null;
-  comedy_group_id: string | null;
-  unit_id: string | null;
-  artist: { id: string; name: string } | null;
-  comedy_group: { id: string; name: string } | null;
-  unit: { id: string; name: string } | null;
-};
-
-function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
-  return (rows ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
-}
 
 function toTopicBase(row: Record<string, unknown>): Topic {
   return {

--- a/src/lib/queries/topics.ts
+++ b/src/lib/queries/topics.ts
@@ -2,6 +2,43 @@ import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { Topic, TopicWithCasts } from "@/lib/types/topic";
 
+type CastRow = {
+  artist_id: string | null;
+  comedy_group_id: string | null;
+  unit_id: string | null;
+  artist: { id: string; name: string } | null;
+  comedy_group: { id: string; name: string } | null;
+  unit: { id: string; name: string } | null;
+};
+
+function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
+  return (rows ?? []).flatMap((c) => {
+    if (c.artist_id && c.artist) {
+      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
+    }
+    if (c.comedy_group_id && c.comedy_group) {
+      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
+    }
+    if (c.unit_id && c.unit) {
+      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
+    }
+    return [];
+  });
+}
+
+function toTopicBase(row: Record<string, unknown>): Topic {
+  return {
+    id: row.id as string,
+    title: row.title as string,
+    content: (row.content as string | null) ?? null,
+    url: (row.url as string | null) ?? null,
+    source: (row.source as string | null) ?? null,
+    topic_date: (row.topic_date as string | null) ?? null,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
 export async function listTopics(): Promise<Topic[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
@@ -15,6 +52,36 @@ export async function listTopics(): Promise<Topic[]> {
   }
 
   return (data ?? []) as Topic[];
+}
+
+export async function listTopicsWithCasts(): Promise<TopicWithCasts[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("topics")
+    .select(
+      `*,
+       topic_casts(
+         id,
+         artist_id,
+         comedy_group_id,
+         unit_id,
+         artist:artists(id, name),
+         comedy_group:comedy_groups(id, name),
+         unit:units(id, name)
+       )`
+    )
+    .order("topic_date", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`トピック一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []).map((row) => {
+    const record = row as Record<string, unknown>;
+    const casts = mapCasts(record.topic_casts as CastRow[] | null | undefined);
+    return { ...toTopicBase(record), casts };
+  });
 }
 
 export async function getTopic(id: string): Promise<TopicWithCasts | null> {
@@ -42,40 +109,7 @@ export async function getTopic(id: string): Promise<TopicWithCasts | null> {
 
   if (!data) return null;
 
-  type CastRow = {
-    artist_id: string | null;
-    comedy_group_id: string | null;
-    unit_id: string | null;
-    artist: { id: string; name: string } | null;
-    comedy_group: { id: string; name: string } | null;
-    unit: { id: string; name: string } | null;
-  };
-
-  const rawCasts = (data as Record<string, unknown>).topic_casts as CastRow[];
-
-  const casts: CastEntry[] = (rawCasts ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
-
-  const topicBase: Topic = {
-    id: (data as { id: string }).id,
-    title: (data as { title: string }).title,
-    content: (data as { content: string | null }).content,
-    url: (data as { url: string | null }).url,
-    source: (data as { source: string | null }).source,
-    topic_date: (data as { topic_date: string | null }).topic_date,
-    created_at: (data as { created_at: string }).created_at,
-    updated_at: (data as { updated_at: string }).updated_at,
-  };
-
-  return { ...topicBase, casts };
+  const record = data as Record<string, unknown>;
+  const casts = mapCasts(record.topic_casts as CastRow[] | null | undefined);
+  return { ...toTopicBase(record), casts };
 }

--- a/src/lib/queries/tv-shows.ts
+++ b/src/lib/queries/tv-shows.ts
@@ -2,6 +2,44 @@ import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { TvShow, TvShowWithCasts } from "@/lib/types/tv-show";
 
+type CastRow = {
+  artist_id: string | null;
+  comedy_group_id: string | null;
+  unit_id: string | null;
+  artist: { id: string; name: string } | null;
+  comedy_group: { id: string; name: string } | null;
+  unit: { id: string; name: string } | null;
+};
+
+function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
+  return (rows ?? []).flatMap((c) => {
+    if (c.artist_id && c.artist) {
+      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
+    }
+    if (c.comedy_group_id && c.comedy_group) {
+      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
+    }
+    if (c.unit_id && c.unit) {
+      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
+    }
+    return [];
+  });
+}
+
+function toTvShowBase(row: Record<string, unknown>): TvShow {
+  return {
+    id: row.id as string,
+    title: row.title as string,
+    network: (row.network as string | null) ?? null,
+    air_date: (row.air_date as string | null) ?? null,
+    air_time: (row.air_time as string | null) ?? null,
+    description: (row.description as string | null) ?? null,
+    url: (row.url as string | null) ?? null,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
 export async function listTvShows(): Promise<TvShow[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
@@ -15,6 +53,37 @@ export async function listTvShows(): Promise<TvShow[]> {
   }
 
   return (data ?? []) as TvShow[];
+}
+
+export async function listTvShowsWithCasts(): Promise<TvShowWithCasts[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("tv_shows")
+    .select(
+      `*,
+       tv_show_casts(
+         id,
+         artist_id,
+         comedy_group_id,
+         unit_id,
+         artist:artists(id, name),
+         comedy_group:comedy_groups(id, name),
+         unit:units(id, name)
+       )`
+    )
+    .order("air_date", { ascending: false, nullsFirst: false })
+    .order("air_time", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`TV番組一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []).map((row) => {
+    const record = row as Record<string, unknown>;
+    const casts = mapCasts(record.tv_show_casts as CastRow[] | null | undefined);
+    return { ...toTvShowBase(record), casts };
+  });
 }
 
 export async function getTvShow(id: string): Promise<TvShowWithCasts | null> {
@@ -42,41 +111,7 @@ export async function getTvShow(id: string): Promise<TvShowWithCasts | null> {
 
   if (!data) return null;
 
-  type CastRow = {
-    artist_id: string | null;
-    comedy_group_id: string | null;
-    unit_id: string | null;
-    artist: { id: string; name: string } | null;
-    comedy_group: { id: string; name: string } | null;
-    unit: { id: string; name: string } | null;
-  };
-
-  const rawCasts = (data as Record<string, unknown>).tv_show_casts as CastRow[];
-
-  const casts: CastEntry[] = (rawCasts ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
-
-  const tvShowBase: TvShow = {
-    id: (data as { id: string }).id,
-    title: (data as { title: string }).title,
-    network: (data as { network: string | null }).network,
-    air_date: (data as { air_date: string | null }).air_date,
-    air_time: (data as { air_time: string | null }).air_time,
-    description: (data as { description: string | null }).description,
-    url: (data as { url: string | null }).url,
-    created_at: (data as { created_at: string }).created_at,
-    updated_at: (data as { updated_at: string }).updated_at,
-  };
-
-  return { ...tvShowBase, casts };
+  const record = data as Record<string, unknown>;
+  const casts = mapCasts(record.tv_show_casts as CastRow[] | null | undefined);
+  return { ...toTvShowBase(record), casts };
 }

--- a/src/lib/queries/tv-shows.ts
+++ b/src/lib/queries/tv-shows.ts
@@ -1,30 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
-import type { CastEntry } from "@/lib/types";
+import { mapCasts, type CastRow } from "@/lib/queries/_casts";
 import type { TvShow, TvShowWithCasts } from "@/lib/types/tv-show";
-
-type CastRow = {
-  artist_id: string | null;
-  comedy_group_id: string | null;
-  unit_id: string | null;
-  artist: { id: string; name: string } | null;
-  comedy_group: { id: string; name: string } | null;
-  unit: { id: string; name: string } | null;
-};
-
-function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
-  return (rows ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
-}
 
 function toTvShowBase(row: Record<string, unknown>): TvShow {
   return {

--- a/src/lib/queries/videos.ts
+++ b/src/lib/queries/videos.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import type { CastEntry } from "@/lib/types";
+import { mapCasts, type CastRow } from "@/lib/queries/_casts";
 import type { Video, VideoWithCasts } from "@/lib/types/video";
 
 export async function listVideos(): Promise<Video[]> {
@@ -62,29 +62,9 @@ export async function getVideo(id: string): Promise<VideoWithCasts | null> {
 
   if (!data) return null;
 
-  type CastRow = {
-    artist_id: string | null;
-    comedy_group_id: string | null;
-    unit_id: string | null;
-    artist: { id: string; name: string } | null;
-    comedy_group: { id: string; name: string } | null;
-    unit: { id: string; name: string } | null;
-  };
-
-  const rawCasts = (data as Record<string, unknown>).video_casts as CastRow[];
-
-  const casts: CastEntry[] = (rawCasts ?? []).flatMap((c) => {
-    if (c.artist_id && c.artist) {
-      return [{ type: "artist" as const, id: c.artist.id, name: c.artist.name }];
-    }
-    if (c.comedy_group_id && c.comedy_group) {
-      return [{ type: "comedy_group" as const, id: c.comedy_group.id, name: c.comedy_group.name }];
-    }
-    if (c.unit_id && c.unit) {
-      return [{ type: "unit" as const, id: c.unit.id, name: c.unit.name }];
-    }
-    return [];
-  });
+  const casts = mapCasts(
+    (data as Record<string, unknown>).video_casts as CastRow[] | null | undefined
+  );
 
   const videoBase: Video = {
     id: (data as { id: string }).id,


### PR DESCRIPTION
## 概要

issue #23（公開側：ラジオ・記事・TV・トピック一覧）の実装。あわせてヘッダーから管理画面リンクを除去。

Closes #23

## 主な変更

- `src/app/(public)/radios/`, `articles/`, `tv/`, `topics/` の一覧ページと詳細ページを追加
- 各コンテンツ用のカードコンポーネント（`radio-card.tsx`, `article-card.tsx`, `tv-show-card.tsx`, `topic-card.tsx`）を追加
- 出演者タグを共通化する `src/components/shared/cast-tag.tsx` を新設
- `lib/queries/{radios,articles,tv-shows,topics}.ts` に `listXxxWithCasts` を追加（既存の `listLivesWithCasts` と同パターン）
- 記事は著作権対応で本文（content）を表示せず、出典元へのリンクのみ掲載
- TVカード/詳細では放送局を水色アクセントのバッジで表示（小橋共作さんの水色）
- トピックには情報源・関連URL・本文を表示

## ヘッダーの管理画面リンク除去

公開UIから `/admin` リンクを削除し、`PublicHeader` から Supabase Auth 取得を撤去（ユーザー1人専用のため不要）。`/admin/*` は引き続き middleware で認証ガードされており、URL直打ちでのみアクセス可能。

## Test plan

- [ ] `/radios` `/articles` `/tv` `/topics` に各コンテンツが日付降順で表示される
- [ ] 各カード→詳細ページに遷移できる
- [ ] 出演者タグから `/artists/[id]` `/combos/[id]` `/units/[id]` に遷移できる
- [ ] 記事詳細に本文が出ない（リンクのみ）
- [ ] 各詳細ページで `generateMetadata` のタイトル・description が反映される
- [ ] 公開側ヘッダーに「管理画面」ボタンが出ない（ログイン状態でも非表示）
- [ ] `/admin` への直アクセスは引き続きできる

## 既知の事項

- リポジトリには CI のビルドチェックがない。`next build` を手元で実行すると、`src/lib/actions/achievements.ts:82` の `AchievementInput` 型不整合が検出されるが、これは本PRの範囲外で main 側に既存の問題（このブランチを切る前から存在）。

https://claude.ai/code/session_011dw3wsxLew9dTmJytmK4uh

---
_Generated by [Claude Code](https://claude.ai/code/session_011dw3wsxLew9dTmJytmK4uh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added listing and detail pages for Articles, Radios, Topics, and TV Shows with titles, dates, source/platform badges, cast tag lists, descriptions, and external "open" links when available.
  * Added card components for Articles, Radios, Topics, and TV Shows for list views.
  * Added cast tag components for consistent performer links across sections.
* **Style**
  * Removed admin management link from the public header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->