### PR TITLE
feat: モバイル表示を全ページで調整

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -71,9 +71,9 @@ export default async function Home() {
     recentContentRes.status === "fulfilled" ? recentContentRes.value : [];
 
   return (
-    <div className="mx-auto w-full max-w-6xl flex-1 px-5">
-      <section className="mb-10 border-b border-brand-border-dark pt-14 pb-12">
-        <h1 className="text-3xl font-bold text-brand-cream">
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 sm:px-5">
+      <section className="mb-8 border-b border-brand-border-dark pt-10 pb-8 sm:mb-10 sm:pt-14 sm:pb-12">
+        <h1 className="text-2xl font-bold text-brand-cream sm:text-3xl">
           DonDecorte Lab
         </h1>
         <p

--- a/src/app/admin/achievements/[id]/edit/page.tsx
+++ b/src/app/admin/achievements/[id]/edit/page.tsx
@@ -42,7 +42,7 @@ export default async function EditAchievementPage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <AchievementForm
           action={action}
           artists={artists}

--- a/src/app/admin/achievements/new/page.tsx
+++ b/src/app/admin/achievements/new/page.tsx
@@ -28,7 +28,7 @@ export default async function NewAchievementPage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <AchievementForm
           action={createAchievement}
           artists={artists}

--- a/src/app/admin/achievements/page.tsx
+++ b/src/app/admin/achievements/page.tsx
@@ -37,7 +37,7 @@ export default async function AdminAchievementsPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {achievements.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだ受賞歴が登録されていません。

--- a/src/app/admin/articles/[id]/edit/page.tsx
+++ b/src/app/admin/articles/[id]/edit/page.tsx
@@ -43,7 +43,7 @@ export default async function EditArticlePage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <ArticleForm
           key={article.id}
           action={action}

--- a/src/app/admin/articles/new/page.tsx
+++ b/src/app/admin/articles/new/page.tsx
@@ -28,7 +28,7 @@ export default async function NewArticlePage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <ArticleForm
           action={createArticle}
           artists={artists}

--- a/src/app/admin/articles/page.tsx
+++ b/src/app/admin/articles/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminArticlesPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {articles.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだ記事が登録されていません。

--- a/src/app/admin/artists/[id]/edit/page.tsx
+++ b/src/app/admin/artists/[id]/edit/page.tsx
@@ -33,7 +33,7 @@ export default async function EditArtistPage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <ArtistForm
           action={action}
           initialValues={artist}

--- a/src/app/admin/artists/new/page.tsx
+++ b/src/app/admin/artists/new/page.tsx
@@ -17,7 +17,7 @@ export default function NewArtistPage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <ArtistForm action={createArtist} submitLabel="作成する" />
       </div>
     </div>

--- a/src/app/admin/artists/page.tsx
+++ b/src/app/admin/artists/page.tsx
@@ -25,7 +25,7 @@ export default async function AdminArtistsPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {artists.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだ芸人が登録されていません。

--- a/src/app/admin/combos/[id]/edit/page.tsx
+++ b/src/app/admin/combos/[id]/edit/page.tsx
@@ -43,7 +43,7 @@ export default async function EditComboPage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <ComboForm
           action={action}
           artists={artists}

--- a/src/app/admin/combos/new/page.tsx
+++ b/src/app/admin/combos/new/page.tsx
@@ -22,7 +22,7 @@ export default async function NewComboPage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <ComboForm
           action={createCombo}
           artists={artists}

--- a/src/app/admin/combos/page.tsx
+++ b/src/app/admin/combos/page.tsx
@@ -32,7 +32,7 @@ export default async function AdminCombosPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {combos.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだコンビが登録されていません。

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -8,7 +8,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
       <AdminSidebar />
       <div className="flex min-w-0 flex-1 flex-col">
         <AdminHeader />
-        <main className="flex-1 overflow-x-hidden px-4 py-6 md:px-8 md:py-8">
+        <main className="flex-1 overflow-x-hidden px-4 py-5 md:px-8 md:py-8">
           {children}
         </main>
       </div>

--- a/src/app/admin/lives/[id]/edit/page.tsx
+++ b/src/app/admin/lives/[id]/edit/page.tsx
@@ -43,7 +43,7 @@ export default async function EditLivePage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <LiveForm
           key={live.id}
           action={action}

--- a/src/app/admin/lives/new/page.tsx
+++ b/src/app/admin/lives/new/page.tsx
@@ -28,7 +28,7 @@ export default async function NewLivePage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <LiveForm
           action={createLive}
           artists={artists}

--- a/src/app/admin/lives/page.tsx
+++ b/src/app/admin/lives/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminLivesPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {lives.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだライブが登録されていません。

--- a/src/app/admin/radios/[id]/edit/page.tsx
+++ b/src/app/admin/radios/[id]/edit/page.tsx
@@ -43,7 +43,7 @@ export default async function EditRadioPage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <RadioForm
           action={action}
           artists={artists}

--- a/src/app/admin/radios/new/page.tsx
+++ b/src/app/admin/radios/new/page.tsx
@@ -28,7 +28,7 @@ export default async function NewRadioPage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <RadioForm
           action={createRadio}
           artists={artists}

--- a/src/app/admin/radios/page.tsx
+++ b/src/app/admin/radios/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminRadiosPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {radios.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだラジオが登録されていません。

--- a/src/app/admin/tags/[id]/edit/page.tsx
+++ b/src/app/admin/tags/[id]/edit/page.tsx
@@ -34,7 +34,7 @@ export default async function EditTagPage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <TagForm action={action} initialValues={tag} submitLabel="更新する" />
       </div>
     </div>

--- a/src/app/admin/tags/new/page.tsx
+++ b/src/app/admin/tags/new/page.tsx
@@ -19,7 +19,7 @@ export default function NewTagPage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <TagForm action={createTag} submitLabel="作成する" />
       </div>
     </div>

--- a/src/app/admin/tags/page.tsx
+++ b/src/app/admin/tags/page.tsx
@@ -25,7 +25,7 @@ export default async function AdminTagsPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {tags.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだタグが登録されていません。

--- a/src/app/admin/topics/[id]/edit/page.tsx
+++ b/src/app/admin/topics/[id]/edit/page.tsx
@@ -43,7 +43,7 @@ export default async function EditTopicPage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <TopicForm
           key={topic.id}
           action={action}

--- a/src/app/admin/topics/new/page.tsx
+++ b/src/app/admin/topics/new/page.tsx
@@ -28,7 +28,7 @@ export default async function NewTopicPage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <TopicForm
           action={createTopic}
           artists={artists}

--- a/src/app/admin/topics/page.tsx
+++ b/src/app/admin/topics/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminTopicsPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {topics.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだトピックが登録されていません。

--- a/src/app/admin/tv/[id]/edit/page.tsx
+++ b/src/app/admin/tv/[id]/edit/page.tsx
@@ -43,7 +43,7 @@ export default async function EditTvPage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <TvShowForm
           key={tvShow.id}
           action={action}

--- a/src/app/admin/tv/new/page.tsx
+++ b/src/app/admin/tv/new/page.tsx
@@ -28,7 +28,7 @@ export default async function NewTvPage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <TvShowForm
           action={createTvShow}
           artists={artists}

--- a/src/app/admin/tv/page.tsx
+++ b/src/app/admin/tv/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminTvPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {tvShows.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだTV番組が登録されていません。

--- a/src/app/admin/units/[id]/edit/page.tsx
+++ b/src/app/admin/units/[id]/edit/page.tsx
@@ -40,7 +40,7 @@ export default async function EditUnitPage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <UnitForm
           action={action}
           artists={artists}

--- a/src/app/admin/units/new/page.tsx
+++ b/src/app/admin/units/new/page.tsx
@@ -26,7 +26,7 @@ export default async function NewUnitPage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <UnitForm
           action={createUnit}
           artists={artists}

--- a/src/app/admin/units/page.tsx
+++ b/src/app/admin/units/page.tsx
@@ -25,7 +25,7 @@ export default async function AdminUnitsPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {units.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだユニットが登録されていません。

--- a/src/app/admin/videos/[id]/edit/page.tsx
+++ b/src/app/admin/videos/[id]/edit/page.tsx
@@ -43,7 +43,7 @@ export default async function EditVideoPage({ params }: Props) {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <VideoForm
           action={action}
           artists={artists}

--- a/src/app/admin/videos/new/page.tsx
+++ b/src/app/admin/videos/new/page.tsx
@@ -28,7 +28,7 @@ export default async function NewVideoPage() {
         </h1>
       </div>
 
-      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-6">
+      <div className="rounded-lg border border-brand-border-light bg-brand-card-light p-4 sm:p-6">
         <VideoForm
           action={createVideo}
           artists={artists}

--- a/src/app/admin/videos/page.tsx
+++ b/src/app/admin/videos/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminVideosPage() {
         </Link>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-brand-border-light bg-brand-card-light">
+      <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
         {videos.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
             まだ動画が登録されていません。

--- a/src/components/layout/admin-header.tsx
+++ b/src/components/layout/admin-header.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { AdminMobileMenu } from "./admin-sidebar";
 import { AdminSignOutButton } from "./admin-sign-out-button";
 
 export async function AdminHeader() {
@@ -8,9 +9,13 @@ export async function AdminHeader() {
   } = await supabase.auth.getUser();
 
   return (
-    <header className="flex items-center justify-between border-b border-brand-border-light bg-brand-card-light px-6 py-3">
-      <div className="text-sm font-medium text-brand-brown-dark">
-        DonDecorte Lab 管理画面
+    <header className="flex items-center justify-between gap-3 border-b border-brand-border-light bg-brand-card-light px-4 py-3 md:px-6">
+      <div className="flex items-center gap-3">
+        <AdminMobileMenu />
+        <div className="text-sm font-medium text-brand-brown-dark">
+          <span className="md:hidden">管理画面</span>
+          <span className="hidden md:inline">DonDecorte Lab 管理画面</span>
+        </div>
       </div>
       <div className="flex items-center gap-3">
         {user?.email ? (

--- a/src/components/layout/admin-sidebar.tsx
+++ b/src/components/layout/admin-sidebar.tsx
@@ -155,7 +155,7 @@ export function AdminMobileMenu() {
           className="fixed inset-0 z-50"
         >
           <div
-            className="absolute inset-0 bg-black/40"
+            className="absolute inset-0 bg-brand-brown-dark/40"
             onClick={() => setOpen(false)}
             aria-hidden="true"
           />

--- a/src/components/layout/admin-sidebar.tsx
+++ b/src/components/layout/admin-sidebar.tsx
@@ -97,20 +97,33 @@ export function AdminMobileMenu() {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
     };
+    const mql = window.matchMedia("(min-width: 768px)");
+    const onMediaChange = (e: MediaQueryListEvent) => {
+      if (e.matches) setOpen(false);
+    };
     document.addEventListener("keydown", onKey);
+    mql.addEventListener("change", onMediaChange);
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
       document.removeEventListener("keydown", onKey);
+      mql.removeEventListener("change", onMediaChange);
       document.body.style.overflow = previousOverflow;
     };
   }, [open]);
+
+  const handleOpen = () => {
+    if (typeof window !== "undefined" && window.matchMedia("(min-width: 768px)").matches) {
+      return;
+    }
+    setOpen(true);
+  };
 
   return (
     <div className="md:hidden">
       <button
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={handleOpen}
         aria-label="メニューを開く"
         aria-expanded={open}
         aria-controls="admin-mobile-drawer"

--- a/src/components/layout/admin-sidebar.tsx
+++ b/src/components/layout/admin-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 
 type AdminNavItem = {
   href: string;
@@ -28,6 +29,38 @@ function isActive(pathname: string, href: string) {
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
+function NavList({
+  pathname,
+  onNavigate,
+}: {
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  return (
+    <ul className="space-y-1">
+      {NAV_ITEMS.map((item) => {
+        const active = isActive(pathname, item.href);
+        return (
+          <li key={item.href}>
+            <Link
+              href={item.href}
+              aria-current={active ? "page" : undefined}
+              onClick={onNavigate}
+              className={
+                active
+                  ? "block rounded-md bg-brand-sky-pale px-3 py-2 text-sm font-medium text-brand-sky"
+                  : "block rounded-md px-3 py-2 text-sm text-brand-brown-dark transition hover:bg-brand-bg-light hover:text-brand-sky"
+              }
+            >
+              {item.label}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
 export function AdminSidebar() {
   const pathname = usePathname();
 
@@ -43,27 +76,117 @@ export function AdminSidebar() {
         <p className="mt-0.5 text-xs text-brand-brown-light">管理画面</p>
       </div>
       <nav className="flex-1 overflow-y-auto px-3 py-4">
-        <ul className="space-y-1">
-          {NAV_ITEMS.map((item) => {
-            const active = isActive(pathname, item.href);
-            return (
-              <li key={item.href}>
-                <Link
-                  href={item.href}
-                  aria-current={active ? "page" : undefined}
-                  className={
-                    active
-                      ? "block rounded-md bg-brand-sky-pale px-3 py-2 text-sm font-medium text-brand-sky"
-                      : "block rounded-md px-3 py-2 text-sm text-brand-brown-dark transition hover:bg-brand-bg-light hover:text-brand-sky"
-                  }
-                >
-                  {item.label}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+        <NavList pathname={pathname} />
       </nav>
     </aside>
+  );
+}
+
+export function AdminMobileMenu() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [lastPathname, setLastPathname] = useState(pathname);
+
+  if (lastPathname !== pathname) {
+    setLastPathname(pathname);
+    setOpen(false);
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  return (
+    <div className="md:hidden">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="メニューを開く"
+        aria-expanded={open}
+        aria-controls="admin-mobile-drawer"
+        className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-brand-border-light text-brand-brown-dark transition hover:bg-brand-bg-light"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="4" y1="6" x2="20" y2="6" />
+          <line x1="4" y1="12" x2="20" y2="12" />
+          <line x1="4" y1="18" x2="20" y2="18" />
+        </svg>
+      </button>
+
+      {open ? (
+        <div
+          id="admin-mobile-drawer"
+          role="dialog"
+          aria-modal="true"
+          aria-label="管理メニュー"
+          className="fixed inset-0 z-50"
+        >
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <div className="absolute inset-y-0 left-0 flex w-72 max-w-[85%] flex-col bg-brand-card-light shadow-xl">
+            <div className="flex items-center justify-between border-b border-brand-border-light px-5 py-4">
+              <div>
+                <Link
+                  href="/admin"
+                  className="block text-base font-bold text-brand-brown-dark"
+                >
+                  DonDecorte Lab
+                </Link>
+                <p className="mt-0.5 text-xs text-brand-brown-light">
+                  管理画面
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="メニューを閉じる"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-brand-brown-light transition hover:bg-brand-bg-light hover:text-brand-brown-dark"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                  <line x1="6" y1="18" x2="18" y2="6" />
+                </svg>
+              </button>
+            </div>
+            <nav className="flex-1 overflow-y-auto px-3 py-4">
+              <NavList pathname={pathname} onNavigate={() => setOpen(false)} />
+            </nav>
+          </div>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -24,7 +24,7 @@ export function PublicHeader() {
 
   return (
     <header className="sticky top-0 z-30 border-b border-brand-border-dark bg-brand-card-dark/95 backdrop-blur">
-      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between gap-4 px-5">
+      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between gap-4 px-4 sm:px-5">
         <Link
           href="/"
           className="text-[17px] font-bold tracking-wide text-brand-cream transition-colors hover:text-brand-sky-light"


### PR DESCRIPTION
## 概要

Issue #31「2-5 レスポンシブ対応強化」対応。全ページのモバイル表示を見直し、特にこれまで実用性に乏しかった管理画面のモバイル対応を強化した。

Closes #31

## 変更内容

### 管理画面（最重要）

- **一覧テーブルの横スクロール対応**
  - 11ページ（artists/combos/units/achievements/videos/lives/radios/articles/tv/topics/tags）の一覧テーブルラッパーを `overflow-hidden` → `overflow-x-auto` に変更し、モバイルでもタイトル列等が切れずに閲覧できるように。
- **モバイル向けドロワーメニュー追加（`AdminMobileMenu`）**
  - 従来サイドバーは `hidden md:flex` で、モバイルでは管理ページ間の遷移手段が無かった。
  - ハンバーガーボタン → 左からスライドイン、リンク選択時/Escape/オーバーレイクリックで閉じる。
- **`AdminHeader` の調整**
  - モバイルメニューボタン配置 + タイトル短縮（モバイルで「管理画面」、PCで「DonDecorte Lab 管理画面」）
  - パディングを `px-6 py-3` → `px-4 py-3 md:px-6` に。
- **フォーム/レイアウトの余白調整**
  - 新規作成・編集ページのカード `p-6` → `p-4 sm:p-6`
  - 管理レイアウト本体 `py-6` → `py-5`（モバイル時のみ）

### 公開側

- トップページ `(public)/page.tsx`
  - 外側コンテナ `px-5` → `px-4 sm:px-5`
  - ヒーローセクションの上下余白 (`pt-14 pb-12 mb-10`) をモバイルでは縮小
  - h1 `text-3xl` → `text-2xl sm:text-3xl`
- ヘッダー `header.tsx`
  - `px-5` → `px-4 sm:px-5`

## 確認内容

- `npx eslint src/components/layout src/app/admin src/app/(public)/page.tsx` パス
- `next build` のコンパイル成功（型チェックは `src/lib/actions/achievements.ts` 等の既存エラーのみで、本変更とは無関係）

## テスト計画

- [ ] iPhone SE 相当（375px）で公開トップページのレイアウトが詰まらず読めること
- [ ] モバイル幅で `/admin/videos` などの一覧テーブルを横スクロールできること
- [ ] モバイル幅でハンバーガーボタンから管理メニューが開閉できること
- [ ] メニュー内のリンク選択時にドロワーが閉じ、ページ遷移すること
- [ ] PC 幅では従来通り左サイドバーが表示されること


---
_Generated by [Claude Code](https://claude.ai/code/session_01BQxg2VoXrWE55HJVwHtF2e)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mobile navigation menu for admin dashboard

* **Bug Fixes**
  * Fixed table and content overflow; admin pages now support horizontal scrolling on mobile

* **Style**
  * Improved responsive spacing and padding across all admin pages
  * Adjusted header and font sizing for better mobile display
  * Enhanced header layout with responsive text variants

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->