### PR TITLE
feat: 公開側のコンビ・芸人 詳細ページを実装

### DIFF
--- a/src/app/(public)/articles/[id]/page.tsx
+++ b/src/app/(public)/articles/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
-import { CastTagList } from "@/components/shared/cast-tag";
+import { PerformerTagList } from "@/components/shared/performer-tags";
 import { getArticle as fetchArticle } from "@/lib/queries/articles";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
@@ -83,7 +83,7 @@ export default async function ArticleDetailPage({ params }: Props) {
 
       {article.casts.length > 0 ? (
         <div className="mt-4">
-          <CastTagList casts={article.casts} />
+          <PerformerTagList performers={article.casts} />
         </div>
       ) : null}
 

--- a/src/app/(public)/artists/[id]/page.tsx
+++ b/src/app/(public)/artists/[id]/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { ArtistProfile } from "@/components/features/artist/artist-profile";
+import { ContentTabs } from "@/components/features/combo/combo-content-tabs";
+import { listAchievementsByTarget } from "@/lib/queries/achievements";
+import { getArtist as fetchArtist } from "@/lib/queries/artists";
+import { listCombosForArtist } from "@/lib/queries/combos";
+import { getPerformerContents } from "@/lib/queries/performer-contents";
+
+export const dynamic = "force-dynamic";
+
+const getArtist = cache(fetchArtist);
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+const DESCRIPTION_MAX_LENGTH = 160;
+
+function buildDescription(artist: {
+  name: string;
+  kana_name: string | null;
+  profile: string | null;
+}): string {
+  const raw = (artist.profile ?? "").replace(/\s+/g, " ").trim();
+  const fallback = `${artist.name}${
+    artist.kana_name ? `（${artist.kana_name}）` : ""
+  }のプロフィール、SNSリンク、所属コンビ、出演コンテンツ。`;
+  const base = raw || fallback;
+  if (base.length <= DESCRIPTION_MAX_LENGTH) return base;
+  return `${base.slice(0, DESCRIPTION_MAX_LENGTH - 1)}…`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const artist = await getArtist(id);
+  if (!artist) return {};
+
+  const description = buildDescription(artist);
+  const url = `/artists/${artist.id}`;
+  const images = artist.image_url ? [{ url: artist.image_url }] : undefined;
+
+  return {
+    title: artist.name,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: artist.name,
+      description,
+      url,
+      images,
+    },
+    twitter: {
+      card: images ? "summary_large_image" : "summary",
+      title: artist.name,
+      description,
+      images: artist.image_url ? [artist.image_url] : undefined,
+    },
+  };
+}
+
+export default async function ArtistDetailPage({ params }: Props) {
+  const { id } = await params;
+  const artist = await getArtist(id);
+  if (!artist) notFound();
+
+  const [memberships, achievements, contents] = await Promise.all([
+    listCombosForArtist(artist.id),
+    listAchievementsByTarget("artist_id", artist.id),
+    getPerformerContents("artist_id", artist.id),
+  ]);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl flex-1 px-4 py-6 md:py-10">
+      <div className="mb-4">
+        <Link
+          href="/"
+          className="text-xs text-brand-muted transition hover:text-brand-sky-light"
+        >
+          ← トップに戻る
+        </Link>
+      </div>
+
+      <ArtistProfile
+        artist={artist}
+        memberships={memberships}
+        achievements={achievements}
+      />
+
+      <div className="mt-10">
+        <ContentTabs
+          videos={contents.videos}
+          lives={contents.lives}
+          radios={contents.radios}
+          tvShows={contents.tvShows}
+          articles={contents.articles}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/artists/page.tsx
+++ b/src/app/(public)/artists/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { listArtists } from "@/lib/queries/artists";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "芸人",
+  description: "ドンデコルテさん関連の芸人一覧。",
+  alternates: { canonical: "/artists" },
+  openGraph: {
+    title: "芸人",
+    description: "ドンデコルテさん関連の芸人一覧。",
+    url: "/artists",
+  },
+};
+
+export default async function ArtistsPage() {
+  const artists = await listArtists();
+
+  return (
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          芸人
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          ドンデコルテさん関連の芸人一覧。
+        </p>
+      </header>
+
+      {artists.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          まだ芸人が登録されていません。
+        </p>
+      ) : (
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {artists.map((artist) => (
+            <li key={artist.id}>
+              <Link
+                href={`/artists/${artist.id}`}
+                className="flex h-full gap-3 rounded-lg border border-brand-border-dark bg-brand-card-dark p-3 transition hover:border-brand-sky-light"
+              >
+                <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-md bg-brand-bg-dark">
+                  {artist.image_url ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={artist.image_url}
+                      alt=""
+                      loading="lazy"
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <span className="text-[10px] text-brand-muted">
+                      No Image
+                    </span>
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-semibold text-brand-cream">
+                    {artist.name}
+                  </p>
+                  {artist.kana_name ? (
+                    <p className="truncate text-xs text-brand-muted">
+                      {artist.kana_name}
+                    </p>
+                  ) : null}
+                  {artist.debut_year ? (
+                    <p className="mt-1 text-xs text-brand-gold">
+                      デビュー {artist.debut_year}年
+                    </p>
+                  ) : null}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(public)/combos/[id]/page.tsx
+++ b/src/app/(public)/combos/[id]/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { ContentTabs } from "@/components/features/combo/combo-content-tabs";
+import { ComboProfile } from "@/components/features/combo/combo-profile";
+import { listAchievementsByTarget } from "@/lib/queries/achievements";
+import { getCombo as fetchCombo } from "@/lib/queries/combos";
+import { getPerformerContents } from "@/lib/queries/performer-contents";
+
+export const dynamic = "force-dynamic";
+
+const getCombo = cache(fetchCombo);
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+const DESCRIPTION_MAX_LENGTH = 160;
+
+function buildDescription(combo: {
+  name: string;
+  kana_name: string | null;
+  description: string | null;
+}): string {
+  const raw = (combo.description ?? "").replace(/\s+/g, " ").trim();
+  const fallback = `${combo.name}${
+    combo.kana_name ? `（${combo.kana_name}）` : ""
+  }のプロフィール、SNSリンク、出演コンテンツ。`;
+  const base = raw || fallback;
+  if (base.length <= DESCRIPTION_MAX_LENGTH) return base;
+  return `${base.slice(0, DESCRIPTION_MAX_LENGTH - 1)}…`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const combo = await getCombo(id);
+  if (!combo) return {};
+
+  const description = buildDescription(combo);
+  const url = `/combos/${combo.id}`;
+  const images = combo.image_url ? [{ url: combo.image_url }] : undefined;
+
+  return {
+    title: combo.name,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: combo.name,
+      description,
+      url,
+      images,
+    },
+    twitter: {
+      card: images ? "summary_large_image" : "summary",
+      title: combo.name,
+      description,
+      images: combo.image_url ? [combo.image_url] : undefined,
+    },
+  };
+}
+
+export default async function ComboDetailPage({ params }: Props) {
+  const { id } = await params;
+  const combo = await getCombo(id);
+  if (!combo) notFound();
+
+  const [achievements, contents] = await Promise.all([
+    listAchievementsByTarget("comedy_group_id", combo.id),
+    getPerformerContents("comedy_group_id", combo.id),
+  ]);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl flex-1 px-4 py-6 md:py-10">
+      <div className="mb-4">
+        <Link
+          href="/"
+          className="text-xs text-brand-muted transition hover:text-brand-sky-light"
+        >
+          ← トップに戻る
+        </Link>
+      </div>
+
+      <ComboProfile
+        combo={combo}
+        members={combo.members}
+        achievements={achievements}
+      />
+
+      <div className="mt-10">
+        <ContentTabs
+          videos={contents.videos}
+          lives={contents.lives}
+          radios={contents.radios}
+          tvShows={contents.tvShows}
+          articles={contents.articles}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/combos/page.tsx
+++ b/src/app/(public)/combos/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { listCombos } from "@/lib/queries/combos";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "コンビ",
+  description: "ドンデコルテさん関連のコンビ一覧。",
+  alternates: { canonical: "/combos" },
+  openGraph: {
+    title: "コンビ",
+    description: "ドンデコルテさん関連のコンビ一覧。",
+    url: "/combos",
+  },
+};
+
+export default async function CombosPage() {
+  const combos = await listCombos();
+
+  return (
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          コンビ
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          ドンデコルテさん関連のコンビ一覧。
+        </p>
+      </header>
+
+      {combos.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          まだコンビが登録されていません。
+        </p>
+      ) : (
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {combos.map((combo) => {
+            const accent = combo.theme_color ?? undefined;
+            return (
+              <li key={combo.id}>
+                <Link
+                  href={`/combos/${combo.id}`}
+                  className="flex h-full gap-3 rounded-lg border border-brand-border-dark bg-brand-card-dark p-3 transition hover:border-brand-sky-light"
+                  style={
+                    accent
+                      ? { borderLeftColor: accent, borderLeftWidth: 4 }
+                      : undefined
+                  }
+                >
+                  <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-md bg-brand-bg-dark">
+                    {combo.image_url ? (
+                      /* eslint-disable-next-line @next/next/no-img-element */
+                      <img
+                        src={combo.image_url}
+                        alt=""
+                        loading="lazy"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <span className="text-[10px] text-brand-muted">
+                        No Image
+                      </span>
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-semibold text-brand-cream">
+                      {combo.name}
+                    </p>
+                    {combo.kana_name ? (
+                      <p className="truncate text-xs text-brand-muted">
+                        {combo.kana_name}
+                      </p>
+                    ) : null}
+                    {combo.formed_year ? (
+                      <p className="mt-1 text-xs text-brand-gold">
+                        結成 {combo.formed_year}年
+                      </p>
+                    ) : null}
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(public)/lives/[id]/page.tsx
+++ b/src/app/(public)/lives/[id]/page.tsx
@@ -6,6 +6,7 @@ import { PerformerTagList } from "@/components/shared/performer-tags";
 import { getLive as fetchLive } from "@/lib/queries/lives";
 import type { CastEntry } from "@/lib/types";
 import { formatDate, formatTime } from "@/lib/utils/date";
+import { normalizeExternalUrl } from "@/lib/utils/url";
 
 export const dynamic = "force-dynamic";
 
@@ -60,6 +61,8 @@ export default async function LiveDetailPage({ params }: Props) {
 
   const eventDate = formatDate(live.event_date);
   const startTime = formatTime(live.start_time);
+  const safeUrl = normalizeExternalUrl(live.url);
+  const description = live.description?.trim() ? live.description : null;
 
   return (
     <div className="mx-auto w-full max-w-4xl flex-1 px-4 py-6 md:py-10">
@@ -98,10 +101,10 @@ export default async function LiveDetailPage({ params }: Props) {
         </div>
       ) : null}
 
-      {live.url ? (
+      {safeUrl ? (
         <div className="mt-6">
           <a
-            href={live.url}
+            href={safeUrl}
             target="_blank"
             rel="noreferrer noopener"
             className="inline-flex items-center rounded-md border border-brand-border-dark bg-brand-card-dark px-4 py-2 text-sm font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"
@@ -111,10 +114,10 @@ export default async function LiveDetailPage({ params }: Props) {
         </div>
       ) : null}
 
-      {live.description ? (
+      {description ? (
         <section className="mt-6 rounded-lg border border-brand-border-dark bg-brand-card-dark p-4">
           <p className="whitespace-pre-wrap text-sm leading-relaxed text-brand-cream">
-            {live.description}
+            {description}
           </p>
         </section>
       ) : null}

--- a/src/app/(public)/lives/[id]/page.tsx
+++ b/src/app/(public)/lives/[id]/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { PerformerTagList } from "@/components/shared/performer-tags";
+import { getLive as fetchLive } from "@/lib/queries/lives";
+import type { CastEntry } from "@/lib/types";
+import { formatDate, formatTime } from "@/lib/utils/date";
+
+export const dynamic = "force-dynamic";
+
+const getLive = cache(fetchLive);
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+const DESCRIPTION_MAX_LENGTH = 160;
+
+function buildDescription(live: {
+  description: string | null;
+  casts: CastEntry[];
+  title: string;
+  venue: string | null;
+}): string {
+  const performerNames = live.casts.map((c) => c.name).join("、");
+  const performerText = performerNames ? `出演: ${performerNames}。` : "";
+  const venueText = live.venue ? `${live.venue}。` : "";
+  const raw = (live.description ?? "").replace(/\s+/g, " ").trim();
+  const fallback = `${performerText}${venueText}ドンデコルテさん関連ライブ「${live.title}」の詳細ページ。`;
+  const base = raw ? `${performerText}${venueText}${raw}` : fallback;
+  if (base.length <= DESCRIPTION_MAX_LENGTH) return base;
+  return `${base.slice(0, DESCRIPTION_MAX_LENGTH - 1)}…`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const live = await getLive(id);
+  if (!live) return {};
+
+  const description = buildDescription(live);
+  const url = `/lives/${live.id}`;
+
+  return {
+    title: live.title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: live.title,
+      description,
+      url,
+    },
+  };
+}
+
+export default async function LiveDetailPage({ params }: Props) {
+  const { id } = await params;
+  const live = await getLive(id);
+  if (!live) notFound();
+
+  const eventDate = formatDate(live.event_date);
+  const startTime = formatTime(live.start_time);
+
+  return (
+    <div className="mx-auto w-full max-w-4xl flex-1 px-4 py-6 md:py-10">
+      <div className="mb-4">
+        <Link
+          href="/lives"
+          className="text-xs text-brand-muted transition hover:text-brand-sky-light"
+        >
+          ← ライブ一覧
+        </Link>
+      </div>
+
+      <h1 className="text-xl font-bold text-brand-cream md:text-2xl">
+        {live.title}
+      </h1>
+
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-brand-muted md:text-sm">
+        {eventDate ? (
+          <span>
+            {eventDate}
+            {startTime ? ` ${startTime}` : ""}
+          </span>
+        ) : (
+          <span>日付未定</span>
+        )}
+        {live.venue ? (
+          <span className="inline-flex items-center rounded border border-brand-border-dark bg-brand-card-dark px-1.5 py-0.5">
+            {live.venue}
+          </span>
+        ) : null}
+      </div>
+
+      {live.casts.length > 0 ? (
+        <div className="mt-4">
+          <PerformerTagList performers={live.casts} />
+        </div>
+      ) : null}
+
+      {live.url ? (
+        <div className="mt-6">
+          <a
+            href={live.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center rounded-md border border-brand-border-dark bg-brand-card-dark px-4 py-2 text-sm font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"
+          >
+            ライブ情報を見る ↗
+          </a>
+        </div>
+      ) : null}
+
+      {live.description ? (
+        <section className="mt-6 rounded-lg border border-brand-border-dark bg-brand-card-dark p-4">
+          <p className="whitespace-pre-wrap text-sm leading-relaxed text-brand-cream">
+            {live.description}
+          </p>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/(public)/radios/[id]/page.tsx
+++ b/src/app/(public)/radios/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
-import { CastTagList } from "@/components/shared/cast-tag";
+import { PerformerTagList } from "@/components/shared/performer-tags";
 import { getRadio as fetchRadio } from "@/lib/queries/radios";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
@@ -84,7 +84,7 @@ export default async function RadioDetailPage({ params }: Props) {
 
       {radio.casts.length > 0 ? (
         <div className="mt-4">
-          <CastTagList casts={radio.casts} />
+          <PerformerTagList performers={radio.casts} />
         </div>
       ) : null}
 

--- a/src/app/(public)/topics/[id]/page.tsx
+++ b/src/app/(public)/topics/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
-import { CastTagList } from "@/components/shared/cast-tag";
+import { PerformerTagList } from "@/components/shared/performer-tags";
 import { getTopic as fetchTopic } from "@/lib/queries/topics";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
@@ -86,7 +86,7 @@ export default async function TopicDetailPage({ params }: Props) {
 
       {topic.casts.length > 0 ? (
         <div className="mt-4">
-          <CastTagList casts={topic.casts} />
+          <PerformerTagList performers={topic.casts} />
         </div>
       ) : null}
 

--- a/src/app/(public)/tv/[id]/page.tsx
+++ b/src/app/(public)/tv/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
-import { CastTagList } from "@/components/shared/cast-tag";
+import { PerformerTagList } from "@/components/shared/performer-tags";
 import { getTvShow as fetchTvShow } from "@/lib/queries/tv-shows";
 import type { CastEntry } from "@/lib/types";
 import { formatDate, formatTime } from "@/lib/utils/date";
@@ -94,7 +94,7 @@ export default async function TvDetailPage({ params }: Props) {
 
       {tvShow.casts.length > 0 ? (
         <div className="mt-4">
-          <CastTagList casts={tvShow.casts} />
+          <PerformerTagList performers={tvShow.casts} />
         </div>
       ) : null}
 

--- a/src/app/(public)/units/[id]/page.tsx
+++ b/src/app/(public)/units/[id]/page.tsx
@@ -1,0 +1,148 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { ContentTabs } from "@/components/features/combo/combo-content-tabs";
+import { listAchievementsByTarget } from "@/lib/queries/achievements";
+import { getPerformerContents } from "@/lib/queries/performer-contents";
+import { getUnit as fetchUnit } from "@/lib/queries/units";
+
+export const dynamic = "force-dynamic";
+
+const getUnit = cache(fetchUnit);
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+const DESCRIPTION_MAX_LENGTH = 160;
+
+function buildDescription(unit: {
+  name: string;
+  description: string | null;
+}): string {
+  const raw = (unit.description ?? "").replace(/\s+/g, " ").trim();
+  const fallback = `${unit.name}の構成メンバーと出演コンテンツ。`;
+  const base = raw || fallback;
+  if (base.length <= DESCRIPTION_MAX_LENGTH) return base;
+  return `${base.slice(0, DESCRIPTION_MAX_LENGTH - 1)}…`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const unit = await getUnit(id);
+  if (!unit) return {};
+
+  const description = buildDescription(unit);
+  const url = `/units/${unit.id}`;
+
+  return {
+    title: unit.name,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: unit.name,
+      description,
+      url,
+    },
+  };
+}
+
+export default async function UnitDetailPage({ params }: Props) {
+  const { id } = await params;
+  const unit = await getUnit(id);
+  if (!unit) notFound();
+
+  const [achievements, contents] = await Promise.all([
+    listAchievementsByTarget("unit_id", unit.id),
+    getPerformerContents("unit_id", unit.id),
+  ]);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl flex-1 px-4 py-6 md:py-10">
+      <div className="mb-4">
+        <Link
+          href="/units"
+          className="text-xs text-brand-muted transition hover:text-brand-sky-light"
+        >
+          ← ユニット一覧
+        </Link>
+      </div>
+
+      <header className="space-y-4">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          {unit.name}
+        </h1>
+        {unit.description ? (
+          <p className="whitespace-pre-wrap text-sm leading-relaxed text-brand-cream md:text-base">
+            {unit.description}
+          </p>
+        ) : null}
+
+        {unit.members.length > 0 ? (
+          <section>
+            <h2 className="mb-3 text-sm font-semibold text-brand-cream md:text-base">
+              構成メンバー
+            </h2>
+            <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {unit.members.map((m) => (
+                <li key={`${m.type}-${m.id}`}>
+                  <Link
+                    href={
+                      m.type === "comedy_group"
+                        ? `/combos/${m.id}`
+                        : `/artists/${m.id}`
+                    }
+                    className="block rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-3 transition hover:border-brand-sky-light"
+                  >
+                    <p className="text-sm font-semibold text-brand-cream">
+                      {m.name}
+                    </p>
+                    <div className="mt-1 flex flex-wrap items-baseline gap-x-2 text-xs text-brand-muted">
+                      <span>{m.type === "comedy_group" ? "コンビ" : "芸人"}</span>
+                      {m.kana_name ? <span>{m.kana_name}</span> : null}
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
+        {achievements.length > 0 ? (
+          <section>
+            <h2 className="mb-3 text-sm font-semibold text-brand-cream md:text-base">
+              受賞歴
+            </h2>
+            <ul className="space-y-2">
+              {achievements.map((a) => (
+                <li
+                  key={a.id}
+                  className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-3"
+                >
+                  <div className="flex flex-wrap items-baseline gap-x-3">
+                    <span className="text-xs font-medium text-brand-gold">
+                      {a.year}
+                    </span>
+                    <span className="text-sm text-brand-cream">{a.title}</span>
+                  </div>
+                  <p className="mt-1 text-xs text-brand-sky-light">{a.result}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+      </header>
+
+      <div className="mt-10">
+        <ContentTabs
+          videos={contents.videos}
+          lives={contents.lives}
+          radios={contents.radios}
+          tvShows={contents.tvShows}
+          articles={contents.articles}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/units/page.tsx
+++ b/src/app/(public)/units/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { listUnits } from "@/lib/queries/units";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "ユニット",
+  description: "ドンデコルテさんが参加するユニット一覧。",
+  alternates: { canonical: "/units" },
+  openGraph: {
+    title: "ユニット",
+    description: "ドンデコルテさんが参加するユニット一覧。",
+    url: "/units",
+  },
+};
+
+export default async function UnitsPage() {
+  const units = await listUnits();
+
+  return (
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          ユニット
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          ドンデコルテさんが参加するユニット一覧。
+        </p>
+      </header>
+
+      {units.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          まだユニットが登録されていません。
+        </p>
+      ) : (
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {units.map((unit) => (
+            <li key={unit.id}>
+              <Link
+                href={`/units/${unit.id}`}
+                className="block h-full rounded-lg border border-brand-border-dark bg-brand-card-dark p-4 transition hover:border-brand-sky-light"
+              >
+                <p className="text-sm font-semibold text-brand-cream">
+                  {unit.name}
+                </p>
+                {unit.description ? (
+                  <p className="mt-2 line-clamp-2 text-xs text-brand-muted">
+                    {unit.description}
+                  </p>
+                ) : null}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/article/article-card.tsx
+++ b/src/components/features/article/article-card.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { CastTagList } from "@/components/shared/cast-tag";
+import { PerformerTagList } from "@/components/shared/performer-tags";
 import type { ArticleWithCasts } from "@/lib/types/article";
 import { formatDate } from "@/lib/utils/date";
 
@@ -39,7 +39,7 @@ export function ArticleCard({ article }: { article: ArticleWithCasts }) {
       ) : null}
       {article.casts.length > 0 ? (
         <div className="mt-2">
-          <CastTagList casts={article.casts} />
+          <PerformerTagList performers={article.casts} />
         </div>
       ) : null}
     </article>

--- a/src/components/features/artist/artist-profile.tsx
+++ b/src/components/features/artist/artist-profile.tsx
@@ -1,0 +1,131 @@
+import Link from "next/link";
+import { SnsLinks } from "@/components/features/sns/sns-links";
+import type { ComboMembershipEntry } from "@/lib/queries/combos";
+import type { Achievement } from "@/lib/types/achievement";
+import type { Artist } from "@/lib/types/artist";
+
+type Props = {
+  artist: Artist;
+  memberships: ComboMembershipEntry[];
+  achievements: Achievement[];
+};
+
+export function ArtistProfile({ artist, memberships, achievements }: Props) {
+  return (
+    <header className="space-y-6">
+      <div className="flex flex-col gap-5 md:flex-row md:items-start">
+        <div className="flex h-32 w-32 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-brand-border-dark bg-brand-card-dark md:h-40 md:w-40">
+          {artist.image_url ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img
+              src={artist.image_url}
+              alt={artist.name}
+              loading="lazy"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <span className="text-xs text-brand-muted">No Image</span>
+          )}
+        </div>
+        <div className="flex-1 space-y-2">
+          {artist.debut_year ? (
+            <span className="text-xs text-brand-muted">
+              デビュー {artist.debut_year}年
+            </span>
+          ) : null}
+          <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+            {artist.name}
+          </h1>
+          {artist.kana_name ? (
+            <p className="text-sm text-brand-gold">{artist.kana_name}</p>
+          ) : null}
+          {artist.profile ? (
+            <p className="whitespace-pre-wrap text-sm leading-relaxed text-brand-cream md:text-base">
+              {artist.profile}
+            </p>
+          ) : null}
+          <div className="pt-1">
+            <SnsLinks sns={artist} />
+          </div>
+        </div>
+      </div>
+
+      {memberships.length > 0 ? (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold text-brand-cream md:text-base">
+            所属コンビ
+          </h2>
+          <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {memberships.map(({ combo, role }) => {
+              const accent = combo.theme_color ?? undefined;
+              return (
+                <li key={combo.id}>
+                  <Link
+                    href={`/combos/${combo.id}`}
+                    className="flex gap-3 rounded-lg border border-brand-border-dark bg-brand-card-dark p-3 transition hover:border-brand-sky-light"
+                    style={accent ? { borderLeftColor: accent, borderLeftWidth: 4 } : undefined}
+                  >
+                    <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-md bg-brand-bg-dark">
+                      {combo.image_url ? (
+                        /* eslint-disable-next-line @next/next/no-img-element */
+                        <img
+                          src={combo.image_url}
+                          alt=""
+                          loading="lazy"
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <span className="text-[10px] text-brand-muted">
+                          No Image
+                        </span>
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-semibold text-brand-cream">
+                        {combo.name}
+                      </p>
+                      {combo.kana_name ? (
+                        <p className="truncate text-xs text-brand-muted">
+                          {combo.kana_name}
+                        </p>
+                      ) : null}
+                      {role ? (
+                        <p className="mt-1 text-xs text-brand-sky-light">
+                          {role}
+                        </p>
+                      ) : null}
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
+
+      {achievements.length > 0 ? (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold text-brand-cream md:text-base">
+            受賞歴
+          </h2>
+          <ul className="space-y-2">
+            {achievements.map((a) => (
+              <li
+                key={a.id}
+                className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-3"
+              >
+                <div className="flex flex-wrap items-baseline gap-x-3">
+                  <span className="text-xs font-medium text-brand-gold">
+                    {a.year}
+                  </span>
+                  <span className="text-sm text-brand-cream">{a.title}</span>
+                </div>
+                <p className="mt-1 text-xs text-brand-sky-light">{a.result}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </header>
+  );
+}

--- a/src/components/features/combo/combo-content-tabs.tsx
+++ b/src/components/features/combo/combo-content-tabs.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+import { ArticleCard } from "@/components/features/article/article-card";
+import { LiveCard } from "@/components/features/live/live-card";
+import { RadioCard } from "@/components/features/radio/radio-card";
+import { TvShowCard } from "@/components/features/tv-show/tv-show-card";
+import { VideoCard } from "@/components/features/video/video-card";
+import type { ArticleWithCasts } from "@/lib/types/article";
+import type { LiveWithCasts } from "@/lib/types/live";
+import type { RadioWithCasts } from "@/lib/types/radio";
+import type { TvShowWithCasts } from "@/lib/types/tv-show";
+import type { VideoWithCasts } from "@/lib/types/video";
+
+type TabKey = "videos" | "lives" | "radios" | "tv" | "articles";
+
+type Props = {
+  videos: VideoWithCasts[];
+  lives: LiveWithCasts[];
+  radios: RadioWithCasts[];
+  tvShows: TvShowWithCasts[];
+  articles: ArticleWithCasts[];
+};
+
+const TAB_LABEL: Record<TabKey, string> = {
+  videos: "Videos",
+  lives: "Lives",
+  radios: "Radio",
+  tv: "TV",
+  articles: "Articles",
+};
+
+const EMPTY_LABEL: Record<TabKey, string> = {
+  videos: "出演動画はまだ登録されていません。",
+  lives: "出演ライブはまだ登録されていません。",
+  radios: "出演ラジオはまだ登録されていません。",
+  tv: "出演TV番組はまだ登録されていません。",
+  articles: "関連記事はまだ登録されていません。",
+};
+
+export function ContentTabs({
+  videos,
+  lives,
+  radios,
+  tvShows,
+  articles,
+}: Props) {
+  const counts: Record<TabKey, number> = {
+    videos: videos.length,
+    lives: lives.length,
+    radios: radios.length,
+    tv: tvShows.length,
+    articles: articles.length,
+  };
+  const orderedTabs: TabKey[] = ["videos", "lives", "radios", "tv", "articles"];
+  const initialTab =
+    orderedTabs.find((t) => counts[t] > 0) ?? ("videos" as TabKey);
+  const [active, setActive] = useState<TabKey>(initialTab);
+
+  return (
+    <section>
+      <div
+        role="tablist"
+        aria-label="出演コンテンツ"
+        className="mb-4 flex flex-wrap gap-1 overflow-x-auto border-b border-brand-border-dark"
+      >
+        {orderedTabs.map((tab) => {
+          const isActive = tab === active;
+          return (
+            <button
+              key={tab}
+              role="tab"
+              type="button"
+              aria-selected={isActive}
+              onClick={() => setActive(tab)}
+              className={`-mb-px shrink-0 border-b-2 px-3 py-2 text-sm transition ${
+                isActive
+                  ? "border-brand-sky text-brand-sky-light"
+                  : "border-transparent text-brand-muted hover:text-brand-cream"
+              }`}
+            >
+              {TAB_LABEL[tab]}
+              <span className="ml-1 text-xs text-brand-muted">
+                {counts[tab]}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div role="tabpanel">
+        {active === "videos" ? (
+          videos.length > 0 ? (
+            <ul className="grid grid-cols-2 gap-4 md:grid-cols-3">
+              {videos.map((v) => (
+                <li key={v.id}>
+                  <VideoCard video={v} />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState message={EMPTY_LABEL.videos} />
+          )
+        ) : null}
+
+        {active === "lives" ? (
+          lives.length > 0 ? (
+            <ul className="space-y-3">
+              {lives.map((l) => (
+                <li key={l.id}>
+                  <LiveCard live={l} variant="past" />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState message={EMPTY_LABEL.lives} />
+          )
+        ) : null}
+
+        {active === "radios" ? (
+          radios.length > 0 ? (
+            <ul className="space-y-3">
+              {radios.map((r) => (
+                <li key={r.id}>
+                  <RadioCard radio={r} />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState message={EMPTY_LABEL.radios} />
+          )
+        ) : null}
+
+        {active === "tv" ? (
+          tvShows.length > 0 ? (
+            <ul className="space-y-3">
+              {tvShows.map((t) => (
+                <li key={t.id}>
+                  <TvShowCard tvShow={t} />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState message={EMPTY_LABEL.tv} />
+          )
+        ) : null}
+
+        {active === "articles" ? (
+          articles.length > 0 ? (
+            <ul className="space-y-3">
+              {articles.map((a) => (
+                <li key={a.id}>
+                  <ArticleCard article={a} />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState message={EMPTY_LABEL.articles} />
+          )
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+      {message}
+    </p>
+  );
+}

--- a/src/components/features/combo/combo-content-tabs.tsx
+++ b/src/components/features/combo/combo-content-tabs.tsx
@@ -69,9 +69,12 @@ export function ContentTabs({
           return (
             <button
               key={tab}
+              id={`tab-${tab}`}
               role="tab"
               type="button"
+              aria-controls={`tabpanel-${tab}`}
               aria-selected={isActive}
+              tabIndex={isActive ? 0 : -1}
               onClick={() => setActive(tab)}
               className={`-mb-px shrink-0 border-b-2 px-3 py-2 text-sm transition ${
                 isActive
@@ -88,7 +91,11 @@ export function ContentTabs({
         })}
       </div>
 
-      <div role="tabpanel">
+      <div
+        role="tabpanel"
+        id={`tabpanel-${active}`}
+        aria-labelledby={`tab-${active}`}
+      >
         {active === "videos" ? (
           videos.length > 0 ? (
             <ul className="grid grid-cols-2 gap-4 md:grid-cols-3">

--- a/src/components/features/combo/combo-content-tabs.tsx
+++ b/src/components/features/combo/combo-content-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { ArticleCard } from "@/components/features/article/article-card";
 import { LiveCard } from "@/components/features/live/live-card";
 import { RadioCard } from "@/components/features/radio/radio-card";
@@ -22,20 +22,13 @@ type Props = {
   articles: ArticleWithCasts[];
 };
 
-const TAB_LABEL: Record<TabKey, string> = {
-  videos: "Videos",
-  lives: "Lives",
-  radios: "Radio",
-  tv: "TV",
-  articles: "Articles",
-};
-
-const EMPTY_LABEL: Record<TabKey, string> = {
-  videos: "出演動画はまだ登録されていません。",
-  lives: "出演ライブはまだ登録されていません。",
-  radios: "出演ラジオはまだ登録されていません。",
-  tv: "出演TV番組はまだ登録されていません。",
-  articles: "関連記事はまだ登録されていません。",
+type TabConfig = {
+  key: TabKey;
+  label: string;
+  count: number;
+  emptyLabel: string;
+  listClassName: string;
+  render: () => ReactNode;
 };
 
 export function ContentTabs({
@@ -45,17 +38,101 @@ export function ContentTabs({
   tvShows,
   articles,
 }: Props) {
-  const counts: Record<TabKey, number> = {
-    videos: videos.length,
-    lives: lives.length,
-    radios: radios.length,
-    tv: tvShows.length,
-    articles: articles.length,
-  };
-  const orderedTabs: TabKey[] = ["videos", "lives", "radios", "tv", "articles"];
-  const initialTab =
-    orderedTabs.find((t) => counts[t] > 0) ?? ("videos" as TabKey);
+  const tabs: TabConfig[] = [
+    {
+      key: "videos",
+      label: "Videos",
+      count: videos.length,
+      emptyLabel: "出演動画はまだ登録されていません。",
+      listClassName: "grid grid-cols-2 gap-4 md:grid-cols-3",
+      render: () =>
+        videos.map((v) => (
+          <li key={v.id}>
+            <VideoCard video={v} />
+          </li>
+        )),
+    },
+    {
+      key: "lives",
+      label: "Lives",
+      count: lives.length,
+      emptyLabel: "出演ライブはまだ登録されていません。",
+      listClassName: "space-y-3",
+      render: () =>
+        lives.map((l) => (
+          <li key={l.id}>
+            <LiveCard live={l} variant="past" />
+          </li>
+        )),
+    },
+    {
+      key: "radios",
+      label: "Radio",
+      count: radios.length,
+      emptyLabel: "出演ラジオはまだ登録されていません。",
+      listClassName: "space-y-3",
+      render: () =>
+        radios.map((r) => (
+          <li key={r.id}>
+            <RadioCard radio={r} />
+          </li>
+        )),
+    },
+    {
+      key: "tv",
+      label: "TV",
+      count: tvShows.length,
+      emptyLabel: "出演TV番組はまだ登録されていません。",
+      listClassName: "space-y-3",
+      render: () =>
+        tvShows.map((t) => (
+          <li key={t.id}>
+            <TvShowCard tvShow={t} />
+          </li>
+        )),
+    },
+    {
+      key: "articles",
+      label: "Articles",
+      count: articles.length,
+      emptyLabel: "関連記事はまだ登録されていません。",
+      listClassName: "space-y-3",
+      render: () =>
+        articles.map((a) => (
+          <li key={a.id}>
+            <ArticleCard article={a} />
+          </li>
+        )),
+    },
+  ];
+
+  const initialTab = (tabs.find((t) => t.count > 0) ?? tabs[0]).key;
   const [active, setActive] = useState<TabKey>(initialTab);
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const focusTab = (index: number) => {
+    const next = tabs[index];
+    setActive(next.key);
+    tabRefs.current[index]?.focus();
+  };
+
+  const onTabKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    const last = tabs.length - 1;
+    let next = index;
+    if (e.key === "ArrowRight") next = index === last ? 0 : index + 1;
+    else if (e.key === "ArrowLeft") next = index === 0 ? last : index - 1;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = last;
+    else return;
+
+    e.preventDefault();
+    focusTab(next);
+  };
+
+  const activeTab = tabs.find((t) => t.key === active) ?? tabs[0];
 
   return (
     <section>
@@ -64,28 +141,30 @@ export function ContentTabs({
         aria-label="出演コンテンツ"
         className="mb-4 flex flex-wrap gap-1 overflow-x-auto border-b border-brand-border-dark"
       >
-        {orderedTabs.map((tab) => {
-          const isActive = tab === active;
+        {tabs.map((tab, index) => {
+          const isActive = tab.key === active;
           return (
             <button
-              key={tab}
-              id={`tab-${tab}`}
+              key={tab.key}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              id={`tab-${tab.key}`}
               role="tab"
               type="button"
-              aria-controls={`tabpanel-${tab}`}
+              aria-controls={`tabpanel-${tab.key}`}
               aria-selected={isActive}
               tabIndex={isActive ? 0 : -1}
-              onClick={() => setActive(tab)}
+              onKeyDown={(e) => onTabKeyDown(e, index)}
+              onClick={() => setActive(tab.key)}
               className={`-mb-px shrink-0 border-b-2 px-3 py-2 text-sm transition ${
                 isActive
                   ? "border-brand-sky text-brand-sky-light"
                   : "border-transparent text-brand-muted hover:text-brand-cream"
               }`}
             >
-              {TAB_LABEL[tab]}
-              <span className="ml-1 text-xs text-brand-muted">
-                {counts[tab]}
-              </span>
+              {tab.label}
+              <span className="ml-1 text-xs text-brand-muted">{tab.count}</span>
             </button>
           );
         })}
@@ -93,78 +172,14 @@ export function ContentTabs({
 
       <div
         role="tabpanel"
-        id={`tabpanel-${active}`}
-        aria-labelledby={`tab-${active}`}
+        id={`tabpanel-${activeTab.key}`}
+        aria-labelledby={`tab-${activeTab.key}`}
       >
-        {active === "videos" ? (
-          videos.length > 0 ? (
-            <ul className="grid grid-cols-2 gap-4 md:grid-cols-3">
-              {videos.map((v) => (
-                <li key={v.id}>
-                  <VideoCard video={v} />
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <EmptyState message={EMPTY_LABEL.videos} />
-          )
-        ) : null}
-
-        {active === "lives" ? (
-          lives.length > 0 ? (
-            <ul className="space-y-3">
-              {lives.map((l) => (
-                <li key={l.id}>
-                  <LiveCard live={l} variant="past" />
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <EmptyState message={EMPTY_LABEL.lives} />
-          )
-        ) : null}
-
-        {active === "radios" ? (
-          radios.length > 0 ? (
-            <ul className="space-y-3">
-              {radios.map((r) => (
-                <li key={r.id}>
-                  <RadioCard radio={r} />
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <EmptyState message={EMPTY_LABEL.radios} />
-          )
-        ) : null}
-
-        {active === "tv" ? (
-          tvShows.length > 0 ? (
-            <ul className="space-y-3">
-              {tvShows.map((t) => (
-                <li key={t.id}>
-                  <TvShowCard tvShow={t} />
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <EmptyState message={EMPTY_LABEL.tv} />
-          )
-        ) : null}
-
-        {active === "articles" ? (
-          articles.length > 0 ? (
-            <ul className="space-y-3">
-              {articles.map((a) => (
-                <li key={a.id}>
-                  <ArticleCard article={a} />
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <EmptyState message={EMPTY_LABEL.articles} />
-          )
-        ) : null}
+        {activeTab.count > 0 ? (
+          <ul className={activeTab.listClassName}>{activeTab.render()}</ul>
+        ) : (
+          <EmptyState message={activeTab.emptyLabel} />
+        )}
       </div>
     </section>
   );

--- a/src/components/features/combo/combo-profile.tsx
+++ b/src/components/features/combo/combo-profile.tsx
@@ -1,0 +1,130 @@
+import Link from "next/link";
+import { SnsLinks } from "@/components/features/sns/sns-links";
+import type { Achievement } from "@/lib/types/achievement";
+import type { Combo, ComboMemberWithArtist } from "@/lib/types/combo";
+
+const GROUP_TYPE_LABEL: Record<Combo["group_type"], string> = {
+  combo: "コンビ",
+  trio: "トリオ",
+  quartet: "カルテット",
+  other: "その他",
+};
+
+type Props = {
+  combo: Combo;
+  members: ComboMemberWithArtist[];
+  achievements: Achievement[];
+};
+
+export function ComboProfile({ combo, members, achievements }: Props) {
+  const accent = combo.theme_color ?? undefined;
+  const sortedMembers = [...members].sort((a, b) => {
+    const ka = a.artist.kana_name ?? "";
+    const kb = b.artist.kana_name ?? "";
+    const cmp = ka.localeCompare(kb);
+    return cmp !== 0 ? cmp : a.artist.name.localeCompare(b.artist.name);
+  });
+
+  return (
+    <header className="space-y-6">
+      <div className="flex flex-col gap-5 md:flex-row md:items-start">
+        <div className="flex h-32 w-32 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-brand-border-dark bg-brand-card-dark md:h-40 md:w-40">
+          {combo.image_url ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img
+              src={combo.image_url}
+              alt={combo.name}
+              loading="lazy"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <span className="text-xs text-brand-muted">No Image</span>
+          )}
+        </div>
+        <div className="flex-1 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className="inline-flex items-center rounded-full border border-brand-border-dark bg-brand-card-dark px-2 py-0.5 text-[11px] text-brand-sky-light"
+              style={accent ? { borderColor: accent, color: accent } : undefined}
+            >
+              {GROUP_TYPE_LABEL[combo.group_type]}
+            </span>
+            {combo.formed_year ? (
+              <span className="text-xs text-brand-muted">
+                結成 {combo.formed_year}年
+              </span>
+            ) : null}
+          </div>
+          <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+            {combo.name}
+          </h1>
+          {combo.kana_name ? (
+            <p className="text-sm text-brand-gold">{combo.kana_name}</p>
+          ) : null}
+          {combo.description ? (
+            <p className="whitespace-pre-wrap text-sm leading-relaxed text-brand-cream md:text-base">
+              {combo.description}
+            </p>
+          ) : null}
+          <div className="pt-1">
+            <SnsLinks sns={combo} />
+          </div>
+        </div>
+      </div>
+
+      {sortedMembers.length > 0 ? (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold text-brand-cream md:text-base">
+            メンバー
+          </h2>
+          <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {sortedMembers.map((m) => (
+              <li key={m.id}>
+                <Link
+                  href={`/artists/${m.artist.id}`}
+                  className="block rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-3 transition hover:border-brand-sky-light"
+                >
+                  <p className="text-sm font-semibold text-brand-cream">
+                    {m.artist.name}
+                  </p>
+                  <div className="mt-1 flex flex-wrap items-baseline gap-x-2 text-xs text-brand-muted">
+                    {m.artist.kana_name ? (
+                      <span>{m.artist.kana_name}</span>
+                    ) : null}
+                    {m.role ? (
+                      <span className="text-brand-sky-light">{m.role}</span>
+                    ) : null}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {achievements.length > 0 ? (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold text-brand-cream md:text-base">
+            受賞歴
+          </h2>
+          <ul className="space-y-2">
+            {achievements.map((a) => (
+              <li
+                key={a.id}
+                className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-3"
+              >
+                <div className="flex flex-wrap items-baseline gap-x-3">
+                  <span className="text-xs font-medium text-brand-gold">
+                    {a.year}
+                  </span>
+                  <span className="text-sm text-brand-cream">{a.title}</span>
+                </div>
+                <p className="mt-1 text-xs text-brand-sky-light">{a.result}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </header>
+  );
+}

--- a/src/components/features/live/live-card.tsx
+++ b/src/components/features/live/live-card.tsx
@@ -1,24 +1,7 @@
 import Link from "next/link";
-import type { CastEntry, CastType } from "@/lib/types";
+import { PerformerTagList } from "@/components/shared/performer-tags";
 import type { LiveWithCasts } from "@/lib/types/live";
 import { formatDate, formatTime } from "@/lib/utils/date";
-
-const CAST_PATH: Record<CastType, string> = {
-  artist: "/artists",
-  comedy_group: "/combos",
-  unit: "/units",
-};
-
-function CastTag({ cast }: { cast: CastEntry }) {
-  return (
-    <Link
-      href={`${CAST_PATH[cast.type]}/${cast.id}`}
-      className="inline-flex items-center rounded-full border border-brand-border-dark bg-brand-bg-dark px-2 py-0.5 text-xs text-brand-gold transition hover:border-brand-sky-light hover:text-brand-sky-light"
-    >
-      {cast.name}
-    </Link>
-  );
-}
 
 export function LiveCard({
   live,
@@ -56,13 +39,9 @@ export function LiveCard({
         </p>
       </Link>
       {live.casts.length > 0 ? (
-        <ul className="mt-2 flex flex-wrap gap-1.5">
-          {live.casts.map((cast) => (
-            <li key={`${cast.type}-${cast.id}`}>
-              <CastTag cast={cast} />
-            </li>
-          ))}
-        </ul>
+        <div className="mt-2">
+          <PerformerTagList performers={live.casts} />
+        </div>
       ) : null}
     </article>
   );

--- a/src/components/features/radio/radio-card.tsx
+++ b/src/components/features/radio/radio-card.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { CastTagList } from "@/components/shared/cast-tag";
+import { PerformerTagList } from "@/components/shared/performer-tags";
 import type { RadioWithCasts } from "@/lib/types/radio";
 import { formatDate } from "@/lib/utils/date";
 
@@ -39,7 +39,7 @@ export function RadioCard({ radio }: { radio: RadioWithCasts }) {
       ) : null}
       {radio.casts.length > 0 ? (
         <div className="mt-2">
-          <CastTagList casts={radio.casts} />
+          <PerformerTagList performers={radio.casts} />
         </div>
       ) : null}
     </article>

--- a/src/components/features/sns/sns-links.tsx
+++ b/src/components/features/sns/sns-links.tsx
@@ -1,3 +1,5 @@
+import { normalizeExternalUrl } from "@/lib/utils/url";
+
 export type SnsInput = {
   x_url?: string | null;
   instagram_url?: string | null;
@@ -22,19 +24,6 @@ const LINKS: SnsLink[] = [
   { key: "standfm_url", label: "stand.fm" },
   { key: "website_url", label: "Web" },
 ];
-
-function normalizeExternalUrl(value: string | null | undefined): string | null {
-  if (!value) return null;
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  try {
-    const url = new URL(trimmed);
-    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
-    return url.toString();
-  } catch {
-    return null;
-  }
-}
 
 export function SnsLinks({ sns }: { sns: SnsInput }) {
   const items = LINKS.flatMap((link) => {

--- a/src/components/features/sns/sns-links.tsx
+++ b/src/components/features/sns/sns-links.tsx
@@ -23,10 +23,23 @@ const LINKS: SnsLink[] = [
   { key: "website_url", label: "Web" },
 ];
 
+function normalizeExternalUrl(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
 export function SnsLinks({ sns }: { sns: SnsInput }) {
-  const items = LINKS.filter((link) => {
-    const value = sns[link.key];
-    return typeof value === "string" && value.length > 0;
+  const items = LINKS.flatMap((link) => {
+    const href = normalizeExternalUrl(sns[link.key]);
+    return href ? [{ ...link, href }] : [];
   });
 
   if (items.length === 0) return null;
@@ -36,7 +49,7 @@ export function SnsLinks({ sns }: { sns: SnsInput }) {
       {items.map((link) => (
         <li key={link.key}>
           <a
-            href={sns[link.key] as string}
+            href={link.href}
             target="_blank"
             rel="noreferrer noopener"
             className="inline-flex items-center rounded-full border border-brand-border-dark bg-brand-card-dark px-3 py-1 text-xs font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"

--- a/src/components/features/sns/sns-links.tsx
+++ b/src/components/features/sns/sns-links.tsx
@@ -1,0 +1,50 @@
+export type SnsInput = {
+  x_url?: string | null;
+  instagram_url?: string | null;
+  note_url?: string | null;
+  youtube_channel_url?: string | null;
+  standfm_url?: string | null;
+  tiktok_url?: string | null;
+  website_url?: string | null;
+};
+
+type SnsLink = {
+  key: keyof SnsInput;
+  label: string;
+};
+
+const LINKS: SnsLink[] = [
+  { key: "x_url", label: "X" },
+  { key: "instagram_url", label: "Instagram" },
+  { key: "youtube_channel_url", label: "YouTube" },
+  { key: "tiktok_url", label: "TikTok" },
+  { key: "note_url", label: "note" },
+  { key: "standfm_url", label: "stand.fm" },
+  { key: "website_url", label: "Web" },
+];
+
+export function SnsLinks({ sns }: { sns: SnsInput }) {
+  const items = LINKS.filter((link) => {
+    const value = sns[link.key];
+    return typeof value === "string" && value.length > 0;
+  });
+
+  if (items.length === 0) return null;
+
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {items.map((link) => (
+        <li key={link.key}>
+          <a
+            href={sns[link.key] as string}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center rounded-full border border-brand-border-dark bg-brand-card-dark px-3 py-1 text-xs font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"
+          >
+            {link.label} ↗
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/features/topic/topic-card.tsx
+++ b/src/components/features/topic/topic-card.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { CastTagList } from "@/components/shared/cast-tag";
+import { PerformerTagList } from "@/components/shared/performer-tags";
 import type { TopicWithCasts } from "@/lib/types/topic";
 import { formatDate } from "@/lib/utils/date";
 
@@ -39,7 +39,7 @@ export function TopicCard({ topic }: { topic: TopicWithCasts }) {
       ) : null}
       {topic.casts.length > 0 ? (
         <div className="mt-2">
-          <CastTagList casts={topic.casts} />
+          <PerformerTagList performers={topic.casts} />
         </div>
       ) : null}
     </article>

--- a/src/components/features/tv-show/tv-show-card.tsx
+++ b/src/components/features/tv-show/tv-show-card.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { CastTagList } from "@/components/shared/cast-tag";
+import { PerformerTagList } from "@/components/shared/performer-tags";
 import type { TvShowWithCasts } from "@/lib/types/tv-show";
 import { formatDate, formatTime } from "@/lib/utils/date";
 
@@ -29,7 +29,7 @@ export function TvShowCard({ tvShow }: { tvShow: TvShowWithCasts }) {
       </Link>
       {tvShow.casts.length > 0 ? (
         <div className="mt-2">
-          <CastTagList casts={tvShow.casts} />
+          <PerformerTagList performers={tvShow.casts} />
         </div>
       ) : null}
     </article>

--- a/src/components/shared/performer-tags.tsx
+++ b/src/components/shared/performer-tags.tsx
@@ -1,30 +1,30 @@
 import Link from "next/link";
 import type { CastEntry, CastType } from "@/lib/types";
 
-const CAST_PATH: Record<CastType, string> = {
+const PERFORMER_PATH: Record<CastType, string> = {
   artist: "/artists",
   comedy_group: "/combos",
   unit: "/units",
 };
 
-export function CastTag({ cast }: { cast: CastEntry }) {
+export function PerformerTag({ performer }: { performer: CastEntry }) {
   return (
     <Link
-      href={`${CAST_PATH[cast.type]}/${cast.id}`}
+      href={`${PERFORMER_PATH[performer.type]}/${performer.id}`}
       className="inline-flex items-center rounded-full border border-brand-border-dark bg-brand-bg-dark px-2 py-0.5 text-xs text-brand-gold transition hover:border-brand-sky-light hover:text-brand-sky-light"
     >
-      {cast.name}
+      {performer.name}
     </Link>
   );
 }
 
-export function CastTagList({ casts }: { casts: CastEntry[] }) {
-  if (casts.length === 0) return null;
+export function PerformerTagList({ performers }: { performers: CastEntry[] }) {
+  if (performers.length === 0) return null;
   return (
     <ul className="flex flex-wrap gap-1.5">
-      {casts.map((cast) => (
-        <li key={`${cast.type}-${cast.id}`}>
-          <CastTag cast={cast} />
+      {performers.map((performer) => (
+        <li key={`${performer.type}-${performer.id}`}>
+          <PerformerTag performer={performer} />
         </li>
       ))}
     </ul>

--- a/src/lib/queries/achievements.ts
+++ b/src/lib/queries/achievements.ts
@@ -1,6 +1,25 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Achievement, AchievementWithTarget } from "@/lib/types/achievement";
 
+export async function listAchievementsByTarget(
+  field: "artist_id" | "comedy_group_id" | "unit_id",
+  id: string
+): Promise<Achievement[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("achievements")
+    .select("*")
+    .eq(field, id)
+    .order("year", { ascending: false })
+    .order("sort_order", { ascending: true });
+
+  if (error) {
+    throw new Error(`受賞歴の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as Achievement[];
+}
+
 export async function listAchievements(): Promise<AchievementWithTarget[]> {
   const supabase = await createClient();
   const { data, error } = await supabase

--- a/src/lib/queries/combos.ts
+++ b/src/lib/queries/combos.ts
@@ -46,6 +46,54 @@ export async function getCombo(id: string): Promise<ComboWithMembers | null> {
   return (data ?? null) as ComboWithMembers | null;
 }
 
+export type ComboMembershipEntry = {
+  combo: Pick<Combo, "id" | "name" | "kana_name" | "image_url" | "theme_color">;
+  role: string | null;
+};
+
+export async function listCombosForArtist(
+  artistId: string
+): Promise<ComboMembershipEntry[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("comedy_group_members")
+    .select(
+      `role,
+       comedy_group:comedy_groups(id, name, kana_name, image_url, theme_color)`
+    )
+    .eq("artist_id", artistId);
+
+  if (error) {
+    throw new Error(`所属コンビの取得に失敗しました: ${error.message}`);
+  }
+
+  type Row = {
+    role: string | null;
+    comedy_group: {
+      id: string;
+      name: string;
+      kana_name: string | null;
+      image_url: string | null;
+      theme_color: string | null;
+    } | null;
+  };
+
+  const rows = (data ?? []) as unknown as Row[];
+
+  return rows
+    .flatMap<ComboMembershipEntry>((row) =>
+      row.comedy_group
+        ? [{ combo: row.comedy_group, role: row.role }]
+        : []
+    )
+    .sort((a, b) => {
+      const ka = a.combo.kana_name ?? "";
+      const kb = b.combo.kana_name ?? "";
+      const cmp = ka.localeCompare(kb);
+      return cmp !== 0 ? cmp : a.combo.name.localeCompare(b.combo.name);
+    });
+}
+
 export async function listComboSummaries(): Promise<ComboSummary[]> {
   const supabase = await createClient();
   const { data, error } = await supabase

--- a/src/lib/queries/performer-contents.ts
+++ b/src/lib/queries/performer-contents.ts
@@ -1,0 +1,157 @@
+import { createClient } from "@/lib/supabase/server";
+import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import type { ArticleWithCasts } from "@/lib/types/article";
+import type { LiveWithCasts } from "@/lib/types/live";
+import type { RadioWithCasts } from "@/lib/types/radio";
+import type { TvShowWithCasts } from "@/lib/types/tv-show";
+import type { VideoWithCasts } from "@/lib/types/video";
+
+export type PerformerField =
+  | "artist_id"
+  | "comedy_group_id"
+  | "unit_id";
+
+export type PerformerContents = {
+  videos: VideoWithCasts[];
+  lives: LiveWithCasts[];
+  radios: RadioWithCasts[];
+  articles: ArticleWithCasts[];
+  tvShows: TvShowWithCasts[];
+};
+
+const CAST_SUBSELECT = `
+  id,
+  artist_id,
+  comedy_group_id,
+  unit_id,
+  artist:artists(id, name),
+  comedy_group:comedy_groups(id, name),
+  unit:units(id, name)
+`;
+
+type Row = Record<string, unknown>;
+
+function castsOf(record: Row, key: string) {
+  return mapCasts(record[key] as CastRow[] | null | undefined);
+}
+
+export async function getPerformerContents(
+  field: PerformerField,
+  id: string
+): Promise<PerformerContents> {
+  const supabase = await createClient();
+
+  const [videosRes, livesRes, radiosRes, articlesRes, tvShowsRes] =
+    await Promise.all([
+      supabase
+        .from("videos")
+        .select(`*, video_casts!inner(${CAST_SUBSELECT})`)
+        .eq(`video_casts.${field}`, id)
+        .order("published_at", { ascending: false, nullsFirst: false })
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("lives")
+        .select(`*, live_casts!inner(${CAST_SUBSELECT})`)
+        .eq(`live_casts.${field}`, id)
+        .order("event_date", { ascending: false, nullsFirst: false })
+        .order("start_time", { ascending: false, nullsFirst: false })
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("radios")
+        .select(`*, radio_casts!inner(${CAST_SUBSELECT})`)
+        .eq(`radio_casts.${field}`, id)
+        .order("published_at", { ascending: false, nullsFirst: false })
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("articles")
+        .select(`*, article_casts!inner(${CAST_SUBSELECT})`)
+        .eq(`article_casts.${field}`, id)
+        .order("published_at", { ascending: false, nullsFirst: false })
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("tv_shows")
+        .select(`*, tv_show_casts!inner(${CAST_SUBSELECT})`)
+        .eq(`tv_show_casts.${field}`, id)
+        .order("air_date", { ascending: false, nullsFirst: false })
+        .order("air_time", { ascending: false, nullsFirst: false })
+        .order("created_at", { ascending: false }),
+    ]);
+
+  const errors = [videosRes, livesRes, radiosRes, articlesRes, tvShowsRes]
+    .map((r) => r.error)
+    .filter((e): e is NonNullable<typeof e> => e !== null);
+  if (errors.length > 0) {
+    throw new Error(`出演コンテンツの取得に失敗しました: ${errors[0].message}`);
+  }
+
+  const videos: VideoWithCasts[] = ((videosRes.data ?? []) as Row[]).map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    youtube_url: (r.youtube_url as string | null) ?? null,
+    youtube_video_id: (r.youtube_video_id as string | null) ?? null,
+    youtube_channel_id: (r.youtube_channel_id as string | null) ?? null,
+    thumbnail_url: (r.thumbnail_url as string | null) ?? null,
+    published_at: (r.published_at as string | null) ?? null,
+    description: (r.description as string | null) ?? null,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: castsOf(r, "video_casts"),
+  }));
+
+  const lives: LiveWithCasts[] = ((livesRes.data ?? []) as Row[]).map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    event_date: (r.event_date as string | null) ?? null,
+    start_time: (r.start_time as string | null) ?? null,
+    venue: (r.venue as string | null) ?? null,
+    description: (r.description as string | null) ?? null,
+    url: (r.url as string | null) ?? null,
+    is_notified: r.is_notified as boolean,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: castsOf(r, "live_casts"),
+  }));
+
+  const radios: RadioWithCasts[] = ((radiosRes.data ?? []) as Row[]).map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    platform: (r.platform as string | null) ?? null,
+    url: (r.url as string | null) ?? null,
+    published_at: (r.published_at as string | null) ?? null,
+    description: (r.description as string | null) ?? null,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: castsOf(r, "radio_casts"),
+  }));
+
+  const articles: ArticleWithCasts[] = ((articlesRes.data ?? []) as Row[]).map(
+    (r) => ({
+      id: r.id as string,
+      title: r.title as string,
+      url: (r.url as string | null) ?? null,
+      source: (r.source as string | null) ?? null,
+      published_at: (r.published_at as string | null) ?? null,
+      content: (r.content as string | null) ?? null,
+      created_at: r.created_at as string,
+      updated_at: r.updated_at as string,
+      casts: castsOf(r, "article_casts"),
+    })
+  );
+
+  const tvShows: TvShowWithCasts[] = ((tvShowsRes.data ?? []) as Row[]).map(
+    (r) => ({
+      id: r.id as string,
+      title: r.title as string,
+      network: (r.network as string | null) ?? null,
+      air_date: (r.air_date as string | null) ?? null,
+      air_time: (r.air_time as string | null) ?? null,
+      description: (r.description as string | null) ?? null,
+      url: (r.url as string | null) ?? null,
+      created_at: r.created_at as string,
+      updated_at: r.updated_at as string,
+      casts: castsOf(r, "tv_show_casts"),
+    })
+  );
+
+  return { videos, lives, radios, articles, tvShows };
+}

--- a/src/lib/queries/performer-contents.ts
+++ b/src/lib/queries/performer-contents.ts
@@ -30,9 +30,36 @@ const CAST_SUBSELECT = `
 `;
 
 type Row = Record<string, unknown>;
+type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
 
 function castsOf(record: Row, key: string) {
   return mapCasts(record[key] as CastRow[] | null | undefined);
+}
+
+async function listMatchingIds<K extends string>(
+  supabase: SupabaseClient,
+  castTable:
+    | "video_casts"
+    | "live_casts"
+    | "radio_casts"
+    | "article_casts"
+    | "tv_show_casts",
+  parentIdField: K,
+  field: PerformerField,
+  id: string
+): Promise<string[]> {
+  const { data, error } = await supabase
+    .from(castTable)
+    .select(parentIdField)
+    .eq(field, id);
+
+  if (error) {
+    throw new Error(`出演コンテンツの取得に失敗しました: ${error.message}`);
+  }
+
+  return ((data ?? []) as Array<Record<K, string>>).map(
+    (row) => row[parentIdField]
+  );
 }
 
 export async function getPerformerContents(
@@ -41,40 +68,59 @@ export async function getPerformerContents(
 ): Promise<PerformerContents> {
   const supabase = await createClient();
 
+  const [videoIds, liveIds, radioIds, articleIds, tvShowIds] =
+    await Promise.all([
+      listMatchingIds(supabase, "video_casts", "video_id", field, id),
+      listMatchingIds(supabase, "live_casts", "live_id", field, id),
+      listMatchingIds(supabase, "radio_casts", "radio_id", field, id),
+      listMatchingIds(supabase, "article_casts", "article_id", field, id),
+      listMatchingIds(supabase, "tv_show_casts", "tv_show_id", field, id),
+    ]);
+
   const [videosRes, livesRes, radiosRes, articlesRes, tvShowsRes] =
     await Promise.all([
-      supabase
-        .from("videos")
-        .select(`*, video_casts!inner(${CAST_SUBSELECT})`)
-        .eq(`video_casts.${field}`, id)
-        .order("published_at", { ascending: false, nullsFirst: false })
-        .order("created_at", { ascending: false }),
-      supabase
-        .from("lives")
-        .select(`*, live_casts!inner(${CAST_SUBSELECT})`)
-        .eq(`live_casts.${field}`, id)
-        .order("event_date", { ascending: false, nullsFirst: false })
-        .order("start_time", { ascending: false, nullsFirst: false })
-        .order("created_at", { ascending: false }),
-      supabase
-        .from("radios")
-        .select(`*, radio_casts!inner(${CAST_SUBSELECT})`)
-        .eq(`radio_casts.${field}`, id)
-        .order("published_at", { ascending: false, nullsFirst: false })
-        .order("created_at", { ascending: false }),
-      supabase
-        .from("articles")
-        .select(`*, article_casts!inner(${CAST_SUBSELECT})`)
-        .eq(`article_casts.${field}`, id)
-        .order("published_at", { ascending: false, nullsFirst: false })
-        .order("created_at", { ascending: false }),
-      supabase
-        .from("tv_shows")
-        .select(`*, tv_show_casts!inner(${CAST_SUBSELECT})`)
-        .eq(`tv_show_casts.${field}`, id)
-        .order("air_date", { ascending: false, nullsFirst: false })
-        .order("air_time", { ascending: false, nullsFirst: false })
-        .order("created_at", { ascending: false }),
+      videoIds.length > 0
+        ? supabase
+            .from("videos")
+            .select(`*, video_casts(${CAST_SUBSELECT})`)
+            .in("id", videoIds)
+            .order("published_at", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+        : Promise.resolve({ data: [], error: null }),
+      liveIds.length > 0
+        ? supabase
+            .from("lives")
+            .select(`*, live_casts(${CAST_SUBSELECT})`)
+            .in("id", liveIds)
+            .order("event_date", { ascending: false, nullsFirst: false })
+            .order("start_time", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+        : Promise.resolve({ data: [], error: null }),
+      radioIds.length > 0
+        ? supabase
+            .from("radios")
+            .select(`*, radio_casts(${CAST_SUBSELECT})`)
+            .in("id", radioIds)
+            .order("published_at", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+        : Promise.resolve({ data: [], error: null }),
+      articleIds.length > 0
+        ? supabase
+            .from("articles")
+            .select(`*, article_casts(${CAST_SUBSELECT})`)
+            .in("id", articleIds)
+            .order("published_at", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+        : Promise.resolve({ data: [], error: null }),
+      tvShowIds.length > 0
+        ? supabase
+            .from("tv_shows")
+            .select(`*, tv_show_casts(${CAST_SUBSELECT})`)
+            .in("id", tvShowIds)
+            .order("air_date", { ascending: false, nullsFirst: false })
+            .order("air_time", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+        : Promise.resolve({ data: [], error: null }),
     ]);
 
   const errors = [videosRes, livesRes, radiosRes, articlesRes, tvShowsRes]

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -1,0 +1,14 @@
+export function normalizeExternalUrl(
+  value: string | null | undefined
+): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 概要

issue #22 対応。公開側のコンビ詳細ページ (`/combos/[id]`) と芸人詳細ページ (`/artists/[id]`) を追加した。各種出演コンテンツ（動画／ライブ／ラジオ／TV／記事）にタブで切り替えてアクセスでき、出演者タグやメンバーカードからの回遊導線を備える。

## 主な変更

### 新規ページ
- `/combos/[id]` — コンビのプロフィール、SNS、メンバー、受賞歴、出演コンテンツ（タブ）
- `/artists/[id]` — 芸人のプロフィール、SNS、所属コンビ、受賞歴、出演コンテンツ（タブ）

### 新規コンポーネント
- `src/components/features/sns/sns-links.tsx` — X / Instagram / YouTube / TikTok / note / stand.fm / Web のリンクをまとめて表示する共通コンポーネント
- `src/components/features/combo/combo-profile.tsx` — コンビのプロフィールヘッダー（画像、種別、結成年、メンバー、受賞歴）
- `src/components/features/combo/combo-content-tabs.tsx` — Videos / Lives / Radio / TV / Articles のタブ切り替え（Client Component）
- `src/components/features/artist/artist-profile.tsx` — 芸人のプロフィールヘッダー（画像、デビュー年、所属コンビ、受賞歴）

### 共通化・リネーム
- `src/components/shared/cast-tag.tsx` → `src/components/shared/performer-tags.tsx` にリネームし、`PerformerTag` / `PerformerTagList` として統一。`live-card` 内の重複実装も置き換え

### クエリの追加
- `src/lib/queries/performer-contents.ts` — `artist_id` / `comedy_group_id` / `unit_id` をキーに 5 種類の出演コンテンツ（videos / lives / radios / articles / tv_shows）を一括取得
- `src/lib/queries/achievements.ts` に `listAchievementsByTarget(field, id)` を追加
- `src/lib/queries/combos.ts` に `listCombosForArtist(artistId)` を追加（芸人の所属コンビ一覧）

## 完了条件のチェック

- [x] コンビ詳細に受賞歴、SNSリンク、メンバー、タブ付きコンテンツが表示される
- [x] 芸人詳細に所属コンビと出演コンテンツが表示される
- [x] タグ、メンバーカードがリンクとして機能する（回遊導線）

## 動作確認 / テスト計画

- [ ] `/combos/[id]` を開き、画像／プロフィール／SNS／メンバー／受賞歴／タブが正しく表示されることを確認
- [ ] `/artists/[id]` を開き、画像／プロフィール／SNS／所属コンビ／受賞歴／タブが正しく表示されることを確認
- [ ] タブの切り替え（Videos / Lives / Radio / TV / Articles）が動作し、空タブで適切なメッセージが出ることを確認
- [ ] メンバーカード → 芸人ページ、所属コンビカード → コンビページ、出演者タグ → 各詳細ページへ遷移することを確認
- [ ] 動画／ライブ／ラジオ／記事／TVの既存ページから出演者タグ経由でコンビ・芸人ページに遷移できることを確認

## 備考

- 型エラーが残っている `src/lib/actions/achievements.ts` および `_casts.ts` / `units.ts` は本 PR の前から存在する既存の問題のため、本 PR の対象外
- メモ機能 (#20 想定) は別 issue のため未対応

Closes #22

---
_Generated by [Claude Code](https://claude.ai/code/session_012Eup3VzEn4jxtMTt83KKWR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detail pages for artists, combos, units, lives, radios, TV shows, topics and articles with rich profiles, memberships, achievements and SEO metadata
  * Listing pages for artists, combos and units with responsive cards and image fallbacks
  * Tabbed content view for videos, lives, radios, TV shows and articles
  * New artist/combo profile and social-links UI

* **Improvements**
  * Unified performer tag UI across cards, lists and detail pages
  * Faster, more complete loading of achievements, memberships and performer-related content
<!-- end of auto-generated comment: release notes by coderabbit.ai -->