### PR TITLE
fix(ui): コンテンツタブをモバイルで横スクロール対応

### DIFF
--- a/src/components/features/combo/combo-content-tabs.tsx
+++ b/src/components/features/combo/combo-content-tabs.tsx
@@ -139,7 +139,7 @@ export function ContentTabs({
       <div
         role="tablist"
         aria-label="出演コンテンツ"
-        className="mb-4 flex flex-wrap gap-1 overflow-x-auto border-b border-brand-border-dark"
+        className="mb-4 flex flex-nowrap gap-1 overflow-x-auto border-b border-brand-border-dark [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {tabs.map((tab, index) => {
           const isActive = tab.key === active;


### PR DESCRIPTION
## 概要

コンビ/芸人詳細ページのコンテンツタブ (`ContentTabs`) が、モバイル幅で折り返して2行になってしまっていた。
1行に保ち、はみ出した分を横スクロールで閲覧できるように変更した。

## 変更内容

- `src/components/features/combo/combo-content-tabs.tsx`
  - `flex-wrap` → `flex-nowrap` に変更（既存の `overflow-x-auto` でスクロール可能になる）
  - スクロールバーは Firefox / IE / WebKit いずれでも非表示にして UI をすっきりさせた

## 動作確認

- [ ] モバイル幅（375px 程度）でタブが折り返さず横スクロールできる
- [ ] PC 幅では従来通り1行に収まる
- [ ] キーボード操作（←/→/Home/End）でのタブ移動が引き続き動作する

Closes #35


---
_Generated by [Claude Code](https://claude.ai/code/session_01DJpvecUCe6ko3kUnsVrYGK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Content tabs now display in a single horizontal scrollable row instead of wrapping across multiple lines, with scrollbar behavior preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/99)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->