### PR TITLE
test: Server Actions のバリデーションテストを追加

### DIFF
--- a/src/components/features/article/article-form.tsx
+++ b/src/components/features/article/article-form.tsx
@@ -138,15 +138,26 @@ export function ArticleForm({
           htmlFor="url"
           className="block text-sm font-medium text-brand-brown-dark"
         >
-          URL
+          URL <span className="text-brand-gold">*</span>
         </label>
         <input
           id="url"
           type="url"
-          {...register("url")}
+          {...register("url", {
+            required: "URLを入力してください",
+            pattern: {
+              value: /^https?:\/\/.+/,
+              message: "URLの形式が不正です（http/https のみ）",
+            },
+          })}
           placeholder="https://..."
           className={inputWithPlaceholderClass}
         />
+        {(clientErrors.url?.message || fieldErrors?.url) && (
+          <p className="mt-1 text-xs text-brand-gold" role="alert">
+            {clientErrors.url?.message ?? fieldErrors?.url}
+          </p>
+        )}
         <p className="mt-0.5 text-xs text-brand-brown-light">
           記事本文の転載不可。元記事へのリンクのみ登録してください。
         </p>
@@ -193,9 +204,20 @@ export function ArticleForm({
         <textarea
           id="content"
           rows={4}
-          {...register("content")}
+          {...register("content", {
+            maxLength: {
+              value: 500,
+              message:
+                "本文の転載は禁止です。要約のみ500文字以内で入力してください",
+            },
+          })}
           className={inputClass}
         />
+        {(clientErrors.content?.message || fieldErrors?.content) && (
+          <p className="mt-1 text-xs text-brand-gold" role="alert">
+            {clientErrors.content?.message ?? fieldErrors?.content}
+          </p>
+        )}
         <p className="mt-0.5 text-xs text-brand-brown-light">
           本文転載不可。自分用のメモや要約のみ記入可能です。
         </p>

--- a/src/components/features/live/live-form.tsx
+++ b/src/components/features/live/live-form.tsx
@@ -136,6 +136,11 @@ export function LiveForm({
           {...register("event_date")}
           className="mt-1 block w-full rounded-md border border-brand-border-light bg-brand-card-light px-3 py-2 text-sm text-brand-brown-dark focus:border-brand-sky focus:outline-none focus:ring-1 focus:ring-brand-sky"
         />
+        {fieldErrors?.event_date && (
+          <p className="mt-1 text-xs text-brand-gold" role="alert">
+            {fieldErrors.event_date}
+          </p>
+        )}
       </div>
 
       <div>

--- a/src/lib/actions/articles.test.ts
+++ b/src/lib/actions/articles.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`__REDIRECT__:${url}`);
+  }),
+}));
+
+const supabaseMock = vi.hoisted(() => ({
+  auth: { getUser: vi.fn() },
+  from: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => supabaseMock),
+}));
+
+import { createArticle, updateArticle, deleteArticle } from "./articles";
+
+function buildFormData(entries: Record<string, string | string[]>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    if (Array.isArray(value)) {
+      for (const v of value) fd.append(key, v);
+    } else {
+      fd.set(key, value);
+    }
+  }
+  return fd;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+  supabaseMock.from.mockReset();
+});
+
+describe("createArticle", () => {
+  it("タイトルが空ならエラーを返す", async () => {
+    const fd = buildFormData({ title: "", url: "https://example.com" });
+    const result = await createArticle({}, fd);
+    expect(result.fieldErrors?.title).toBe("タイトルを入力してください");
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("URLが空の場合はエラーを返す", async () => {
+    const fd = buildFormData({ title: "テスト記事", url: "" });
+    const result = await createArticle({}, fd);
+    expect(result.fieldErrors?.url).toBe("URLを入力してください");
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("URLの形式が不正な場合はエラーを返す", async () => {
+    const fd = buildFormData({ title: "テスト", url: "not-a-url" });
+    const result = await createArticle({}, fd);
+    expect(result.fieldErrors?.url).toBe(
+      "URLの形式が不正です（http/https のみ）"
+    );
+  });
+
+  it("ftp など http/https 以外のスキームは不正", async () => {
+    const fd = buildFormData({
+      title: "テスト",
+      url: "ftp://example.com",
+    });
+    const result = await createArticle({}, fd);
+    expect(result.fieldErrors?.url).toBeDefined();
+  });
+
+  it("contentが500文字を超える（本文転載相当）の場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      title: "テスト",
+      url: "https://example.com",
+      content: "あ".repeat(501),
+    });
+    const result = await createArticle({}, fd);
+    expect(result.fieldErrors?.content).toMatch(/本文の転載は禁止/);
+  });
+
+  it("認証されていない場合はエラーを返す", async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const fd = buildFormData({
+      title: "テスト",
+      url: "https://example.com",
+    });
+    const result = await createArticle({}, fd);
+    expect(result.error).toBe("認証が必要です");
+  });
+
+  it("バリデーション通過時は records を挿入して redirect する", async () => {
+    const insertSelectSingle = vi.fn().mockResolvedValue({
+      data: { id: "11111111-1111-4111-8111-111111111111" },
+      error: null,
+    });
+    const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
+    const insertChain = vi.fn(() => ({ select: insertSelect }));
+    const deleteEq = vi.fn().mockResolvedValue({ error: null });
+    const deleteChain = vi.fn(() => ({ eq: deleteEq }));
+
+    supabaseMock.from.mockImplementation((table: string) => {
+      if (table === "articles") return { insert: insertChain };
+      if (table === "article_casts") return { delete: deleteChain };
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const fd = buildFormData({
+      title: "テスト",
+      url: "https://example.com/article",
+      content: "短い要約",
+    });
+    await expect(createArticle({}, fd)).rejects.toThrow(/__REDIRECT__/);
+    expect(insertChain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "テスト",
+        url: "https://example.com/article",
+        content: "短い要約",
+      })
+    );
+  });
+});
+
+describe("updateArticle", () => {
+  it("IDがUUID形式でない場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      title: "テスト",
+      url: "https://example.com",
+    });
+    const result = await updateArticle("invalid", {}, fd);
+    expect(result.error).toBe("IDが不正です");
+  });
+
+  it("URL未指定の場合はバリデーションエラーを返す", async () => {
+    const fd = buildFormData({ title: "テスト" });
+    const result = await updateArticle(
+      "11111111-1111-4111-8111-111111111111",
+      {},
+      fd
+    );
+    expect(result.fieldErrors?.url).toBeDefined();
+  });
+});
+
+describe("deleteArticle", () => {
+  it("IDが空なら何もせず終了する", async () => {
+    const fd = buildFormData({ id: "" });
+    await expect(deleteArticle(fd)).resolves.toBeUndefined();
+  });
+
+  it("IDがUUID形式でない場合は例外を投げる", async () => {
+    const fd = buildFormData({ id: "not-a-uuid" });
+    await expect(deleteArticle(fd)).rejects.toThrow("IDが不正です");
+  });
+});

