### PR TITLE
feat: 詳細ページに同じ出演者の関連コンテンツセクションを追加

### DIFF
--- a/src/app/(public)/articles/[id]/page.tsx
+++ b/src/app/(public)/articles/[id]/page.tsx
@@ -3,8 +3,10 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 import { MemoSection } from "@/components/features/memo/memo-section";
+import { RelatedContents } from "@/components/features/related/related-contents";
 import { PerformerTagList } from "@/components/shared/performer-tags";
 import { getArticle as fetchArticle } from "@/lib/queries/articles";
+import { getRelatedContents } from "@/lib/queries/related-contents";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
 
@@ -17,6 +19,7 @@ type Props = {
 };
 
 const DESCRIPTION_MAX_LENGTH = 160;
+const RELATED_LIMIT = 6;
 
 function buildDescription(article: {
   casts: CastEntry[];
@@ -56,6 +59,11 @@ export default async function ArticleDetailPage({ params }: Props) {
   const article = await getArticle(id);
   if (!article) notFound();
 
+  const related = await getRelatedContents(
+    article.casts,
+    { type: "article", id: article.id },
+    RELATED_LIMIT
+  );
   const published = formatDate(article.published_at);
 
   return (
@@ -106,6 +114,8 @@ export default async function ArticleDetailPage({ params }: Props) {
       </p>
 
       <MemoSection targetType="article" targetId={article.id} />
+
+      <RelatedContents contents={related} />
     </div>
   );
 }

--- a/src/app/(public)/lives/[id]/page.tsx
+++ b/src/app/(public)/lives/[id]/page.tsx
@@ -3,8 +3,10 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 import { MemoSection } from "@/components/features/memo/memo-section";
+import { RelatedContents } from "@/components/features/related/related-contents";
 import { PerformerTagList } from "@/components/shared/performer-tags";
 import { getLive as fetchLive } from "@/lib/queries/lives";
+import { getRelatedContents } from "@/lib/queries/related-contents";
 import type { CastEntry } from "@/lib/types";
 import { formatDate, formatTime } from "@/lib/utils/date";
 import { normalizeExternalUrl } from "@/lib/utils/url";
@@ -18,6 +20,7 @@ type Props = {
 };
 
 const DESCRIPTION_MAX_LENGTH = 160;
+const RELATED_LIMIT = 6;
 
 function buildDescription(live: {
   description: string | null;
@@ -60,6 +63,11 @@ export default async function LiveDetailPage({ params }: Props) {
   const live = await getLive(id);
   if (!live) notFound();
 
+  const related = await getRelatedContents(
+    live.casts,
+    { type: "live", id: live.id },
+    RELATED_LIMIT
+  );
   const eventDate = formatDate(live.event_date);
   const startTime = formatTime(live.start_time);
   const safeUrl = normalizeExternalUrl(live.url);
@@ -124,6 +132,8 @@ export default async function LiveDetailPage({ params }: Props) {
       ) : null}
 
       <MemoSection targetType="live" targetId={live.id} />
+
+      <RelatedContents contents={related} />
     </div>
   );
 }

--- a/src/app/(public)/radios/[id]/page.tsx
+++ b/src/app/(public)/radios/[id]/page.tsx
@@ -3,8 +3,10 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 import { MemoSection } from "@/components/features/memo/memo-section";
+import { RelatedContents } from "@/components/features/related/related-contents";
 import { PerformerTagList } from "@/components/shared/performer-tags";
 import { getRadio as fetchRadio } from "@/lib/queries/radios";
+import { getRelatedContents } from "@/lib/queries/related-contents";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
 
@@ -17,6 +19,7 @@ type Props = {
 };
 
 const DESCRIPTION_MAX_LENGTH = 160;
+const RELATED_LIMIT = 6;
 
 function buildDescription(radio: {
   description: string | null;
@@ -57,6 +60,11 @@ export default async function RadioDetailPage({ params }: Props) {
   const radio = await getRadio(id);
   if (!radio) notFound();
 
+  const related = await getRelatedContents(
+    radio.casts,
+    { type: "radio", id: radio.id },
+    RELATED_LIMIT
+  );
   const published = formatDate(radio.published_at);
 
   return (
@@ -111,6 +119,8 @@ export default async function RadioDetailPage({ params }: Props) {
       ) : null}
 
       <MemoSection targetType="radio" targetId={radio.id} />
+
+      <RelatedContents contents={related} />
     </div>
   );
 }

--- a/src/app/(public)/topics/[id]/page.tsx
+++ b/src/app/(public)/topics/[id]/page.tsx
@@ -3,7 +3,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 import { MemoSection } from "@/components/features/memo/memo-section";
+import { RelatedContents } from "@/components/features/related/related-contents";
 import { PerformerTagList } from "@/components/shared/performer-tags";
+import { getRelatedContents } from "@/lib/queries/related-contents";
 import { getTopic as fetchTopic } from "@/lib/queries/topics";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
@@ -17,6 +19,7 @@ type Props = {
 };
 
 const DESCRIPTION_MAX_LENGTH = 160;
+const RELATED_LIMIT = 6;
 
 function buildDescription(topic: {
   content: string | null;
@@ -59,6 +62,11 @@ export default async function TopicDetailPage({ params }: Props) {
   const topic = await getTopic(id);
   if (!topic) notFound();
 
+  const related = await getRelatedContents(
+    topic.casts,
+    { type: "topic", id: topic.id },
+    RELATED_LIMIT
+  );
   const topicDate = formatDate(topic.topic_date);
 
   return (
@@ -113,6 +121,8 @@ export default async function TopicDetailPage({ params }: Props) {
       ) : null}
 
       <MemoSection targetType="topic" targetId={topic.id} />
+
+      <RelatedContents contents={related} />
     </div>
   );
 }

--- a/src/app/(public)/tv/[id]/page.tsx
+++ b/src/app/(public)/tv/[id]/page.tsx
@@ -3,7 +3,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 import { MemoSection } from "@/components/features/memo/memo-section";
+import { RelatedContents } from "@/components/features/related/related-contents";
 import { PerformerTagList } from "@/components/shared/performer-tags";
+import { getRelatedContents } from "@/lib/queries/related-contents";
 import { getTvShow as fetchTvShow } from "@/lib/queries/tv-shows";
 import type { CastEntry } from "@/lib/types";
 import { formatDate, formatTime } from "@/lib/utils/date";
@@ -17,6 +19,7 @@ type Props = {
 };
 
 const DESCRIPTION_MAX_LENGTH = 160;
+const RELATED_LIMIT = 6;
 
 function buildDescription(tvShow: {
   description: string | null;
@@ -59,6 +62,11 @@ export default async function TvDetailPage({ params }: Props) {
   const tvShow = await getTvShow(id);
   if (!tvShow) notFound();
 
+  const related = await getRelatedContents(
+    tvShow.casts,
+    { type: "tv_show", id: tvShow.id },
+    RELATED_LIMIT
+  );
   const airDate = formatDate(tvShow.air_date);
   const airTime = formatTime(tvShow.air_time);
 
@@ -121,6 +129,8 @@ export default async function TvDetailPage({ params }: Props) {
       ) : null}
 
       <MemoSection targetType="tv_show" targetId={tvShow.id} />
+
+      <RelatedContents contents={related} />
     </div>
   );
 }

--- a/src/app/(public)/videos/[id]/page.tsx
+++ b/src/app/(public)/videos/[id]/page.tsx
@@ -3,12 +3,10 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 import { MemoSection } from "@/components/features/memo/memo-section";
-import { VideoGrid } from "@/components/features/video/video-grid";
+import { RelatedContents } from "@/components/features/related/related-contents";
 import { VideoPlayer } from "@/components/features/video/video-player";
-import {
-  getVideo as fetchVideo,
-  listRelatedVideos,
-} from "@/lib/queries/videos";
+import { getRelatedContents } from "@/lib/queries/related-contents";
+import { getVideo as fetchVideo } from "@/lib/queries/videos";
 import type { CastEntry } from "@/lib/types";
 import { formatDate } from "@/lib/utils/date";
 
@@ -82,7 +80,11 @@ export default async function VideoDetailPage({ params }: Props) {
   const video = await getVideo(id);
   if (!video) notFound();
 
-  const related = await listRelatedVideos(video.id, RELATED_LIMIT);
+  const related = await getRelatedContents(
+    video.casts,
+    { type: "video", id: video.id },
+    RELATED_LIMIT
+  );
   const published = formatDate(video.published_at);
 
   return (
@@ -146,14 +148,7 @@ export default async function VideoDetailPage({ params }: Props) {
 
       <MemoSection targetType="video" targetId={video.id} />
 
-      {related.length > 0 ? (
-        <section className="mt-10">
-          <h2 className="mb-4 text-lg font-semibold text-brand-cream md:text-xl">
-            関連動画
-          </h2>
-          <VideoGrid videos={related} />
-        </section>
-      ) : null}
+      <RelatedContents contents={related} />
     </div>
   );
 }

--- a/src/components/features/related/related-contents.tsx
+++ b/src/components/features/related/related-contents.tsx
@@ -10,6 +10,29 @@ type Props = {
   contents: RelatedContentsType;
 };
 
+const BUSINESS_TIMEZONE = "Asia/Tokyo";
+
+function todayInBusinessTimezone(): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: BUSINESS_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+  const year = parts.find((p) => p.type === "year")?.value ?? "1970";
+  const month = parts.find((p) => p.type === "month")?.value ?? "01";
+  const day = parts.find((p) => p.type === "day")?.value ?? "01";
+  return `${year}-${month}-${day}`;
+}
+
+function liveVariant(
+  eventDate: string | null,
+  today: string
+): "upcoming" | "past" {
+  if (!eventDate) return "past";
+  return eventDate >= today ? "upcoming" : "past";
+}
+
 export function RelatedContents({ contents }: Props) {
   const { videos, lives, radios, articles, tvShows, topics } = contents;
   const total =
@@ -21,6 +44,8 @@ export function RelatedContents({ contents }: Props) {
     topics.length;
 
   if (total === 0) return null;
+
+  const today = todayInBusinessTimezone();
 
   return (
     <section className="mt-10 space-y-8">
@@ -51,7 +76,7 @@ export function RelatedContents({ contents }: Props) {
           <ul className="space-y-3">
             {lives.map((l) => (
               <li key={l.id}>
-                <LiveCard live={l} variant="past" />
+                <LiveCard live={l} variant={liveVariant(l.event_date, today)} />
               </li>
             ))}
           </ul>

--- a/src/components/features/related/related-contents.tsx
+++ b/src/components/features/related/related-contents.tsx
@@ -1,0 +1,122 @@
+import { ArticleCard } from "@/components/features/article/article-card";
+import { LiveCard } from "@/components/features/live/live-card";
+import { RadioCard } from "@/components/features/radio/radio-card";
+import { TopicCard } from "@/components/features/topic/topic-card";
+import { TvShowCard } from "@/components/features/tv-show/tv-show-card";
+import { VideoCard } from "@/components/features/video/video-card";
+import type { RelatedContents as RelatedContentsType } from "@/lib/queries/related-contents";
+
+type Props = {
+  contents: RelatedContentsType;
+};
+
+export function RelatedContents({ contents }: Props) {
+  const { videos, lives, radios, articles, tvShows, topics } = contents;
+  const total =
+    videos.length +
+    lives.length +
+    radios.length +
+    articles.length +
+    tvShows.length +
+    topics.length;
+
+  if (total === 0) return null;
+
+  return (
+    <section className="mt-10 space-y-8">
+      <h2 className="text-lg font-semibold text-brand-cream md:text-xl">
+        関連コンテンツ
+      </h2>
+
+      {videos.length > 0 ? (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold text-brand-gold">
+            動画
+          </h3>
+          <ul className="grid grid-cols-2 gap-4 md:grid-cols-3">
+            {videos.map((v) => (
+              <li key={v.id}>
+                <VideoCard video={v} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {lives.length > 0 ? (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold text-brand-gold">
+            ライブ
+          </h3>
+          <ul className="space-y-3">
+            {lives.map((l) => (
+              <li key={l.id}>
+                <LiveCard live={l} variant="past" />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {radios.length > 0 ? (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold text-brand-gold">
+            ラジオ
+          </h3>
+          <ul className="space-y-3">
+            {radios.map((r) => (
+              <li key={r.id}>
+                <RadioCard radio={r} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {tvShows.length > 0 ? (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold text-brand-gold">
+            TV
+          </h3>
+          <ul className="space-y-3">
+            {tvShows.map((t) => (
+              <li key={t.id}>
+                <TvShowCard tvShow={t} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {articles.length > 0 ? (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold text-brand-gold">
+            記事
+          </h3>
+          <ul className="space-y-3">
+            {articles.map((a) => (
+              <li key={a.id}>
+                <ArticleCard article={a} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {topics.length > 0 ? (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold text-brand-gold">
+            トピック
+          </h3>
+          <ul className="space-y-3">
+            {topics.map((t) => (
+              <li key={t.id}>
+                <TopicCard topic={t} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/lib/queries/related-contents.ts
+++ b/src/lib/queries/related-contents.ts
@@ -1,0 +1,306 @@
+import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry, ContentType } from "@/lib/types";
+import type { ArticleWithCasts } from "@/lib/types/article";
+import type { LiveWithCasts } from "@/lib/types/live";
+import type { RadioWithCasts } from "@/lib/types/radio";
+import type { TopicWithCasts } from "@/lib/types/topic";
+import type { TvShowWithCasts } from "@/lib/types/tv-show";
+import type { VideoWithCasts } from "@/lib/types/video";
+
+export type RelatedContents = {
+  videos: VideoWithCasts[];
+  lives: LiveWithCasts[];
+  radios: RadioWithCasts[];
+  articles: ArticleWithCasts[];
+  tvShows: TvShowWithCasts[];
+  topics: TopicWithCasts[];
+};
+
+const EMPTY: RelatedContents = {
+  videos: [],
+  lives: [],
+  radios: [],
+  articles: [],
+  tvShows: [],
+  topics: [],
+};
+
+const CAST_SUBSELECT = `
+  id,
+  artist_id,
+  comedy_group_id,
+  unit_id,
+  artist:artists(id, name),
+  comedy_group:comedy_groups(id, name),
+  unit:units(id, name)
+`;
+
+type Row = Record<string, unknown>;
+type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
+
+type CastTable =
+  | "video_casts"
+  | "live_casts"
+  | "radio_casts"
+  | "article_casts"
+  | "tv_show_casts"
+  | "topic_casts";
+
+function partitionCasts(casts: CastEntry[]): {
+  artistIds: string[];
+  comedyGroupIds: string[];
+  unitIds: string[];
+} {
+  const artistIds: string[] = [];
+  const comedyGroupIds: string[] = [];
+  const unitIds: string[] = [];
+  for (const c of casts) {
+    if (c.type === "artist") artistIds.push(c.id);
+    else if (c.type === "comedy_group") comedyGroupIds.push(c.id);
+    else if (c.type === "unit") unitIds.push(c.id);
+  }
+  return { artistIds, comedyGroupIds, unitIds };
+}
+
+async function listMatchingParentIds<K extends string>(
+  supabase: SupabaseClient,
+  castTable: CastTable,
+  parentIdField: K,
+  partitioned: ReturnType<typeof partitionCasts>
+): Promise<string[]> {
+  const { artistIds, comedyGroupIds, unitIds } = partitioned;
+  const filters: string[] = [];
+  if (artistIds.length > 0) {
+    filters.push(`artist_id.in.(${artistIds.join(",")})`);
+  }
+  if (comedyGroupIds.length > 0) {
+    filters.push(`comedy_group_id.in.(${comedyGroupIds.join(",")})`);
+  }
+  if (unitIds.length > 0) {
+    filters.push(`unit_id.in.(${unitIds.join(",")})`);
+  }
+  if (filters.length === 0) return [];
+
+  const { data, error } = await supabase
+    .from(castTable)
+    .select(parentIdField)
+    .or(filters.join(","));
+
+  if (error) {
+    throw new Error(`関連コンテンツの取得に失敗しました: ${error.message}`);
+  }
+
+  const ids = ((data ?? []) as Array<Record<K, string>>).map(
+    (row) => row[parentIdField]
+  );
+  return Array.from(new Set(ids));
+}
+
+function castsOf(record: Row, key: string) {
+  return mapCasts(record[key] as CastRow[] | null | undefined);
+}
+
+export async function getRelatedContents(
+  casts: CastEntry[],
+  exclude: { type: ContentType; id: string },
+  limit: number
+): Promise<RelatedContents> {
+  if (casts.length === 0) return EMPTY;
+
+  const supabase = await createClient();
+  const partitioned = partitionCasts(casts);
+
+  const [videoIds, liveIds, radioIds, articleIds, tvShowIds, topicIds] =
+    await Promise.all([
+      listMatchingParentIds(supabase, "video_casts", "video_id", partitioned),
+      listMatchingParentIds(supabase, "live_casts", "live_id", partitioned),
+      listMatchingParentIds(supabase, "radio_casts", "radio_id", partitioned),
+      listMatchingParentIds(
+        supabase,
+        "article_casts",
+        "article_id",
+        partitioned
+      ),
+      listMatchingParentIds(
+        supabase,
+        "tv_show_casts",
+        "tv_show_id",
+        partitioned
+      ),
+      listMatchingParentIds(supabase, "topic_casts", "topic_id", partitioned),
+    ]);
+
+  const filterIds = (ids: string[], excludeType: ContentType) =>
+    exclude.type === excludeType ? ids.filter((id) => id !== exclude.id) : ids;
+
+  const videoTargets = filterIds(videoIds, "video");
+  const liveTargets = filterIds(liveIds, "live");
+  const radioTargets = filterIds(radioIds, "radio");
+  const articleTargets = filterIds(articleIds, "article");
+  const tvShowTargets = filterIds(tvShowIds, "tv_show");
+  const topicTargets = filterIds(topicIds, "topic");
+
+  const [videosRes, livesRes, radiosRes, articlesRes, tvShowsRes, topicsRes] =
+    await Promise.all([
+      videoTargets.length > 0
+        ? supabase
+            .from("videos")
+            .select(`*, video_casts(${CAST_SUBSELECT})`)
+            .in("id", videoTargets)
+            .order("published_at", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+            .limit(limit)
+        : Promise.resolve({ data: [], error: null }),
+      liveTargets.length > 0
+        ? supabase
+            .from("lives")
+            .select(`*, live_casts(${CAST_SUBSELECT})`)
+            .in("id", liveTargets)
+            .order("event_date", { ascending: false, nullsFirst: false })
+            .order("start_time", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+            .limit(limit)
+        : Promise.resolve({ data: [], error: null }),
+      radioTargets.length > 0
+        ? supabase
+            .from("radios")
+            .select(`*, radio_casts(${CAST_SUBSELECT})`)
+            .in("id", radioTargets)
+            .order("published_at", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+            .limit(limit)
+        : Promise.resolve({ data: [], error: null }),
+      articleTargets.length > 0
+        ? supabase
+            .from("articles")
+            .select(`*, article_casts(${CAST_SUBSELECT})`)
+            .in("id", articleTargets)
+            .order("published_at", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+            .limit(limit)
+        : Promise.resolve({ data: [], error: null }),
+      tvShowTargets.length > 0
+        ? supabase
+            .from("tv_shows")
+            .select(`*, tv_show_casts(${CAST_SUBSELECT})`)
+            .in("id", tvShowTargets)
+            .order("air_date", { ascending: false, nullsFirst: false })
+            .order("air_time", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+            .limit(limit)
+        : Promise.resolve({ data: [], error: null }),
+      topicTargets.length > 0
+        ? supabase
+            .from("topics")
+            .select(`*, topic_casts(${CAST_SUBSELECT})`)
+            .in("id", topicTargets)
+            .order("topic_date", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+            .limit(limit)
+        : Promise.resolve({ data: [], error: null }),
+    ]);
+
+  const errors = [
+    videosRes,
+    livesRes,
+    radiosRes,
+    articlesRes,
+    tvShowsRes,
+    topicsRes,
+  ]
+    .map((r) => r.error)
+    .filter((e): e is NonNullable<typeof e> => e !== null);
+  if (errors.length > 0) {
+    throw new Error(`関連コンテンツの取得に失敗しました: ${errors[0].message}`);
+  }
+
+  const videos: VideoWithCasts[] = ((videosRes.data ?? []) as Row[]).map(
+    (r) => ({
+      id: r.id as string,
+      title: r.title as string,
+      youtube_url: (r.youtube_url as string | null) ?? null,
+      youtube_video_id: (r.youtube_video_id as string | null) ?? null,
+      youtube_channel_id: (r.youtube_channel_id as string | null) ?? null,
+      thumbnail_url: (r.thumbnail_url as string | null) ?? null,
+      published_at: (r.published_at as string | null) ?? null,
+      description: (r.description as string | null) ?? null,
+      created_at: r.created_at as string,
+      updated_at: r.updated_at as string,
+      casts: castsOf(r, "video_casts"),
+    })
+  );
+
+  const lives: LiveWithCasts[] = ((livesRes.data ?? []) as Row[]).map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    event_date: (r.event_date as string | null) ?? null,
+    start_time: (r.start_time as string | null) ?? null,
+    venue: (r.venue as string | null) ?? null,
+    description: (r.description as string | null) ?? null,
+    url: (r.url as string | null) ?? null,
+    is_notified: r.is_notified as boolean,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: castsOf(r, "live_casts"),
+  }));
+
+  const radios: RadioWithCasts[] = ((radiosRes.data ?? []) as Row[]).map(
+    (r) => ({
+      id: r.id as string,
+      title: r.title as string,
+      platform: (r.platform as string | null) ?? null,
+      url: (r.url as string | null) ?? null,
+      published_at: (r.published_at as string | null) ?? null,
+      description: (r.description as string | null) ?? null,
+      created_at: r.created_at as string,
+      updated_at: r.updated_at as string,
+      casts: castsOf(r, "radio_casts"),
+    })
+  );
+
+  const articles: ArticleWithCasts[] = ((articlesRes.data ?? []) as Row[]).map(
+    (r) => ({
+      id: r.id as string,
+      title: r.title as string,
+      url: (r.url as string | null) ?? null,
+      source: (r.source as string | null) ?? null,
+      published_at: (r.published_at as string | null) ?? null,
+      content: (r.content as string | null) ?? null,
+      created_at: r.created_at as string,
+      updated_at: r.updated_at as string,
+      casts: castsOf(r, "article_casts"),
+    })
+  );
+
+  const tvShows: TvShowWithCasts[] = ((tvShowsRes.data ?? []) as Row[]).map(
+    (r) => ({
+      id: r.id as string,
+      title: r.title as string,
+      network: (r.network as string | null) ?? null,
+      air_date: (r.air_date as string | null) ?? null,
+      air_time: (r.air_time as string | null) ?? null,
+      description: (r.description as string | null) ?? null,
+      url: (r.url as string | null) ?? null,
+      created_at: r.created_at as string,
+      updated_at: r.updated_at as string,
+      casts: castsOf(r, "tv_show_casts"),
+    })
+  );
+
+  const topics: TopicWithCasts[] = ((topicsRes.data ?? []) as Row[]).map(
+    (r) => ({
+      id: r.id as string,
+      title: r.title as string,
+      content: (r.content as string | null) ?? null,
+      url: (r.url as string | null) ?? null,
+      source: (r.source as string | null) ?? null,
+      topic_date: (r.topic_date as string | null) ?? null,
+      created_at: r.created_at as string,
+      updated_at: r.updated_at as string,
+      casts: castsOf(r, "topic_casts"),
+    })
+  );
+
+  return { videos, lives, radios, articles, tvShows, topics };
+}

--- a/src/lib/queries/videos.ts
+++ b/src/lib/queries/videos.ts
@@ -17,26 +17,6 @@ export async function listVideos(): Promise<Video[]> {
   return (data ?? []) as Video[];
 }
 
-export async function listRelatedVideos(
-  excludeId: string,
-  limit: number
-): Promise<Video[]> {
-  const supabase = await createClient();
-  const { data, error } = await supabase
-    .from("videos")
-    .select("*")
-    .neq("id", excludeId)
-    .order("published_at", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false })
-    .limit(limit);
-
-  if (error) {
-    throw new Error(`関連動画の取得に失敗しました: ${error.message}`);
-  }
-
-  return (data ?? []) as Video[];
-}
-
 export async function getVideo(id: string): Promise<VideoWithCasts | null> {
   const supabase = await createClient();
   const { data, error } = await supabase


### PR DESCRIPTION
## 概要

各コンテンツ詳細ページに、同じ出演者を含む他のコンテンツを横断表示する「関連コンテンツ」セクションを追加しました。推し活時の回遊性を高めることが目的です。

Closes #30

## 変更内容

- `src/lib/queries/related-contents.ts` を追加
  - `getRelatedContents(casts, exclude, limit)` : 渡された出演者（artist / comedy_group / unit）と1つでも一致する動画・ライブ・ラジオ・記事・TV番組・トピックを最大 `limit` 件ずつ取得（自身の id は除外）
  - cast 中間テーブルに対し `OR(artist_id.in.(...), comedy_group_id.in.(...), unit_id.in.(...))` でまとめてフィルタしてから親テーブルを `.in("id", ...)` で取得
- `src/components/features/related/related-contents.tsx` を追加
  - 既存の各種 Card（VideoCard / LiveCard / RadioCard / TvShowCard / ArticleCard / TopicCard）を再利用してコンテンツ種別ごとに小見出し付きで表示
  - 関連コンテンツがゼロのときはセクションごと非表示
- 6つの公開詳細ページ（`/videos/[id]`, `/lives/[id]`, `/radios/[id]`, `/articles/[id]`, `/tv/[id]`, `/topics/[id]`）に `<RelatedContents />` セクションを追加（メモ欄の下）
- `videos.ts` の旧 `listRelatedVideos`（同出演者ではなく単純に新着動画を返す実装）を削除し、新しいクロスタイプの関連コンテンツ取得に置き換え

## 動作仕様

- 出演者が登録されていないコンテンツでは関連セクションは表示されません
- 関連コンテンツが1件もないコンテンツ種別はその小見出しごと非表示になります
- 関連コンテンツの並び順は各種一覧と同じ（公開日 / 開催日降順）

## Test plan

- [ ] 動画詳細ページで、出演者が共通する動画・ライブ・ラジオ・記事・TV・トピックが表示されること
- [ ] ライブ / ラジオ / 記事 / TV / トピックの各詳細ページでも同様に関連コンテンツが表示されること
- [ ] 出演者なしのコンテンツでは「関連コンテンツ」セクションが描画されないこと
- [ ] 自分自身の id は関連コンテンツに含まれないこと
- [ ] `npx eslint` が通ること（実機で確認済み）


---
_Generated by [Claude Code](https://claude.ai/code/session_016U24rv4nMh4nZFzdn4yZVf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added related content recommendations to detail pages for articles, lives, radios, topics, TV shows, and videos. Each page displays up to 6 related items to help users discover similar content based on cast associations.

* **Refactor**
  * Consolidated related content fetching logic into a unified system, replacing the previous video-specific implementation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->