### PR TITLE
feat: タグ機能（DB + 管理画面）を追加

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -18,6 +18,7 @@ const CARDS: DashboardCard[] = [
   { label: "記事", table: "articles", href: "/admin/articles" },
   { label: "テレビ", table: "tv_shows", href: "/admin/tv" },
   { label: "トピック", table: "topics", href: "/admin/topics" },
+  { label: "タグ", table: "tags", href: "/admin/tags" },
 ];
 
 async function fetchCounts() {

--- a/src/app/admin/tags/[id]/edit/page.tsx
+++ b/src/app/admin/tags/[id]/edit/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { TagForm } from "@/components/features/tag/tag-form";
+import { updateTag } from "@/lib/actions/tags";
+import { getTag } from "@/lib/queries/tags";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditTagPage({ params }: Props) {
+  const { id } = await params;
+  const tag = await getTag(id);
+
+  if (!tag) {
+    notFound();
+  }
+
+  const action = updateTag.bind(null, id);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/tags"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← タグ一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          タグを編集
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <TagForm action={action} initialValues={tag} submitLabel="更新する" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/tags/new/page.tsx
+++ b/src/app/admin/tags/new/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { TagForm } from "@/components/features/tag/tag-form";
+import { createTag } from "@/lib/actions/tags";
+
+export const dynamic = "force-dynamic";
+
+export default function NewTagPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/tags"
+          className="text-xs text-brand-brown-light transition hover:text-brand-sky"
+        >
+          ← タグ一覧
+        </Link>
+        <h1 className="mt-1 text-xl font-bold text-brand-brown-dark">
+          タグを新規作成
+        </h1>
+      </div>
+
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+        <TagForm action={createTag} submitLabel="作成する" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/tags/page.tsx
+++ b/src/app/admin/tags/page.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+import { TagDeleteButton } from "@/components/features/tag/tag-delete-button";
+import { deleteTag } from "@/lib/actions/tags";
+import { listTags } from "@/lib/queries/tags";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminTagsPage() {
+  const tags = await listTags();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-brand-brown-dark">タグ</h1>
+          <p className="mt-1 text-sm text-brand-brown-light">
+            動画・ライブ・記事などコンテンツ横断のタグを管理します。
+          </p>
+        </div>
+        <Link
+          href="/admin/tags/new"
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark"
+        >
+          新規作成
+        </Link>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+        {tags.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
+            まだタグが登録されていません。
+          </p>
+        ) : (
+          <table className="min-w-full divide-y divide-brand-border-light text-sm">
+            <thead className="bg-brand-bg-light text-xs text-brand-brown-light">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium">タグ名</th>
+                <th className="px-4 py-2 text-left font-medium">スラッグ</th>
+                <th className="px-4 py-2 text-left font-medium">色</th>
+                <th className="px-4 py-2 text-left font-medium">紐付け数</th>
+                <th className="px-4 py-2 text-right font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-brand-border-light">
+              {tags.map((tag) => (
+                <tr key={tag.id} className="hover:bg-brand-bg-light">
+                  <td className="px-4 py-2 font-medium text-brand-brown-dark">
+                    {tag.name}
+                  </td>
+                  <td className="px-4 py-2 font-mono text-xs text-brand-brown-light">
+                    {tag.slug}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {tag.color ? (
+                      <span className="inline-flex items-center gap-2">
+                        <span
+                          className="inline-block h-4 w-4 rounded border border-brand-border-light"
+                          style={{ backgroundColor: tag.color }}
+                          aria-hidden="true"
+                        />
+                        <span className="font-mono text-xs">{tag.color}</span>
+                      </span>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-brand-brown-light">
+                    {tag.taggings_count}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        href={`/admin/tags/${tag.id}/edit`}
+                        className="rounded-md border border-brand-border-light px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-bg-light"
+                      >
+                        編集
+                      </Link>
+                      <form action={deleteTag}>
+                        <input type="hidden" name="id" value={tag.id} />
+                        <TagDeleteButton name={tag.name} />
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/tag/tag-delete-button.tsx
+++ b/src/components/features/tag/tag-delete-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+
+type Props = {
+  name: string;
+};
+
+export function TagDeleteButton({ name }: Props) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      onClick={(event) => {
+        if (!window.confirm(`「${name}」を削除します。よろしいですか？`)) {
+          event.preventDefault();
+        }
+      }}
+      className="rounded-md border border-brand-gold px-3 py-1 text-xs text-brand-brown-dark transition hover:bg-brand-cream disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {pending ? "削除中..." : "削除"}
+    </button>
+  );
+}

--- a/src/components/features/tag/tag-form.tsx
+++ b/src/components/features/tag/tag-form.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import Link from "next/link";
+import { useActionState, useEffect, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import type { TagFormState } from "@/lib/actions/tags";
+import type { Tag } from "@/lib/types/tag";
+
+type TagFormAction = (
+  prev: TagFormState,
+  formData: FormData
+) => Promise<TagFormState>;
+
+type TagFormValues = {
+  name: string;
+  slug: string;
+  description: string;
+  color: string;
+};
+
+type Props = {
+  action: TagFormAction;
+  initialValues?: Partial<Tag>;
+  submitLabel: string;
+};
+
+export function TagForm({ action, initialValues, submitLabel }: Props) {
+  const [state, formAction] = useActionState<TagFormState, FormData>(
+    action,
+    {}
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<TagFormValues>({
+    defaultValues: {
+      name: initialValues?.name ?? "",
+      slug: initialValues?.slug ?? "",
+      description: initialValues?.description ?? "",
+      color: initialValues?.color ?? "",
+    },
+  });
+
+  useEffect(() => {
+    if (!state.fieldErrors) return;
+    for (const [field, message] of Object.entries(state.fieldErrors)) {
+      if (!message) continue;
+      setError(field as keyof TagFormValues, {
+        type: "server",
+        message,
+      });
+    }
+  }, [state, setError]);
+
+  const onSubmit = handleSubmit((values) => {
+    const formData = new FormData();
+    for (const [key, value] of Object.entries(values)) {
+      formData.append(key, value ?? "");
+    }
+    startTransition(() => {
+      formAction(formData);
+    });
+  });
+
+  const inputClass =
+    "mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-brand-brown-dark placeholder-brand-brown-light focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky";
+
+  return (
+    <form onSubmit={onSubmit} noValidate className="space-y-6">
+      {state.error && (
+        <p
+          className="rounded-md bg-brand-cream px-3 py-2 text-sm text-brand-brown-dark"
+          role="alert"
+        >
+          {state.error}
+        </p>
+      )}
+
+      <Field id="name" label="タグ名" required error={errors.name?.message}>
+        <input
+          id="name"
+          type="text"
+          autoComplete="off"
+          className={inputClass}
+          placeholder="例: M-1グランプリ"
+          {...register("name", {
+            required: "タグ名を入力してください",
+            maxLength: { value: 50, message: "50文字以内で入力してください" },
+          })}
+        />
+      </Field>
+
+      <Field id="slug" label="スラッグ（URL用）" required error={errors.slug?.message}>
+        <input
+          id="slug"
+          type="text"
+          autoComplete="off"
+          className={inputClass}
+          placeholder="例: m-1-grand-prix"
+          {...register("slug", {
+            required: "スラッグを入力してください",
+            maxLength: { value: 50, message: "50文字以内で入力してください" },
+            pattern: {
+              value: /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+              message: "半角英数字とハイフンのみ使用できます",
+            },
+          })}
+        />
+        <p className="mt-1 text-xs text-brand-brown-light">
+          半角英数字とハイフンのみ。URL に使われます（例: /tags/m-1-grand-prix）。
+        </p>
+      </Field>
+
+      <Field id="description" label="説明" error={errors.description?.message}>
+        <textarea
+          id="description"
+          rows={3}
+          className={inputClass}
+          placeholder="このタグの説明（任意）"
+          {...register("description", {
+            maxLength: { value: 200, message: "200文字以内で入力してください" },
+          })}
+        />
+      </Field>
+
+      <Field id="color" label="表示色（任意）" error={errors.color?.message}>
+        <div className="mt-1 flex items-center gap-3">
+          <input
+            id="color"
+            type="text"
+            autoComplete="off"
+            className={inputClass}
+            placeholder="#6BB8D4"
+            {...register("color", {
+              pattern: {
+                value: /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/,
+                message: "#RGB または #RRGGBB の形式で入力してください",
+              },
+            })}
+          />
+        </div>
+      </Field>
+
+      <div className="flex items-center gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-brand-cream transition hover:bg-brand-sky-dark disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isPending ? "保存中..." : submitLabel}
+        </button>
+        <Link
+          href="/admin/tags"
+          className="rounded-md border border-brand-border-light px-4 py-2 text-sm text-brand-brown-dark transition hover:bg-brand-bg-light"
+        >
+          キャンセル
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  id,
+  label,
+  required,
+  error,
+  children,
+}: {
+  id: string;
+  label: string;
+  required?: boolean;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="block text-sm font-medium text-brand-brown-dark"
+      >
+        {label}
+        {required && <span className="ml-1 text-brand-gold">*</span>}
+      </label>
+      {children}
+      {error && (
+        <p className="mt-1 text-xs text-brand-gold" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/admin-sidebar.tsx
+++ b/src/components/layout/admin-sidebar.tsx
@@ -20,6 +20,7 @@ const NAV_ITEMS: AdminNavItem[] = [
   { href: "/admin/articles", label: "記事（Articles）" },
   { href: "/admin/tv", label: "テレビ（TV）" },
   { href: "/admin/topics", label: "トピック（Topics）" },
+  { href: "/admin/tags", label: "タグ（Tags）" },
 ];
 
 function isActive(pathname: string, href: string) {

--- a/src/lib/actions/tags.ts
+++ b/src/lib/actions/tags.ts
@@ -125,13 +125,21 @@ export async function updateTag(
     return { error: "認証が必要です" };
   }
 
-  const { error } = await supabase.from("tags").update(values).eq("id", id);
+  const { data, error } = await supabase
+    .from("tags")
+    .update(values)
+    .eq("id", id)
+    .select("id")
+    .maybeSingle();
 
   if (error) {
     if (error.code === "23505") {
       return { fieldErrors: uniqueViolationFieldErrors(error) };
     }
     return { error: `タグの更新に失敗しました: ${error.message}` };
+  }
+  if (!data) {
+    return { error: "対象のタグが見つかりません" };
   }
 
   revalidatePath("/admin/tags");
@@ -153,10 +161,18 @@ export async function deleteTag(formData: FormData): Promise<void> {
     throw new Error("認証が必要です");
   }
 
-  const { error } = await supabase.from("tags").delete().eq("id", id);
+  const { data, error } = await supabase
+    .from("tags")
+    .delete()
+    .eq("id", id)
+    .select("id")
+    .maybeSingle();
 
   if (error) {
     throw new Error(`タグの削除に失敗しました: ${error.message}`);
+  }
+  if (!data) {
+    throw new Error("対象のタグが見つかりません");
   }
 
   revalidatePath("/admin/tags");

--- a/src/lib/actions/tags.ts
+++ b/src/lib/actions/tags.ts
@@ -1,0 +1,161 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type { TagInput } from "@/lib/types/tag";
+
+export type TagFormState = {
+  error?: string;
+  fieldErrors?: Partial<Record<keyof TagInput, string>>;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const COLOR_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+function toNullableString(value: FormDataEntryValue | null): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function parseFormData(formData: FormData): {
+  values: TagInput;
+  fieldErrors: TagFormState["fieldErrors"];
+} {
+  const fieldErrors: TagFormState["fieldErrors"] = {};
+
+  const name = String(formData.get("name") ?? "").trim();
+  if (!name) {
+    fieldErrors.name = "タグ名を入力してください";
+  } else if (name.length > 50) {
+    fieldErrors.name = "50文字以内で入力してください";
+  }
+
+  const slug = String(formData.get("slug") ?? "").trim();
+  if (!slug) {
+    fieldErrors.slug = "スラッグを入力してください";
+  } else if (slug.length > 50) {
+    fieldErrors.slug = "50文字以内で入力してください";
+  } else if (!SLUG_PATTERN.test(slug)) {
+    fieldErrors.slug = "半角英数字とハイフンのみ使用できます（例: m-1-grand-prix）";
+  }
+
+  const description = toNullableString(formData.get("description"));
+  if (description !== null && description.length > 200) {
+    fieldErrors.description = "200文字以内で入力してください";
+  }
+
+  const color = toNullableString(formData.get("color"));
+  if (color !== null && !COLOR_PATTERN.test(color)) {
+    fieldErrors.color = "#RGB または #RRGGBB の形式で入力してください";
+  }
+
+  const values: TagInput = {
+    name,
+    slug,
+    description,
+    color,
+  };
+
+  return { values, fieldErrors };
+}
+
+export async function createTag(
+  _prev: TagFormState,
+  formData: FormData
+): Promise<TagFormState> {
+  const { values, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
+  const { error } = await supabase.from("tags").insert(values);
+
+  if (error) {
+    if (error.code === "23505") {
+      return {
+        fieldErrors: {
+          name: "同じ名前またはスラッグのタグが既に存在します",
+        },
+      };
+    }
+    return { error: `タグの登録に失敗しました: ${error.message}` };
+  }
+
+  revalidatePath("/admin/tags");
+  redirect("/admin/tags");
+}
+
+export async function updateTag(
+  id: string,
+  _prev: TagFormState,
+  formData: FormData
+): Promise<TagFormState> {
+  if (!UUID_PATTERN.test(id)) {
+    return { error: "IDが不正です" };
+  }
+
+  const { values, fieldErrors } = parseFormData(formData);
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors };
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: "認証が必要です" };
+  }
+
+  const { error } = await supabase.from("tags").update(values).eq("id", id);
+
+  if (error) {
+    if (error.code === "23505") {
+      return {
+        fieldErrors: {
+          name: "同じ名前またはスラッグのタグが既に存在します",
+        },
+      };
+    }
+    return { error: `タグの更新に失敗しました: ${error.message}` };
+  }
+
+  revalidatePath("/admin/tags");
+  revalidatePath(`/admin/tags/${id}/edit`);
+  redirect("/admin/tags");
+}
+
+export async function deleteTag(formData: FormData): Promise<void> {
+  const id = String(formData.get("id") ?? "").trim();
+  if (!id) return;
+  if (!UUID_PATTERN.test(id)) {
+    throw new Error("IDが不正です");
+  }
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    throw new Error("認証が必要です");
+  }
+
+  const { error } = await supabase.from("tags").delete().eq("id", id);
+
+  if (error) {
+    throw new Error(`タグの削除に失敗しました: ${error.message}`);
+  }
+
+  revalidatePath("/admin/tags");
+  redirect("/admin/tags");
+}

--- a/src/lib/actions/tags.ts
+++ b/src/lib/actions/tags.ts
@@ -16,6 +16,17 @@ const UUID_PATTERN =
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const COLOR_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
 
+function uniqueViolationFieldErrors(error: {
+  message: string;
+  details?: string | null;
+}): TagFormState["fieldErrors"] {
+  const detail = `${error.message} ${error.details ?? ""}`;
+  if (detail.includes("tags_slug_key") || detail.includes("(slug)")) {
+    return { slug: "同じスラッグのタグが既に存在します" };
+  }
+  return { name: "同じ名前のタグが既に存在します" };
+}
+
 function toNullableString(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
@@ -84,11 +95,7 @@ export async function createTag(
 
   if (error) {
     if (error.code === "23505") {
-      return {
-        fieldErrors: {
-          name: "同じ名前またはスラッグのタグが既に存在します",
-        },
-      };
+      return { fieldErrors: uniqueViolationFieldErrors(error) };
     }
     return { error: `タグの登録に失敗しました: ${error.message}` };
   }
@@ -122,11 +129,7 @@ export async function updateTag(
 
   if (error) {
     if (error.code === "23505") {
-      return {
-        fieldErrors: {
-          name: "同じ名前またはスラッグのタグが既に存在します",
-        },
-      };
+      return { fieldErrors: uniqueViolationFieldErrors(error) };
     }
     return { error: `タグの更新に失敗しました: ${error.message}` };
   }

--- a/src/lib/queries/tags.ts
+++ b/src/lib/queries/tags.ts
@@ -1,6 +1,9 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Tag, TagSummary, TagWithCount } from "@/lib/types/tag";
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function listTags(): Promise<TagWithCount[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
@@ -41,6 +44,8 @@ export async function listTagSummaries(): Promise<TagSummary[]> {
 }
 
 export async function getTag(id: string): Promise<Tag | null> {
+  if (!UUID_PATTERN.test(id)) return null;
+
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("tags")

--- a/src/lib/queries/tags.ts
+++ b/src/lib/queries/tags.ts
@@ -1,0 +1,71 @@
+import { createClient } from "@/lib/supabase/server";
+import type { Tag, TagSummary, TagWithCount } from "@/lib/types/tag";
+
+export async function listTags(): Promise<TagWithCount[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .select("*, taggings(count)")
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw new Error(`タグ一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  type Row = Tag & { taggings: { count: number }[] };
+
+  return ((data ?? []) as Row[]).map((row) => ({
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description,
+    color: row.color,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    taggings_count: row.taggings[0]?.count ?? 0,
+  }));
+}
+
+export async function listTagSummaries(): Promise<TagSummary[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .select("id, name, slug, color")
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw new Error(`タグ一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? []) as TagSummary[];
+}
+
+export async function getTag(id: string): Promise<Tag | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`タグの取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? null) as Tag | null;
+}
+
+export async function getTagBySlug(slug: string): Promise<Tag | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .select("*")
+    .eq("slug", slug)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`タグの取得に失敗しました: ${error.message}`);
+  }
+
+  return (data ?? null) as Tag | null;
+}

--- a/src/lib/types/tag.ts
+++ b/src/lib/types/tag.ts
@@ -1,0 +1,32 @@
+import type { ContentType } from "@/lib/types";
+
+export type Tag = {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  color: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TagInput = {
+  name: string;
+  slug: string;
+  description: string | null;
+  color: string | null;
+};
+
+export type TagSummary = Pick<Tag, "id" | "name" | "slug" | "color">;
+
+export type Tagging = {
+  id: string;
+  tag_id: string;
+  target_type: ContentType;
+  target_id: string;
+  created_at: string;
+};
+
+export type TagWithCount = Tag & {
+  taggings_count: number;
+};

--- a/supabase/migrations/004_tags_and_taggings.sql
+++ b/supabase/migrations/004_tags_and_taggings.sql
@@ -17,6 +17,13 @@ create table tags (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
 
+  -- アプリ側（src/lib/actions/tags.ts）と同じ制約をDBレベルでも担保する
+  check (char_length(btrim(name)) between 1 and 50),
+  check (char_length(slug) between 1 and 50),
+  check (slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'),
+  check (description is null or char_length(description) <= 200),
+  check (color is null or color ~* '^#(?:[0-9a-f]{3}|[0-9a-f]{6})$'),
+
   unique (name),
   unique (slug)
 );

--- a/supabase/migrations/004_tags_and_taggings.sql
+++ b/supabase/migrations/004_tags_and_taggings.sql
@@ -19,9 +19,15 @@ create table tags (
 
   -- アプリ側（src/lib/actions/tags.ts）と同じ制約をDBレベルでも担保する
   check (char_length(btrim(name)) between 1 and 50),
+  check (name = btrim(name)),
   check (char_length(slug) between 1 and 50),
   check (slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'),
-  check (description is null or char_length(description) <= 200),
+  check (
+    description is null or (
+      description = btrim(description)
+      and char_length(description) <= 200
+    )
+  ),
   check (color is null or color ~* '^#(?:[0-9a-f]{3}|[0-9a-f]{6})$'),
 
   unique (name),

--- a/supabase/migrations/004_tags_and_taggings.sql
+++ b/supabase/migrations/004_tags_and_taggings.sql
@@ -1,0 +1,68 @@
+-- ============================================
+-- タグ機能（tags + taggings）
+-- ============================================
+-- 各コンテンツ（video/live/radio/article/tv_show/topic）を
+-- 横断的に分類するためのタグ機構。
+-- taggings は memos と同じくポリモーフィック設計（target_type + target_id）。
+
+-- ============================================
+-- 1. tags
+-- ============================================
+create table tags (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text not null,                          -- URL用の一意なスラッグ
+  description text,
+  color text,                                  -- 表示色（例: #6BB8D4）
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  unique (name),
+  unique (slug)
+);
+
+comment on table tags is 'コンテンツ横断のタグマスタ';
+
+-- ============================================
+-- 2. taggings（ポリモーフィック）
+-- ============================================
+create table taggings (
+  id uuid primary key default gen_random_uuid(),
+  tag_id uuid not null references tags(id) on delete cascade,
+  target_type text not null
+    check (target_type in ('video', 'live', 'radio', 'article', 'tv_show', 'topic')),
+  target_id uuid not null,
+  created_at timestamptz not null default now(),
+
+  unique (tag_id, target_type, target_id)
+);
+
+comment on table taggings is 'タグと各コンテンツの紐付け（ポリモーフィック設計）';
+
+-- ============================================
+-- インデックス
+-- ============================================
+create index idx_taggings_target on taggings(target_type, target_id);
+create index idx_taggings_tag on taggings(tag_id);
+
+-- ============================================
+-- updated_at 自動更新トリガー
+-- ============================================
+create trigger trg_tags_updated before update on tags
+  for each row execute function update_updated_at();
+
+-- ============================================
+-- RLS
+-- ============================================
+alter table tags enable row level security;
+alter table taggings enable row level security;
+
+create policy tags_select on tags for select to anon, authenticated using (true);
+create policy tags_insert on tags for insert to authenticated with check (true);
+create policy tags_update on tags for update to authenticated using (true) with check (true);
+create policy tags_delete on tags for delete to authenticated using (true);
+
+create policy taggings_select on taggings for select to anon, authenticated using (true);
+create policy taggings_insert on taggings for insert to authenticated with check (true);
+create policy taggings_update on taggings for update to authenticated using (true) with check (true);
+create policy taggings_delete on taggings for delete to authenticated using (true);


### PR DESCRIPTION
## 概要

issue #27 「2-1 タグ機能（DB + 管理画面）」の対応です。

- `tags` / `taggings` テーブルを追加
- 管理画面でタグの CRUD ができる UI を追加

Closes #27

## 変更内容

### DB マイグレーション

`supabase/migrations/004_tags_and_taggings.sql` を追加。

- **`tags` テーブル**: `id` / `name` (unique) / `slug` (unique) / `description` / `color` / `created_at` / `updated_at`
- **`taggings` テーブル**: `memos` と同じポリモーフィック設計（`target_type` + `target_id`）。`target_type` は `video` / `live` / `radio` / `article` / `tv_show` / `topic` のいずれか
- `(tag_id, target_type, target_id)` の UNIQUE 制約と `(target_type, target_id)` / `(tag_id)` のインデックス
- 既存テーブルと同じパターンで RLS（読み取り公開・書き込み認証ユーザーのみ）

### 型・データ層

- `src/lib/types/tag.ts` — `Tag` / `TagInput` / `TagSummary` / `Tagging` / `TagWithCount`
- `src/lib/queries/tags.ts` — `listTags` / `listTagSummaries` / `getTag` / `getTagBySlug`
  - `listTags` は taggings 件数も同時取得（管理画面で「紐付け数」を表示）
- `src/lib/actions/tags.ts` — `createTag` / `updateTag` / `deleteTag`
  - スラッグは `^[a-z0-9]+(?:-[a-z0-9]+)*$`、色は `#RGB` / `#RRGGBB` のバリデーション
  - 一意制約違反は `name` フィールドエラーとして返却

### 管理画面 UI

- `src/app/admin/tags/page.tsx` — 一覧（タグ名・スラッグ・色プレビュー・紐付け数）
- `src/app/admin/tags/new/page.tsx` — 新規作成
- `src/app/admin/tags/[id]/edit/page.tsx` — 編集
- `src/components/features/tag/tag-form.tsx` — react-hook-form ベースの共通フォーム
- `src/components/features/tag/tag-delete-button.tsx` — 削除ボタン（確認ダイアログ付き）
- サイドバーとダッシュボードに「タグ」を追加

## 動作確認

- [ ] `supabase/migrations/004_tags_and_taggings.sql` を Supabase SQL Editor で実行し、テーブル・インデックス・RLS が作成されることを確認
- [ ] `/admin/tags` でタグ一覧が表示される
- [ ] 新規作成 → 一覧に追加されることを確認
- [ ] 編集・削除が動作する
- [ ] 同名 / 同スラッグでは UNIQUE 制約違反エラーが表示される

## 補足

- 各コンテンツ（video / live / radio / article / tv_show / topic）にタグを付与する UI は今回のスコープ外。`taggings` テーブルだけ先に用意し、コンテンツ側のフォームへの組み込みは別 issue で対応する想定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01RtJouz9DxiUXSVWsGNXxTP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full tag management in the admin dashboard: create, edit, and delete tags.
  * Tags support name, slug, description and color (with visual color swatch).
  * Tag list shows usage counts and integrates into admin cards and sidebar.
  * Deletion confirms with a prompt and buttons reflect pending state.
  * Underlying tagging enables associating tags across content types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->