--- a/src/lib/actions/articles.ts
+++ b/src/lib/actions/articles.ts
@@ -9,6 +9,17 @@ import type { ArticleFormState, ArticleInput } from "@/lib/types/article";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+const CONTENT_MAX_LENGTH = 500;
+
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 function toNullableString(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
@@ -62,12 +73,24 @@ function parseFormData(formData: FormData): {
     fieldErrors.title = "200文字以内で入力してください";
   }
 
+  const url = toNullableString(formData.get("url"));
+  if (!url) {
+    fieldErrors.url = "URLを入力してください";
+  } else if (!isValidHttpUrl(url)) {
+    fieldErrors.url = "URLの形式が不正です（http/https のみ）";
+  }
+
+  const content = toNullableString(formData.get("content"));
+  if (content && content.length > CONTENT_MAX_LENGTH) {
+    fieldErrors.content = `本文の転載は禁止です。要約のみ${CONTENT_MAX_LENGTH}文字以内で入力してください`;
+  }
+
   const values: ArticleInput = {
     title,
-    url: toNullableString(formData.get("url")),
+    url,
     source: toNullableString(formData.get("source")),
     published_at: toNullableString(formData.get("published_at")),
-    content: toNullableString(formData.get("content")),
+    content,
   };
 
   const { casts, error: castsError } = parseCasts(formData);

--- a/src/lib/actions/lives.test.ts
+++ b/src/lib/actions/lives.test.ts
@@ -65,6 +65,24 @@ describe("createLive", () => {
     expect(supabaseMock.from).not.toHaveBeenCalled();
   });
 
+  it("event_date が存在しない日付（2026-02-30 など）の場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      title: "テストライブ",
+      event_date: "2026-02-30",
+    });
+    const result = await createLive({}, fd);
+    expect(result.fieldErrors?.event_date).toBe(
+      "開催日はYYYY-MM-DD形式で入力してください"
+    );
+
+    const fd2 = buildFormData({
+      title: "テストライブ",
+      event_date: "2026-13-01",
+    });
+    const result2 = await createLive({}, fd2);
+    expect(result2.fieldErrors?.event_date).toBeDefined();
+  });
+
   it("event_date が空でも作成は進む（必須ではない）", async () => {
     const insertSelectSingle = vi.fn().mockResolvedValue({
       data: { id: "11111111-1111-4111-8111-111111111111" },

--- a/src/lib/actions/lives.test.ts
+++ b/src/lib/actions/lives.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`__REDIRECT__:${url}`);
+  }),
+}));
+
+const supabaseMock = vi.hoisted(() => ({
+  auth: { getUser: vi.fn() },
+  from: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => supabaseMock),
+}));
+
+import { createLive, updateLive, deleteLive } from "./lives";
+
+function buildFormData(entries: Record<string, string | string[]>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    if (Array.isArray(value)) {
+      for (const v of value) fd.append(key, v);
+    } else {
+      fd.set(key, value);
+    }
+  }
+  return fd;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+  supabaseMock.from.mockReset();
+});
+
+describe("createLive", () => {
+  it("タイトルが空ならエラーを返す", async () => {
+    const fd = buildFormData({ title: "" });
+    const result = await createLive({}, fd);
+    expect(result.fieldErrors?.title).toBe("タイトルを入力してください");
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("タイトルが200文字を超えるとエラーを返す", async () => {
+    const fd = buildFormData({ title: "あ".repeat(201) });
+    const result = await createLive({}, fd);
+    expect(result.fieldErrors?.title).toBe("200文字以内で入力してください");
+  });
+
+  it("event_date が不正な形式の場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      title: "テストライブ",
+      event_date: "2026/05/01",
+    });
+    const result = await createLive({}, fd);
+    expect(result.fieldErrors?.event_date).toBe(
+      "開催日はYYYY-MM-DD形式で入力してください"
+    );
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("event_date が空でも作成は進む（必須ではない）", async () => {
+    const insertSelectSingle = vi.fn().mockResolvedValue({
+      data: { id: "11111111-1111-4111-8111-111111111111" },
+      error: null,
+    });
+    const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
+    const insertChain = vi.fn(() => ({ select: insertSelect }));
+    const deleteEq = vi.fn().mockResolvedValue({ error: null });
+    const deleteChain = vi.fn(() => ({ eq: deleteEq }));
+
+    supabaseMock.from.mockImplementation((table: string) => {
+      if (table === "lives") return { insert: insertChain };
+      if (table === "live_casts") return { delete: deleteChain };
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const fd = buildFormData({ title: "テスト" });
+    await expect(createLive({}, fd)).rejects.toThrow(/__REDIRECT__/);
+    expect(insertChain).toHaveBeenCalledWith(
+      expect.objectContaining({ event_date: null, start_time: null })
+    );
+  });
+
+  it("event_date と start_time から ISO 形式の開始時刻を組み立てる", async () => {
+    const insertSelectSingle = vi.fn().mockResolvedValue({
+      data: { id: "11111111-1111-4111-8111-111111111111" },
+      error: null,
+    });
+    const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
+    const insertChain = vi.fn(() => ({ select: insertSelect }));
+    const deleteEq = vi.fn().mockResolvedValue({ error: null });
+    const deleteChain = vi.fn(() => ({ eq: deleteEq }));
+
+    supabaseMock.from.mockImplementation((table: string) => {
+      if (table === "lives") return { insert: insertChain };
+      if (table === "live_casts") return { delete: deleteChain };
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const fd = buildFormData({
+      title: "テスト",
+      event_date: "2026-05-14",
+      start_time: "19:30",
+    });
+    await expect(createLive({}, fd)).rejects.toThrow(/__REDIRECT__/);
+    expect(insertChain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_date: "2026-05-14",
+        start_time: "2026-05-14T19:30:00",
+      })
+    );
+  });
+
+  it("認証されていない場合はエラーを返す", async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const fd = buildFormData({ title: "テスト" });
+    const result = await createLive({}, fd);
+    expect(result.error).toBe("認証が必要です");
+  });
+});
+
+describe("updateLive", () => {
+  it("IDがUUID形式でない場合はエラーを返す", async () => {
+    const fd = buildFormData({ title: "テスト" });
+    const result = await updateLive("invalid", {}, fd);
+    expect(result.error).toBe("IDが不正です");
+  });
+
+  it("バリデーションエラーを返す", async () => {
+    const fd = buildFormData({ title: "テスト", event_date: "不正" });
+    const result = await updateLive(
+      "11111111-1111-4111-8111-111111111111",
+      {},
+      fd
+    );
+    expect(result.fieldErrors?.event_date).toBeDefined();
+  });
+});
+
+describe("deleteLive", () => {
+  it("IDが空なら何もせず終了する", async () => {
+    const fd = buildFormData({ id: "" });
+    await expect(deleteLive(fd)).resolves.toBeUndefined();
+  });
+
+  it("IDがUUID形式でない場合は例外を投げる", async () => {
+    const fd = buildFormData({ id: "not-a-uuid" });
+    await expect(deleteLive(fd)).rejects.toThrow("IDが不正です");
+  });
+});

--- a/src/lib/actions/lives.ts
+++ b/src/lib/actions/lives.ts
@@ -9,7 +9,22 @@ import type { LiveFormState, LiveInput } from "@/lib/types/live";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const EVENT_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const EVENT_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+function isValidEventDate(value: string): boolean {
+  const match = EVENT_DATE_PATTERN.exec(value);
+  if (!match) return false;
+  const [, y, m, d] = match;
+  const year = Number(y);
+  const month = Number(m);
+  const day = Number(d);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
 
 function toNullableString(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") return null;
@@ -65,7 +80,7 @@ function parseFormData(formData: FormData): {
   }
 
   const event_date = toNullableString(formData.get("event_date"));
-  if (event_date && !EVENT_DATE_PATTERN.test(event_date)) {
+  if (event_date && !isValidEventDate(event_date)) {
     fieldErrors.event_date = "開催日はYYYY-MM-DD形式で入力してください";
   }
 

--- a/src/lib/actions/lives.ts
+++ b/src/lib/actions/lives.ts
@@ -9,6 +9,8 @@ import type { LiveFormState, LiveInput } from "@/lib/types/live";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+const EVENT_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
 function toNullableString(value: FormDataEntryValue | null): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
@@ -63,6 +65,10 @@ function parseFormData(formData: FormData): {
   }
 
   const event_date = toNullableString(formData.get("event_date"));
+  if (event_date && !EVENT_DATE_PATTERN.test(event_date)) {
+    fieldErrors.event_date = "開催日はYYYY-MM-DD形式で入力してください";
+  }
+
   const startTimeInput = String(formData.get("start_time") ?? "").trim();
   const start_time =
     event_date && startTimeInput ? `${event_date}T${startTimeInput}:00` : null;

--- a/src/lib/actions/memos.test.ts
+++ b/src/lib/actions/memos.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const supabaseMock = vi.hoisted(() => ({
+  auth: { getUser: vi.fn() },
+  from: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => supabaseMock),
+}));
+
+import { createMemo, updateMemo, deleteMemo } from "./memos";
+
+function buildFormData(entries: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+const VALID_UUID = "11111111-1111-4111-8111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+  supabaseMock.from.mockReset();
+});
+
+describe("createMemo", () => {
+  it("target_type が空ならエラーを返す", async () => {
+    const fd = buildFormData({
+      target_type: "",
+      target_id: VALID_UUID,
+      content: "感想",
+    });
+    const result = await createMemo({}, fd);
+    expect(result.error).toBe("対象種別が不正です");
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("target_type が許可外の値ならエラーを返す", async () => {
+    const fd = buildFormData({
+      target_type: "unknown",
+      target_id: VALID_UUID,
+      content: "感想",
+    });
+    const result = await createMemo({}, fd);
+    expect(result.error).toBe("対象種別が不正です");
+  });
+
+  it("target_id がUUID形式でない場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      target_type: "video",
+      target_id: "not-a-uuid",
+      content: "感想",
+    });
+    const result = await createMemo({}, fd);
+    expect(result.error).toBe("対象IDが不正です");
+  });
+
+  it("content が空ならエラーを返す", async () => {
+    const fd = buildFormData({
+      target_type: "video",
+      target_id: VALID_UUID,
+      content: "",
+    });
+    const result = await createMemo({}, fd);
+    expect(result.fieldError).toBe("感想を入力してください");
+  });
+
+  it("content が2000文字を超える場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      target_type: "video",
+      target_id: VALID_UUID,
+      content: "あ".repeat(2001),
+    });
+    const result = await createMemo({}, fd);
+    expect(result.fieldError).toBe("2000文字以内で入力してください");
+  });
+
+  it("認証されていない場合はエラーを返す", async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const fd = buildFormData({
+      target_type: "video",
+      target_id: VALID_UUID,
+      content: "感想",
+    });
+    const result = await createMemo({}, fd);
+    expect(result.error).toBe("認証が必要です");
+  });
+
+  it("各コンテンツ種別を許可する", async () => {
+    const insertMock = vi.fn().mockResolvedValue({ error: null });
+    supabaseMock.from.mockReturnValue({ insert: insertMock });
+
+    const types = ["video", "live", "radio", "article", "tv_show", "topic"];
+    for (const type of types) {
+      const fd = buildFormData({
+        target_type: type,
+        target_id: VALID_UUID,
+        content: "感想",
+      });
+      const result = await createMemo({}, fd);
+      expect(result).toEqual({});
+    }
+    expect(insertMock).toHaveBeenCalledTimes(types.length);
+    expect(insertMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        target_type: "topic",
+        target_id: VALID_UUID,
+        content: "感想",
+      })
+    );
+  });
+
+  it("挿入失敗時はエラーメッセージを返す", async () => {
+    const insertMock = vi
+      .fn()
+      .mockResolvedValue({ error: { message: "boom" } });
+    supabaseMock.from.mockReturnValue({ insert: insertMock });
+
+    const fd = buildFormData({
+      target_type: "video",
+      target_id: VALID_UUID,
+      content: "感想",
+    });
+    const result = await createMemo({}, fd);
+    expect(result.error).toMatch(/感想の登録に失敗しました: boom/);
+  });
+});
+
+describe("updateMemo", () => {
+  it("IDがUUID形式でない場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      id: "invalid",
+      target_type: "video",
+      target_id: VALID_UUID,
+      content: "感想",
+    });
+    const result = await updateMemo({}, fd);
+    expect(result.error).toBe("感想IDが不正です");
+  });
+
+  it("target_type が不正な場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      id: VALID_UUID,
+      target_type: "unknown",
+      target_id: VALID_UUID,
+      content: "感想",
+    });
+    const result = await updateMemo({}, fd);
+    expect(result.error).toBe("対象種別が不正です");
+  });
+
+  it("target_id が不正な場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      id: VALID_UUID,
+      target_type: "video",
+      target_id: "invalid",
+      content: "感想",
+    });
+    const result = await updateMemo({}, fd);
+    expect(result.error).toBe("対象IDが不正です");
+  });
+
+  it("contentが空の場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      id: VALID_UUID,
+      target_type: "video",
+      target_id: VALID_UUID,
+      content: "",
+    });
+    const result = await updateMemo({}, fd);
+    expect(result.fieldError).toBe("感想を入力してください");
+  });
+});
+
+describe("deleteMemo", () => {
+  it("IDがUUID形式でない場合は例外を投げる", async () => {
+    const fd = buildFormData({ id: "invalid" });
+    await expect(deleteMemo(fd)).rejects.toThrow("感想IDが不正です");
+  });
+
+  it("認証されていない場合は例外を投げる", async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const fd = buildFormData({ id: VALID_UUID });
+    await expect(deleteMemo(fd)).rejects.toThrow("認証が必要です");
+  });
+});

