### PR TITLE
feat: 全コンテンツを時系列表示するタイムラインページを追加

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -256,7 +256,7 @@ function VideoThumbnailPlaceholder({ title }: { title: string }) {
 function RecentContentSection({ items }: { items: RecentContentItem[] }) {
   return (
     <section className="mb-10 md:mb-14">
-      <SectionHeader title="最近追加されたコンテンツ" />
+      <SectionHeader title="最近追加されたコンテンツ" href="/timeline" />
       {items.length === 0 ? (
         <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
           まだコンテンツが登録されていません。

--- a/src/app/(public)/timeline/page.tsx
+++ b/src/app/(public)/timeline/page.tsx
@@ -1,0 +1,117 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ContentTypeBadge } from "@/components/shared/content-type-badge";
+import { PerformerTagList } from "@/components/shared/performer-tags";
+import { listTimeline, type TimelineItem } from "@/lib/queries/timeline";
+import { formatDate } from "@/lib/utils/date";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "タイムライン",
+  description:
+    "ドンデコルテさん関連の全コンテンツ（動画・ライブ・ラジオ・記事・TV・トピック）を時系列で一覧できるタイムライン。",
+  alternates: { canonical: "/timeline" },
+  openGraph: {
+    title: "タイムライン",
+    description:
+      "ドンデコルテさん関連の全コンテンツを時系列で一覧できるタイムライン。",
+    url: "/timeline",
+  },
+};
+
+const CONTENT_TYPE_PATH: Record<TimelineItem["type"], string> = {
+  video: "videos",
+  live: "lives",
+  radio: "radios",
+  article: "articles",
+  tv_show: "tv",
+  topic: "topics",
+};
+
+type Group = {
+  key: string;
+  label: string;
+  items: TimelineItem[];
+};
+
+function groupByDate(items: TimelineItem[]): Group[] {
+  const groups = new Map<string, Group>();
+  for (const item of items) {
+    const raw = item.date ?? item.createdAt;
+    const key = raw.slice(0, 10);
+    const label = formatDate(key) ?? "日付未定";
+    const existing = groups.get(key);
+    if (existing) {
+      existing.items.push(item);
+    } else {
+      groups.set(key, { key, label, items: [item] });
+    }
+  }
+  return Array.from(groups.values());
+}
+
+export default async function TimelinePage() {
+  const items = await listTimeline();
+  const groups = groupByDate(items);
+
+  return (
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          タイムライン
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          動画・ライブ・ラジオ・記事・TV・トピックを時系列で一覧。
+        </p>
+      </header>
+
+      {items.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          まだコンテンツが登録されていません。
+        </p>
+      ) : (
+        <ol className="space-y-8">
+          {groups.map((group) => (
+            <li key={group.key}>
+              <div className="mb-3 border-l-2 border-brand-sky pl-3">
+                <p
+                  className="text-sm font-semibold text-brand-cream"
+                  style={{ fontVariantNumeric: "tabular-nums" }}
+                >
+                  {group.label}
+                </p>
+              </div>
+              <ul className="space-y-2">
+                {group.items.map((item) => (
+                  <li key={`${item.type}-${item.id}`}>
+                    <Link
+                      href={`/${CONTENT_TYPE_PATH[item.type]}/${item.id}`}
+                      className="block rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-3 transition hover:border-brand-sky-light"
+                    >
+                      <div className="flex items-start gap-3">
+                        <div className="pt-0.5">
+                          <ContentTypeBadge type={item.type} />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm font-medium text-brand-cream">
+                            {item.title}
+                          </p>
+                          {item.casts.length > 0 ? (
+                            <div className="mt-2">
+                              <PerformerTagList performers={item.casts} />
+                            </div>
+                          ) : null}
+                        </div>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -17,6 +17,7 @@ const PRIMARY_ITEMS: NavItem[] = [
 ];
 
 const MORE_ITEMS: NavItem[] = [
+  { href: "/timeline", label: "タイムライン" },
   { href: "/combos", label: "コンビ" },
   { href: "/units", label: "ユニット" },
   { href: "/radios", label: "ラジオ" },

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const NAV_ITEMS = [
+  { href: "/timeline", label: "タイムライン" },
   { href: "/videos", label: "動画" },
   { href: "/lives", label: "ライブ" },
   { href: "/radios", label: "ラジオ" },

--- a/src/lib/queries/timeline.ts
+++ b/src/lib/queries/timeline.ts
@@ -1,0 +1,133 @@
+import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry, ContentType } from "@/lib/types";
+
+export type TimelineItem = {
+  type: ContentType;
+  id: string;
+  title: string;
+  /** ソート・表示用の日付。各コンテンツの主たる日付（publish/event/air/topic_date）。null の場合は created_at を使用。 */
+  date: string | null;
+  createdAt: string;
+  casts: CastEntry[];
+};
+
+const CAST_SUBSELECT = `
+  id,
+  artist_id,
+  comedy_group_id,
+  unit_id,
+  artist:artists(id, name),
+  comedy_group:comedy_groups(id, name),
+  unit:units(id, name)
+`;
+
+type Row = Record<string, unknown>;
+
+function sortKey(item: TimelineItem): string {
+  return item.date ?? item.createdAt;
+}
+
+export async function listTimeline(limit = 200): Promise<TimelineItem[]> {
+  const supabase = await createClient();
+
+  const [videos, lives, radios, articles, tvShows, topics] = await Promise.all([
+    supabase
+      .from("videos")
+      .select(`id, title, published_at, created_at, video_casts(${CAST_SUBSELECT})`)
+      .order("published_at", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .limit(limit),
+    supabase
+      .from("lives")
+      .select(`id, title, event_date, created_at, live_casts(${CAST_SUBSELECT})`)
+      .order("event_date", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .limit(limit),
+    supabase
+      .from("radios")
+      .select(`id, title, published_at, created_at, radio_casts(${CAST_SUBSELECT})`)
+      .order("published_at", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .limit(limit),
+    supabase
+      .from("articles")
+      .select(`id, title, published_at, created_at, article_casts(${CAST_SUBSELECT})`)
+      .order("published_at", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .limit(limit),
+    supabase
+      .from("tv_shows")
+      .select(`id, title, air_date, created_at, tv_show_casts(${CAST_SUBSELECT})`)
+      .order("air_date", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .limit(limit),
+    supabase
+      .from("topics")
+      .select(`id, title, topic_date, created_at, topic_casts(${CAST_SUBSELECT})`)
+      .order("topic_date", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .limit(limit),
+  ]);
+
+  const errors = [videos, lives, radios, articles, tvShows, topics]
+    .map((r) => r.error)
+    .filter((e): e is NonNullable<typeof e> => e !== null);
+  if (errors.length > 0) {
+    throw new Error(`タイムラインの取得に失敗しました: ${errors[0].message}`);
+  }
+
+  const items: TimelineItem[] = [
+    ...((videos.data ?? []) as Row[]).map((r) => ({
+      type: "video" as const,
+      id: r.id as string,
+      title: r.title as string,
+      date: (r.published_at as string | null) ?? null,
+      createdAt: r.created_at as string,
+      casts: mapCasts(r.video_casts as CastRow[] | null | undefined),
+    })),
+    ...((lives.data ?? []) as Row[]).map((r) => ({
+      type: "live" as const,
+      id: r.id as string,
+      title: r.title as string,
+      date: (r.event_date as string | null) ?? null,
+      createdAt: r.created_at as string,
+      casts: mapCasts(r.live_casts as CastRow[] | null | undefined),
+    })),
+    ...((radios.data ?? []) as Row[]).map((r) => ({
+      type: "radio" as const,
+      id: r.id as string,
+      title: r.title as string,
+      date: (r.published_at as string | null) ?? null,
+      createdAt: r.created_at as string,
+      casts: mapCasts(r.radio_casts as CastRow[] | null | undefined),
+    })),
+    ...((articles.data ?? []) as Row[]).map((r) => ({
+      type: "article" as const,
+      id: r.id as string,
+      title: r.title as string,
+      date: (r.published_at as string | null) ?? null,
+      createdAt: r.created_at as string,
+      casts: mapCasts(r.article_casts as CastRow[] | null | undefined),
+    })),
+    ...((tvShows.data ?? []) as Row[]).map((r) => ({
+      type: "tv_show" as const,
+      id: r.id as string,
+      title: r.title as string,
+      date: (r.air_date as string | null) ?? null,
+      createdAt: r.created_at as string,
+      casts: mapCasts(r.tv_show_casts as CastRow[] | null | undefined),
+    })),
+    ...((topics.data ?? []) as Row[]).map((r) => ({
+      type: "topic" as const,
+      id: r.id as string,
+      title: r.title as string,
+      date: (r.topic_date as string | null) ?? null,
+      createdAt: r.created_at as string,
+      casts: mapCasts(r.topic_casts as CastRow[] | null | undefined),
+    })),
+  ];
+
+  items.sort((a, b) => sortKey(b).localeCompare(sortKey(a)));
+  return items.slice(0, limit);
+}

--- a/src/lib/queries/timeline.ts
+++ b/src/lib/queries/timeline.ts
@@ -28,7 +28,7 @@ function sortKey(item: TimelineItem): string {
   return item.date ?? item.createdAt;
 }
 
-export async function listTimeline(limit = 200): Promise<TimelineItem[]> {
+export async function listTimeline(limit?: number): Promise<TimelineItem[]> {
   const supabase = await createClient();
 
   const [videos, lives, radios, articles, tvShows, topics] = await Promise.all([
@@ -36,38 +36,32 @@ export async function listTimeline(limit = 200): Promise<TimelineItem[]> {
       .from("videos")
       .select(`id, title, published_at, created_at, video_casts(${CAST_SUBSELECT})`)
       .order("published_at", { ascending: false, nullsFirst: false })
-      .order("created_at", { ascending: false })
-      .limit(limit),
+      .order("created_at", { ascending: false }),
     supabase
       .from("lives")
       .select(`id, title, event_date, created_at, live_casts(${CAST_SUBSELECT})`)
       .order("event_date", { ascending: false, nullsFirst: false })
-      .order("created_at", { ascending: false })
-      .limit(limit),
+      .order("created_at", { ascending: false }),
     supabase
       .from("radios")
       .select(`id, title, published_at, created_at, radio_casts(${CAST_SUBSELECT})`)
       .order("published_at", { ascending: false, nullsFirst: false })
-      .order("created_at", { ascending: false })
-      .limit(limit),
+      .order("created_at", { ascending: false }),
     supabase
       .from("articles")
       .select(`id, title, published_at, created_at, article_casts(${CAST_SUBSELECT})`)
       .order("published_at", { ascending: false, nullsFirst: false })
-      .order("created_at", { ascending: false })
-      .limit(limit),
+      .order("created_at", { ascending: false }),
     supabase
       .from("tv_shows")
       .select(`id, title, air_date, created_at, tv_show_casts(${CAST_SUBSELECT})`)
       .order("air_date", { ascending: false, nullsFirst: false })
-      .order("created_at", { ascending: false })
-      .limit(limit),
+      .order("created_at", { ascending: false }),
     supabase
       .from("topics")
       .select(`id, title, topic_date, created_at, topic_casts(${CAST_SUBSELECT})`)
       .order("topic_date", { ascending: false, nullsFirst: false })
-      .order("created_at", { ascending: false })
-      .limit(limit),
+      .order("created_at", { ascending: false }),
   ]);
 
   const errors = [videos, lives, radios, articles, tvShows, topics]
@@ -128,6 +122,10 @@ export async function listTimeline(limit = 200): Promise<TimelineItem[]> {
     })),
   ];
 
-  items.sort((a, b) => sortKey(b).localeCompare(sortKey(a)));
-  return items.slice(0, limit);
+  items.sort((a, b) => {
+    const aKey = sortKey(a);
+    const bKey = sortKey(b);
+    return aKey < bKey ? 1 : aKey > bKey ? -1 : 0;
+  });
+  return typeof limit === "number" ? items.slice(0, limit) : items;
 }


### PR DESCRIPTION
## 概要

issue #33 の対応として、全コンテンツ（動画・ライブ・ラジオ・記事・TV・トピック）を時系列で一本にまとめて閲覧できるタイムラインページを追加しました。

## 変更内容

- `/timeline` ページを新設
  - 各コンテンツの主たる日付（`published_at` / `event_date` / `air_date` / `topic_date`、なければ `created_at`）で降順ソート
  - 日付ごとにグルーピングし、ブランドカラーの縦線で「タイムライン」感を演出
  - 各アイテムに `ContentTypeBadge`（種別バッジ）と `PerformerTagList`（出演者タグ）を表示
- データ取得層 `src/lib/queries/timeline.ts` を追加
  - 6 種類のコンテンツテーブルを並列取得し、共通の `TimelineItem` に正規化
  - 既存の `mapCasts` を再利用して出演者情報を統合
- 動線追加
  - ヘッダーナビとモバイルの More メニューに「タイムライン」リンク
  - トップページの「最近追加されたコンテンツ」セクションから `/timeline` へ遷移できるよう一覧リンクを追加

## 動作確認

- [ ] `/timeline` で全コンテンツが日付降順に表示される
- [ ] 各アイテムのバッジが種別に対応している
- [ ] 各アイテムから個別の詳細ページへ遷移できる
- [ ] ヘッダー・モバイル More メニュー・トップページからタイムラインへ遷移できる
- [ ] コンテンツが 0 件のときに空メッセージが表示される

Closes #33

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyPJd8JECPnoBoE74UwcDa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Timeline view showing recent content grouped by date.
  * Added Timeline links in the header and bottom navigation.
  * Recent Content section now includes a link to the full Timeline view.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/84)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->