### PR TITLE
feat: 一覧ページに並び替えと出演者フィルタを追加

### DIFF
--- a/src/app/(public)/articles/page.tsx
+++ b/src/app/(public)/articles/page.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from "next";
 import { ArticleCard } from "@/components/features/article/article-card";
+import { ListFilterBar } from "@/components/shared/list-filter-bar";
+import {
+  parsePerformerParam,
+  parseSortParam,
+} from "@/lib/queries/_list-options";
 import { listArticlesWithCasts } from "@/lib/queries/articles";
+import { listAllPerformers } from "@/lib/queries/performers";
 
 export const dynamic = "force-dynamic";
 
@@ -16,8 +22,24 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function ArticlesPage() {
-  const articles = await listArticlesWithCasts();
+type SearchParams = Promise<{
+  sort?: string | string[];
+  performer?: string | string[];
+}>;
+
+export default async function ArticlesPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const sort = parseSortParam(params.sort);
+  const performer = parsePerformerParam(params.performer);
+
+  const [articles, performers] = await Promise.all([
+    listArticlesWithCasts({ sort, performer }),
+    listAllPerformers(),
+  ]);
 
   return (
     <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
@@ -29,6 +51,8 @@ export default async function ArticlesPage() {
           ドンデコルテさん関連の記事・インタビュー。本文は転載せず、出典元へのリンクのみ掲載しています。
         </p>
       </header>
+
+      <ListFilterBar performers={performers} />
 
       {articles.length === 0 ? (
         <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">

--- a/src/app/(public)/lives/page.tsx
+++ b/src/app/(public)/lives/page.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from "next";
 import { LiveList } from "@/components/features/live/live-list";
+import { ListFilterBar } from "@/components/shared/list-filter-bar";
+import {
+  parsePerformerParam,
+  parseSortParam,
+} from "@/lib/queries/_list-options";
 import { listLivesWithCasts } from "@/lib/queries/lives";
+import { listAllPerformers } from "@/lib/queries/performers";
 
 export const dynamic = "force-dynamic";
 
@@ -15,8 +21,24 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function LivesPage() {
-  const lives = await listLivesWithCasts();
+type SearchParams = Promise<{
+  sort?: string | string[];
+  performer?: string | string[];
+}>;
+
+export default async function LivesPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const sort = parseSortParam(params.sort);
+  const performer = parsePerformerParam(params.performer);
+
+  const [lives, performers] = await Promise.all([
+    listLivesWithCasts({ sort, performer }),
+    listAllPerformers(),
+  ]);
 
   return (
     <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
@@ -28,6 +50,8 @@ export default async function LivesPage() {
           ドンデコルテさん関連のライブ情報一覧。
         </p>
       </header>
+
+      <ListFilterBar performers={performers} />
 
       <LiveList lives={lives} />
     </div>

--- a/src/app/(public)/radios/page.tsx
+++ b/src/app/(public)/radios/page.tsx
@@ -1,5 +1,11 @@
 import type { Metadata } from "next";
 import { RadioCard } from "@/components/features/radio/radio-card";
+import { ListFilterBar } from "@/components/shared/list-filter-bar";
+import {
+  parsePerformerParam,
+  parseSortParam,
+} from "@/lib/queries/_list-options";
+import { listAllPerformers } from "@/lib/queries/performers";
 import { listRadiosWithCasts } from "@/lib/queries/radios";
 
 export const dynamic = "force-dynamic";
@@ -15,8 +21,24 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function RadiosPage() {
-  const radios = await listRadiosWithCasts();
+type SearchParams = Promise<{
+  sort?: string | string[];
+  performer?: string | string[];
+}>;
+
+export default async function RadiosPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const sort = parseSortParam(params.sort);
+  const performer = parsePerformerParam(params.performer);
+
+  const [radios, performers] = await Promise.all([
+    listRadiosWithCasts({ sort, performer }),
+    listAllPerformers(),
+  ]);
 
   return (
     <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
@@ -28,6 +50,8 @@ export default async function RadiosPage() {
           ドンデコルテさんのラジオ出演情報一覧。
         </p>
       </header>
+
+      <ListFilterBar performers={performers} />
 
       {radios.length === 0 ? (
         <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">

--- a/src/app/(public)/topics/page.tsx
+++ b/src/app/(public)/topics/page.tsx
@@ -1,5 +1,11 @@
 import type { Metadata } from "next";
 import { TopicCard } from "@/components/features/topic/topic-card";
+import { ListFilterBar } from "@/components/shared/list-filter-bar";
+import {
+  parsePerformerParam,
+  parseSortParam,
+} from "@/lib/queries/_list-options";
+import { listAllPerformers } from "@/lib/queries/performers";
 import { listTopicsWithCasts } from "@/lib/queries/topics";
 
 export const dynamic = "force-dynamic";
@@ -16,8 +22,24 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function TopicsPage() {
-  const topics = await listTopicsWithCasts();
+type SearchParams = Promise<{
+  sort?: string | string[];
+  performer?: string | string[];
+}>;
+
+export default async function TopicsPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const sort = parseSortParam(params.sort);
+  const performer = parsePerformerParam(params.performer);
+
+  const [topics, performers] = await Promise.all([
+    listTopicsWithCasts({ sort, performer }),
+    listAllPerformers(),
+  ]);
 
   return (
     <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
@@ -29,6 +51,8 @@ export default async function TopicsPage() {
           写真撮影会・X投稿・CM情報など、ドンデコルテさんに関する雑多な情報。
         </p>
       </header>
+
+      <ListFilterBar performers={performers} />
 
       {topics.length === 0 ? (
         <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">

--- a/src/app/(public)/tv/page.tsx
+++ b/src/app/(public)/tv/page.tsx
@@ -1,5 +1,11 @@
 import type { Metadata } from "next";
 import { TvShowCard } from "@/components/features/tv-show/tv-show-card";
+import { ListFilterBar } from "@/components/shared/list-filter-bar";
+import {
+  parsePerformerParam,
+  parseSortParam,
+} from "@/lib/queries/_list-options";
+import { listAllPerformers } from "@/lib/queries/performers";
 import { listTvShowsWithCasts } from "@/lib/queries/tv-shows";
 
 export const dynamic = "force-dynamic";
@@ -15,8 +21,24 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function TvPage() {
-  const tvShows = await listTvShowsWithCasts();
+type SearchParams = Promise<{
+  sort?: string | string[];
+  performer?: string | string[];
+}>;
+
+export default async function TvPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const sort = parseSortParam(params.sort);
+  const performer = parsePerformerParam(params.performer);
+
+  const [tvShows, performers] = await Promise.all([
+    listTvShowsWithCasts({ sort, performer }),
+    listAllPerformers(),
+  ]);
 
   return (
     <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
@@ -26,6 +48,8 @@ export default async function TvPage() {
           ドンデコルテさんのテレビ出演情報一覧。
         </p>
       </header>
+
+      <ListFilterBar performers={performers} />
 
       {tvShows.length === 0 ? (
         <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">

--- a/src/app/(public)/videos/page.tsx
+++ b/src/app/(public)/videos/page.tsx
@@ -1,5 +1,11 @@
 import type { Metadata } from "next";
 import { VideoGrid } from "@/components/features/video/video-grid";
+import { ListFilterBar } from "@/components/shared/list-filter-bar";
+import {
+  parsePerformerParam,
+  parseSortParam,
+} from "@/lib/queries/_list-options";
+import { listAllPerformers } from "@/lib/queries/performers";
 import { listVideos } from "@/lib/queries/videos";
 
 export const dynamic = "force-dynamic";
@@ -15,8 +21,24 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function VideosPage() {
-  const videos = await listVideos();
+type SearchParams = Promise<{
+  sort?: string | string[];
+  performer?: string | string[];
+}>;
+
+export default async function VideosPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const sort = parseSortParam(params.sort);
+  const performer = parsePerformerParam(params.performer);
+
+  const [videos, performers] = await Promise.all([
+    listVideos({ sort, performer }),
+    listAllPerformers(),
+  ]);
 
   return (
     <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
@@ -28,6 +50,8 @@ export default async function VideosPage() {
           ドンデコルテさん関連のYouTube動画一覧。
         </p>
       </header>
+
+      <ListFilterBar performers={performers} />
 
       <VideoGrid videos={videos} />
     </div>

--- a/src/components/shared/list-filter-bar.tsx
+++ b/src/components/shared/list-filter-bar.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+import type { PerformerOptions } from "@/lib/queries/performers";
+
+type Props = {
+  performers: PerformerOptions;
+};
+
+export function ListFilterBar({ performers }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const sort = searchParams.get("sort") === "oldest" ? "oldest" : "newest";
+  const performer = searchParams.get("performer") ?? "";
+
+  const updateParam = (key: string, value: string | null) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    const qs = params.toString();
+    startTransition(() => {
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    });
+  };
+
+  return (
+    <div
+      className="mb-4 flex flex-col gap-2 rounded-lg border border-brand-border-dark bg-brand-card-dark p-3 sm:flex-row sm:items-center sm:gap-3 md:mb-6"
+      aria-busy={isPending}
+    >
+      <label className="flex items-center gap-2 text-xs text-brand-gold sm:text-sm">
+        <span className="shrink-0">並び替え</span>
+        <select
+          value={sort}
+          onChange={(e) =>
+            updateParam("sort", e.target.value === "oldest" ? "oldest" : null)
+          }
+          className="block w-full min-w-0 rounded-md border border-brand-border-dark bg-brand-bg-dark px-2 py-1.5 text-sm text-brand-cream focus:border-brand-sky-light focus:outline-none focus:ring-1 focus:ring-brand-sky-light sm:w-auto"
+        >
+          <option value="newest">新着順</option>
+          <option value="oldest">古い順</option>
+        </select>
+      </label>
+
+      <label className="flex items-center gap-2 text-xs text-brand-gold sm:text-sm">
+        <span className="shrink-0">出演者</span>
+        <select
+          value={performer}
+          onChange={(e) => updateParam("performer", e.target.value || null)}
+          className="block w-full min-w-0 rounded-md border border-brand-border-dark bg-brand-bg-dark px-2 py-1.5 text-sm text-brand-cream focus:border-brand-sky-light focus:outline-none focus:ring-1 focus:ring-brand-sky-light sm:w-64"
+        >
+          <option value="">すべて</option>
+          {performers.combos.length > 0 ? (
+            <optgroup label="コンビ">
+              {performers.combos.map((p) => (
+                <option key={`combo-${p.id}`} value={`comedy_group:${p.id}`}>
+                  {p.name}
+                </option>
+              ))}
+            </optgroup>
+          ) : null}
+          {performers.artists.length > 0 ? (
+            <optgroup label="芸人">
+              {performers.artists.map((p) => (
+                <option key={`artist-${p.id}`} value={`artist:${p.id}`}>
+                  {p.name}
+                </option>
+              ))}
+            </optgroup>
+          ) : null}
+          {performers.units.length > 0 ? (
+            <optgroup label="ユニット">
+              {performers.units.map((p) => (
+                <option key={`unit-${p.id}`} value={`unit:${p.id}`}>
+                  {p.name}
+                </option>
+              ))}
+            </optgroup>
+          ) : null}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/src/lib/queries/_list-options.ts
+++ b/src/lib/queries/_list-options.ts
@@ -1,0 +1,76 @@
+import type { createClient } from "@/lib/supabase/server";
+import type { CastType } from "@/lib/types";
+
+export type SortOrder = "newest" | "oldest";
+
+export type PerformerFilter = {
+  type: CastType;
+  id: string;
+};
+
+export type ListOptions = {
+  sort?: SortOrder;
+  performer?: PerformerFilter | null;
+};
+
+type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
+
+type CastTable =
+  | "video_casts"
+  | "live_casts"
+  | "radio_casts"
+  | "article_casts"
+  | "tv_show_casts"
+  | "topic_casts";
+
+function castFieldFor(
+  type: CastType
+): "artist_id" | "comedy_group_id" | "unit_id" {
+  if (type === "artist") return "artist_id";
+  if (type === "comedy_group") return "comedy_group_id";
+  return "unit_id";
+}
+
+export async function getIdsForPerformer<K extends string>(
+  supabase: SupabaseClient,
+  castTable: CastTable,
+  parentIdField: K,
+  performer: PerformerFilter
+): Promise<string[]> {
+  const { data, error } = await supabase
+    .from(castTable)
+    .select(parentIdField)
+    .eq(castFieldFor(performer.type), performer.id);
+
+  if (error) {
+    throw new Error(`出演者による絞り込みに失敗しました: ${error.message}`);
+  }
+
+  const ids = ((data ?? []) as Array<Record<K, string>>).map(
+    (row) => row[parentIdField]
+  );
+  return Array.from(new Set(ids));
+}
+
+export function parsePerformerParam(
+  raw: string | string[] | null | undefined
+): PerformerFilter | null {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (!value) return null;
+  const sep = value.indexOf(":");
+  if (sep < 0) return null;
+  const type = value.slice(0, sep);
+  const id = value.slice(sep + 1);
+  if (!id) return null;
+  if (type !== "artist" && type !== "comedy_group" && type !== "unit") {
+    return null;
+  }
+  return { type, id };
+}
+
+export function parseSortParam(
+  raw: string | string[] | null | undefined
+): SortOrder {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return value === "oldest" ? "oldest" : "newest";
+}

--- a/src/lib/queries/_list-options.ts
+++ b/src/lib/queries/_list-options.ts
@@ -52,6 +52,9 @@ export async function getIdsForPerformer<K extends string>(
   return Array.from(new Set(ids));
 }
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function parsePerformerParam(
   raw: string | string[] | null | undefined
 ): PerformerFilter | null {
@@ -61,7 +64,7 @@ export function parsePerformerParam(
   if (sep < 0) return null;
   const type = value.slice(0, sep);
   const id = value.slice(sep + 1);
-  if (!id) return null;
+  if (!UUID_PATTERN.test(id)) return null;
   if (type !== "artist" && type !== "comedy_group" && type !== "unit") {
     return null;
   }

--- a/src/lib/queries/articles.ts
+++ b/src/lib/queries/articles.ts
@@ -1,5 +1,9 @@
 import { createClient } from "@/lib/supabase/server";
 import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import {
+  getIdsForPerformer,
+  type ListOptions,
+} from "@/lib/queries/_list-options";
 import type { Article, ArticleWithCasts } from "@/lib/types/article";
 
 function toArticleBase(row: Record<string, unknown>): Article {
@@ -15,13 +19,34 @@ function toArticleBase(row: Record<string, unknown>): Article {
   };
 }
 
-export async function listArticles(): Promise<Article[]> {
+export async function listArticles(
+  options: ListOptions = {}
+): Promise<Article[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "article_casts",
+      "article_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("articles")
     .select("*")
-    .order("published_at", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("published_at", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`記事一覧の取得に失敗しました: ${error.message}`);
@@ -30,9 +55,24 @@ export async function listArticles(): Promise<Article[]> {
   return (data ?? []) as Article[];
 }
 
-export async function listArticlesWithCasts(): Promise<ArticleWithCasts[]> {
+export async function listArticlesWithCasts(
+  options: ListOptions = {}
+): Promise<ArticleWithCasts[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "article_casts",
+      "article_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("articles")
     .select(
       `*,
@@ -46,8 +86,14 @@ export async function listArticlesWithCasts(): Promise<ArticleWithCasts[]> {
          unit:units(id, name)
        )`
     )
-    .order("published_at", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("published_at", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`記事一覧の取得に失敗しました: ${error.message}`);

--- a/src/lib/queries/lives.ts
+++ b/src/lib/queries/lives.ts
@@ -1,5 +1,9 @@
 import { createClient } from "@/lib/supabase/server";
 import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import {
+  getIdsForPerformer,
+  type ListOptions,
+} from "@/lib/queries/_list-options";
 import type { Live, LiveWithCasts } from "@/lib/types/live";
 
 function toLiveBase(row: Record<string, unknown>): Live {
@@ -17,13 +21,32 @@ function toLiveBase(row: Record<string, unknown>): Live {
   };
 }
 
-export async function listLives(): Promise<Live[]> {
+export async function listLives(options: ListOptions = {}): Promise<Live[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "live_casts",
+      "live_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("lives")
     .select("*")
-    .order("event_date", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("event_date", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`ライブ一覧の取得に失敗しました: ${error.message}`);
@@ -32,9 +55,24 @@ export async function listLives(): Promise<Live[]> {
   return (data ?? []) as Live[];
 }
 
-export async function listLivesWithCasts(): Promise<LiveWithCasts[]> {
+export async function listLivesWithCasts(
+  options: ListOptions = {}
+): Promise<LiveWithCasts[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "live_casts",
+      "live_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("lives")
     .select(
       `*,
@@ -48,9 +86,15 @@ export async function listLivesWithCasts(): Promise<LiveWithCasts[]> {
          unit:units(id, name)
        )`
     )
-    .order("event_date", { ascending: false, nullsFirst: false })
-    .order("start_time", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("event_date", { ascending, nullsFirst: false })
+    .order("start_time", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`ライブ一覧の取得に失敗しました: ${error.message}`);

--- a/src/lib/queries/performers.ts
+++ b/src/lib/queries/performers.ts
@@ -1,0 +1,32 @@
+import { listArtistSummaries } from "@/lib/queries/artists";
+import { listComboSummaries } from "@/lib/queries/combos";
+import { listUnitSummaries } from "@/lib/queries/units";
+import type { CastEntry } from "@/lib/types";
+
+export type PerformerOptions = {
+  combos: CastEntry[];
+  artists: CastEntry[];
+  units: CastEntry[];
+};
+
+export async function listAllPerformers(): Promise<PerformerOptions> {
+  const [artists, combos, units] = await Promise.all([
+    listArtistSummaries(),
+    listComboSummaries(),
+    listUnitSummaries(),
+  ]);
+
+  return {
+    combos: combos.map((c) => ({
+      type: "comedy_group" as const,
+      id: c.id,
+      name: c.name,
+    })),
+    artists: artists.map((a) => ({
+      type: "artist" as const,
+      id: a.id,
+      name: a.name,
+    })),
+    units: units.map((u) => ({ type: "unit" as const, id: u.id, name: u.name })),
+  };
+}

--- a/src/lib/queries/radios.ts
+++ b/src/lib/queries/radios.ts
@@ -1,5 +1,9 @@
 import { createClient } from "@/lib/supabase/server";
 import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import {
+  getIdsForPerformer,
+  type ListOptions,
+} from "@/lib/queries/_list-options";
 import type { Radio, RadioWithCasts } from "@/lib/types/radio";
 
 function toRadioBase(row: Record<string, unknown>): Radio {
@@ -15,13 +19,32 @@ function toRadioBase(row: Record<string, unknown>): Radio {
   };
 }
 
-export async function listRadios(): Promise<Radio[]> {
+export async function listRadios(options: ListOptions = {}): Promise<Radio[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "radio_casts",
+      "radio_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("radios")
     .select("*")
-    .order("published_at", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("published_at", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`ラジオ一覧の取得に失敗しました: ${error.message}`);
@@ -30,9 +53,24 @@ export async function listRadios(): Promise<Radio[]> {
   return (data ?? []) as Radio[];
 }
 
-export async function listRadiosWithCasts(): Promise<RadioWithCasts[]> {
+export async function listRadiosWithCasts(
+  options: ListOptions = {}
+): Promise<RadioWithCasts[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "radio_casts",
+      "radio_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("radios")
     .select(
       `*,
@@ -46,8 +84,14 @@ export async function listRadiosWithCasts(): Promise<RadioWithCasts[]> {
          unit:units(id, name)
        )`
     )
-    .order("published_at", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("published_at", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`ラジオ一覧の取得に失敗しました: ${error.message}`);

--- a/src/lib/queries/topics.ts
+++ b/src/lib/queries/topics.ts
@@ -1,5 +1,9 @@
 import { createClient } from "@/lib/supabase/server";
 import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import {
+  getIdsForPerformer,
+  type ListOptions,
+} from "@/lib/queries/_list-options";
 import type { Topic, TopicWithCasts } from "@/lib/types/topic";
 
 function toTopicBase(row: Record<string, unknown>): Topic {
@@ -15,13 +19,34 @@ function toTopicBase(row: Record<string, unknown>): Topic {
   };
 }
 
-export async function listTopics(): Promise<Topic[]> {
+export async function listTopics(
+  options: ListOptions = {}
+): Promise<Topic[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "topic_casts",
+      "topic_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("topics")
     .select("*")
-    .order("topic_date", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("topic_date", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`トピック一覧の取得に失敗しました: ${error.message}`);
@@ -30,9 +55,24 @@ export async function listTopics(): Promise<Topic[]> {
   return (data ?? []) as Topic[];
 }
 
-export async function listTopicsWithCasts(): Promise<TopicWithCasts[]> {
+export async function listTopicsWithCasts(
+  options: ListOptions = {}
+): Promise<TopicWithCasts[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "topic_casts",
+      "topic_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("topics")
     .select(
       `*,
@@ -46,8 +86,14 @@ export async function listTopicsWithCasts(): Promise<TopicWithCasts[]> {
          unit:units(id, name)
        )`
     )
-    .order("topic_date", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("topic_date", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`トピック一覧の取得に失敗しました: ${error.message}`);

--- a/src/lib/queries/tv-shows.ts
+++ b/src/lib/queries/tv-shows.ts
@@ -1,5 +1,9 @@
 import { createClient } from "@/lib/supabase/server";
 import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import {
+  getIdsForPerformer,
+  type ListOptions,
+} from "@/lib/queries/_list-options";
 import type { TvShow, TvShowWithCasts } from "@/lib/types/tv-show";
 
 function toTvShowBase(row: Record<string, unknown>): TvShow {
@@ -16,13 +20,34 @@ function toTvShowBase(row: Record<string, unknown>): TvShow {
   };
 }
 
-export async function listTvShows(): Promise<TvShow[]> {
+export async function listTvShows(
+  options: ListOptions = {}
+): Promise<TvShow[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "tv_show_casts",
+      "tv_show_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("tv_shows")
     .select("*")
-    .order("air_date", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("air_date", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`TV番組一覧の取得に失敗しました: ${error.message}`);
@@ -31,9 +56,24 @@ export async function listTvShows(): Promise<TvShow[]> {
   return (data ?? []) as TvShow[];
 }
 
-export async function listTvShowsWithCasts(): Promise<TvShowWithCasts[]> {
+export async function listTvShowsWithCasts(
+  options: ListOptions = {}
+): Promise<TvShowWithCasts[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "tv_show_casts",
+      "tv_show_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("tv_shows")
     .select(
       `*,
@@ -47,9 +87,15 @@ export async function listTvShowsWithCasts(): Promise<TvShowWithCasts[]> {
          unit:units(id, name)
        )`
     )
-    .order("air_date", { ascending: false, nullsFirst: false })
-    .order("air_time", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("air_date", { ascending, nullsFirst: false })
+    .order("air_time", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`TV番組一覧の取得に失敗しました: ${error.message}`);

--- a/src/lib/queries/videos.ts
+++ b/src/lib/queries/videos.ts
@@ -1,14 +1,37 @@
 import { createClient } from "@/lib/supabase/server";
 import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import {
+  getIdsForPerformer,
+  type ListOptions,
+} from "@/lib/queries/_list-options";
 import type { Video, VideoWithCasts } from "@/lib/types/video";
 
-export async function listVideos(): Promise<Video[]> {
+export async function listVideos(options: ListOptions = {}): Promise<Video[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const ascending = options.sort === "oldest";
+
+  let allowedIds: string[] | null = null;
+  if (options.performer) {
+    allowedIds = await getIdsForPerformer(
+      supabase,
+      "video_casts",
+      "video_id",
+      options.performer
+    );
+    if (allowedIds.length === 0) return [];
+  }
+
+  let query = supabase
     .from("videos")
     .select("*")
-    .order("published_at", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false });
+    .order("published_at", { ascending, nullsFirst: false })
+    .order("created_at", { ascending });
+
+  if (allowedIds) {
+    query = query.in("id", allowedIds);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`動画一覧の取得に失敗しました: ${error.message}`);


### PR DESCRIPTION
## 概要

公開側の各一覧ページ（動画・ライブ・ラジオ・記事・TV・トピック）に、URLクエリパラメータで操作する **並び替え** と **出演者フィルタ** を追加しました。

Closes #34

## 変更内容

### UI
- `src/components/shared/list-filter-bar.tsx` を新規追加（Client Component）
  - 並び替え（新着順 / 古い順）の `<select>`
  - 出演者フィルタの `<select>`（コンビ / 芸人 / ユニットを `<optgroup>` で分類）
  - `useRouter().replace()` でURLクエリを更新（履歴を汚さず、`startTransition` で滑らかに再フェッチ）

### Server / Query
- `src/lib/queries/_list-options.ts` を新規追加
  - `ListOptions = { sort?: "newest" | "oldest"; performer?: { type, id } | null }`
  - `parseSortParam` / `parsePerformerParam` — `searchParams` の安全なパース
  - `getIdsForPerformer` — `*_casts` テーブルから親IDを引く共通ヘルパ
- `src/lib/queries/performers.ts` を新規追加
  - `listAllPerformers()` — コンビ・芸人・ユニットをまとめて取得しフィルタ用に整形
- 各 `list*` / `list*WithCasts` クエリが `ListOptions` を受け取るように更新
  - `sort` に応じて `ascending` を反転（日付NULLは常に末尾）
  - `performer` 指定時は cast テーブルで親IDを絞り込んでから本体を取得

### Pages
- `/videos`, `/lives`, `/radios`, `/articles`, `/tv`, `/topics` の各ページで:
  - `searchParams` を受け取り、`parseSortParam` / `parsePerformerParam` でパース
  - クエリと出演者一覧を `Promise.all` で並列取得
  - 一覧の上部に `<ListFilterBar />` を表示

## URLクエリ仕様

- `?sort=oldest` で古い順、未指定なら新着順
- `?performer=comedy_group:<uuid>` / `artist:<uuid>` / `unit:<uuid>` で出演者絞り込み

## テスト計画

- [ ] 各一覧ページで「新着順 / 古い順」を切り替えると並び順が変わる
- [ ] 出演者を選ぶと該当する出演者を含むコンテンツのみが表示される
- [ ] フィルタ・並び替えがURLに反映され、リロード後も状態が維持される
- [ ] 出演者を「すべて」に戻すとフィルタが解除される
- [ ] 該当データが0件のときに空表示メッセージが表示される


---
_Generated by [Claude Code](https://claude.ai/code/session_01E1bxmMBbLPairTpJUbyRba)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global filtering & sorting now available on Articles, Lives, Radios, Topics, TV Shows, and Videos — filter by performer and sort by newest/oldest.
  * Adds a shared filter bar UI across those pages, populated with performer options and reflected in the URL for sharable state.
  * Pages fetch performer lists and content concurrently for faster, consistent filter-driven results.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/85)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->