--- a/src/lib/actions/videos.test.ts
+++ b/src/lib/actions/videos.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`__REDIRECT__:${url}`);
+  }),
+}));
+
+const supabaseMock = vi.hoisted(() => ({
+  auth: { getUser: vi.fn() },
+  from: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => supabaseMock),
+}));
+
+import { createVideo, updateVideo, deleteVideo } from "./videos";
+
+function buildFormData(entries: Record<string, string | string[]>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    if (Array.isArray(value)) {
+      for (const v of value) fd.append(key, v);
+    } else {
+      fd.set(key, value);
+    }
+  }
+  return fd;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+  supabaseMock.from.mockReset();
+});
+
+describe("createVideo", () => {
+  it("タイトルが空ならエラーを返す", async () => {
+    const fd = buildFormData({ title: "" });
+    const result = await createVideo({}, fd);
+    expect(result.fieldErrors?.title).toBe("タイトルを入力してください");
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("タイトルが200文字を超えるとエラーを返す", async () => {
+    const fd = buildFormData({ title: "あ".repeat(201) });
+    const result = await createVideo({}, fd);
+    expect(result.fieldErrors?.title).toBe("200文字以内で入力してください");
+  });
+
+  it("youtube_video_id の形式が不正だとエラーを返す", async () => {
+    const fd = buildFormData({
+      title: "テスト動画",
+      youtube_video_id: "invalid",
+    });
+    const result = await createVideo({}, fd);
+    expect(result.fieldErrors?.youtube_video_id).toBe(
+      "YouTube動画IDの形式が不正です（11文字の英数字）"
+    );
+  });
+
+  it("youtube_video_id が11文字の英数字なら受理する（redirectまで進む）", async () => {
+    const insertSelectSingle = vi.fn().mockResolvedValue({
+      data: { id: "11111111-1111-4111-8111-111111111111" },
+      error: null,
+    });
+    const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
+    const insertChain = vi.fn(() => ({ select: insertSelect }));
+    const deleteEq = vi.fn().mockResolvedValue({ error: null });
+    const deleteChain = vi.fn(() => ({ eq: deleteEq }));
+
+    supabaseMock.from.mockImplementation((table: string) => {
+      if (table === "videos") {
+        return { insert: insertChain };
+      }
+      if (table === "video_casts") {
+        return { delete: deleteChain };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const fd = buildFormData({
+      title: "テスト",
+      youtube_video_id: "abcDEF12345",
+    });
+
+    await expect(createVideo({}, fd)).rejects.toThrow(/__REDIRECT__/);
+    expect(insertChain).toHaveBeenCalledWith(
+      expect.objectContaining({ youtube_video_id: "abcDEF12345" })
+    );
+  });
+
+  it("youtube_url から動画IDを抽出する", async () => {
+    const insertSelectSingle = vi.fn().mockResolvedValue({
+      data: { id: "11111111-1111-4111-8111-111111111111" },
+      error: null,
+    });
+    const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
+    const insertChain = vi.fn(() => ({ select: insertSelect }));
+    const deleteEq = vi.fn().mockResolvedValue({ error: null });
+    const deleteChain = vi.fn(() => ({ eq: deleteEq }));
+
+    supabaseMock.from.mockImplementation((table: string) => {
+      if (table === "videos") return { insert: insertChain };
+      if (table === "video_casts") return { delete: deleteChain };
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const fd = buildFormData({
+      title: "テスト",
+      youtube_url: "https://youtu.be/abcDEF12345",
+    });
+
+    await expect(createVideo({}, fd)).rejects.toThrow(/__REDIRECT__/);
+    expect(insertChain).toHaveBeenCalledWith(
+      expect.objectContaining({ youtube_video_id: "abcDEF12345" })
+    );
+  });
+
+  it("認証されていない場合はエラーを返す", async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const fd = buildFormData({ title: "テスト" });
+    const result = await createVideo({}, fd);
+    expect(result.error).toBe("認証が必要です");
+  });
+
+  it("出演者の種別が不正な場合はエラーを返す", async () => {
+    const fd = buildFormData({
+      title: "テスト",
+      cast_type: ["invalid"],
+      cast_id: ["11111111-1111-4111-8111-111111111111"],
+      cast_name: ["X"],
+    });
+    const result = await createVideo({}, fd);
+    expect(result.fieldErrors?.casts).toBe("出演者の種別が不正です");
+  });
+
+  it("同じ出演者を複数回指定するとエラーを返す", async () => {
+    const fd = buildFormData({
+      title: "テスト",
+      cast_type: ["artist", "artist"],
+      cast_id: ["aaaa", "aaaa"],
+      cast_name: ["A", "A"],
+    });
+    const result = await createVideo({}, fd);
+    expect(result.fieldErrors?.casts).toBe("同じ出演者を複数回追加できません");
+  });
+});
+
+describe("updateVideo", () => {
+  it("IDがUUID形式でない場合はエラーを返す", async () => {
+    const fd = buildFormData({ title: "テスト" });
+    const result = await updateVideo("not-a-uuid", {}, fd);
+    expect(result.error).toBe("IDが不正です");
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("バリデーションエラーを返す", async () => {
+    const fd = buildFormData({ title: "" });
+    const result = await updateVideo(
+      "11111111-1111-4111-8111-111111111111",
+      {},
+      fd
+    );
+    expect(result.fieldErrors?.title).toBeDefined();
+  });
+});
+
+describe("deleteVideo", () => {
+  it("IDが空なら何もせず終了する", async () => {
+    const fd = buildFormData({ id: "" });
+    await expect(deleteVideo(fd)).resolves.toBeUndefined();
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("IDがUUID形式でない場合は例外を投げる", async () => {
+    const fd = buildFormData({ id: "not-a-uuid" });
+    await expect(deleteVideo(fd)).rejects.toThrow("IDが不正です");
+  });
+});


### PR DESCRIPTION
## 概要

issue #86 ステップ3として、`src/lib/actions/` 配下の Server Actions に対するバリデーションテストを追加した。Supabase クライアント・`next/cache`・`next/navigation` をモックし、バリデーションロジックのみを検証している。

## 追加したテスト

- `src/lib/actions/videos.test.ts` — タイトル必須・文字数、`youtube_video_id` の形式チェック、`youtube_url` からの ID 抽出、出演者の種別・重複チェック、UUID チェック等（12 ケース）
- `src/lib/actions/lives.test.ts` — タイトル必須・文字数、`event_date` 形式チェック（存在しない日付の検証含む）、`event_date` + `start_time` の ISO 組み立て、UUID チェック等（11 ケース）
- `src/lib/actions/articles.test.ts` — タイトル必須、URL 必須・形式（http/https のみ）、本文（content）の文字数上限、UUID チェック等（11 ケース）
- `src/lib/actions/memos.test.ts` — `target_type` の許可値、`target_id` の UUID、本文の必須・文字数、認証チェック等（14 ケース）

合計 48 ケース。`pnpm test` で全 95 件パス。

## 既存コードの変更

issue のチェックリストに沿って、欠けていたバリデーションを最小限追加した。

- `actions/lives.ts`: `event_date` の検証を追加。`YYYY-MM-DD` の形式に加え、strict parse + round-trip で `2026-02-30` のような存在しない日付も弾く（DB スキーマに合わせ任意入力のまま）。
- `actions/articles.ts`: `url` を必須化し、`http`/`https` のスキームのみ許可。`content` に 500 文字の上限を設け、CLAUDE.md の「記事本文は転載不可」方針に沿わせた。
- `components/features/article/article-form.tsx`: 新規追加した `url` / `content` のサーバ側エラーを画面に表示。`url` にクライアント側の `required` + `pattern` バリデーションを追加し、ラベルに必須マークを表示。
- `components/features/live/live-form.tsx`: `event_date` のサーバ側エラーを画面に表示。

## テスト計画

- [x] `pnpm test` で 95 件すべてパス
- [x] `pnpm lint` でエラーなし
- [x] `pnpm tsc --noEmit` で本 PR の変更ファイルにエラーなし（既存ファイルの型エラーは PR の対象外）

Closes #89