### PR TITLE
test: middleware の認証ガードテストを追加

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const getUserMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(() => ({
+    auth: { getUser: getUserMock },
+  })),
+}));
+
+import { middleware } from "./middleware";
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(new URL(`http://localhost${path}`));
+}
+
+beforeEach(() => {
+  getUserMock.mockReset();
+});
+
+describe("middleware の認証ガード", () => {
+  it("未認証で /admin にアクセスすると /auth/login にリダイレクトされる", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+
+    const response = await middleware(makeRequest("/admin"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/auth/login"
+    );
+  });
+
+  it("未認証で /admin 配下のサブパスにアクセスすると /auth/login にリダイレクトされる", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+
+    const response = await middleware(makeRequest("/admin/videos/new"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/auth/login"
+    );
+  });
+
+  it("認証済みなら /admin/* を通過する", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "u1" } } });
+
+    const response = await middleware(makeRequest("/admin/videos"));
+
+    // NextResponse.next() はリダイレクトを返さない
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("公開ページ（/videos）は未認証でもガード対象外", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+
+    const response = await middleware(makeRequest("/videos"));
+
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("公開ページ（トップ /）は未認証でもガード対象外", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+
+    const response = await middleware(makeRequest("/"));
+
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("認証済みで /auth/login にアクセスすると /admin にリダイレクトされる", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "u1" } } });
+
+    const response = await middleware(makeRequest("/auth/login"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost/admin");
+  });
+
+  it("未認証で /auth/login にアクセスするとそのまま通過する", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+
+    const response = await middleware(makeRequest("/auth/login"));
+
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+});


### PR DESCRIPTION
## 概要

issue #86 のステップ 4。`/admin/*` への未認証アクセスのリダイレクトを担保するテストを追加。

## 実装内容

`src/middleware.test.ts` を追加。`@supabase/ssr` の `createServerClient` をモックし、`NextRequest` を組み立てて `middleware()` の挙動を直接検証する。

### テストケース（7件）

- 未認証で `/admin` にアクセスすると `/auth/login` に 307 リダイレクトされる
- 未認証で `/admin/videos/new` のようなサブパスでも `/auth/login` にリダイレクトされる
- 認証済みなら `/admin/*` を通過する（`x-middleware-next: 1`）
- 公開ページ `/videos` は未認証でもガード対象外
- 公開ページ `/` （トップ）も未認証でもガード対象外
- 認証済みで `/auth/login` にアクセスすると `/admin` にリダイレクトされる
- 未認証で `/auth/login` にアクセスするとそのまま通過する

## テスト結果

```
Test Files  10 passed (10)
     Tests  102 passed (102)
```

Closes #90

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gh7RydGXcekkRSkk6aKzDB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authentication middleware to verify proper access control and redirect behavior across protected and public routes.

---

**Note:** This release contains internal testing improvements with no user-visible changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/94)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->