### PR TITLE
test: Playwright を導入して E2E テスト雛形を追加

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,9 @@
+# Playwright E2E 用の環境変数サンプル
+# 実際の値は .env.test にコピーして利用する（.env.test は .gitignore 対象）
+
+# Playwright のベース URL（未指定なら http://localhost:3000 を使用）
+PLAYWRIGHT_BASE_URL=http://localhost:3000
+
+# 認証フローのテストに使うアカウント（未設定なら admin-flow.spec.ts はスキップされる）
+E2E_TEST_EMAIL=
+E2E_TEST_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
+/playwright/.cache
 
 # next.js
 /.next/
@@ -33,6 +36,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.test.example
 
 # vercel
 .vercel

--- a/e2e/admin-flow.spec.ts
+++ b/e2e/admin-flow.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+const TEST_EMAIL = process.env.E2E_TEST_EMAIL;
+const TEST_PASSWORD = process.env.E2E_TEST_PASSWORD;
+
+test.describe("管理画面フロー", () => {
+  test.skip(
+    !TEST_EMAIL || !TEST_PASSWORD,
+    "E2E_TEST_EMAIL / E2E_TEST_PASSWORD が未設定のためスキップ",
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/auth/login");
+    await page.getByLabel("メールアドレス").fill(TEST_EMAIL!);
+    await page.getByLabel("パスワード").fill(TEST_PASSWORD!);
+    await page.getByRole("button", { name: /ログイン/ }).click();
+    await page.waitForURL(/\/admin/);
+  });
+
+  test("ログイン後、動画新規作成ページが開ける", async ({ page }) => {
+    await page.goto("/admin/videos/new");
+    await expect(
+      page.getByRole("heading", { name: "動画を新規作成" }),
+    ).toBeVisible();
+  });
+
+  test.fixme(
+    "cast-selector で芸人を選択して動画を保存できる",
+    async () => {
+      // TODO: cast-selector の操作と保存後のリダイレクトを検証する。
+    },
+  );
+
+  test.fixme("メモを追加・編集できる", async () => {
+    // TODO: 認証ユーザーのみメモ追加 UI が表示されることと、追加・編集の動作を検証する。
+  });
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("認証ガード", () => {
+  test("未ログインで /admin にアクセスすると /auth/login にリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/admin");
+    await expect(page).toHaveURL(/\/auth\/login/);
+    await expect(
+      page.getByRole("heading", { name: "管理画面ログイン" }),
+    ).toBeVisible();
+  });
+
+  test("ログインフォームのバリデーションが効く", async ({ page }) => {
+    await page.goto("/auth/login");
+
+    const email = page.getByLabel("メールアドレス");
+    const password = page.getByLabel("パスワード");
+
+    await expect(email).toHaveAttribute("required", "");
+    await expect(password).toHaveAttribute("required", "");
+    await expect(email).toHaveAttribute("type", "email");
+    await expect(password).toHaveAttribute("type", "password");
+  });
+});

--- a/e2e/public.spec.ts
+++ b/e2e/public.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("公開側", () => {
+  test("トップページが表示される", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/DonDecorte/i);
+  });
+
+  test("動画一覧ページに見出しが表示される", async ({ page }) => {
+    await page.goto("/videos");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "動画" }),
+    ).toBeVisible();
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,8 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
     "coverage/**",
+    "playwright-report/**",
+    "test-results/**",
   ]),
 ]);
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.2",
@@ -19,6 +21,7 @@
     "react-hook-form": "^7.72.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -30,6 +33,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.5",
     "jsdom": "^29.1.1",
+    "playwright": "^1.60.0",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.6"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",
+    "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.5",
     "jsdom": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.5",
     "jsdom": "^29.1.1",
-    "playwright": "^1.60.0",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.6"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,21 @@
 import { defineConfig, devices } from "@playwright/test";
+import { config as loadEnv } from "dotenv";
+import fs from "node:fs";
+import path from "node:path";
 
-const PORT = Number(process.env.PORT ?? 3000);
-const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${PORT}`;
+const envTestPath = path.resolve(__dirname, ".env.test");
+if (fs.existsSync(envTestPath)) {
+  loadEnv({ path: envTestPath });
+}
+
+const defaultPort = 3000;
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${defaultPort}`;
+
+const parsedPort = Number(new URL(baseURL).port);
+const port = Number.isFinite(parsedPort) && parsedPort > 0
+  ? parsedPort
+  : defaultPort;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -21,7 +35,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev",
+    command: `pnpm dev --port ${port}`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = Number(process.env.PORT ?? 3000);
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 const envTestPath = path.resolve(__dirname, ".env.test");
 if (fs.existsSync(envTestPath)) {
-  loadEnv({ path: envTestPath });
+  loadEnv({ path: envTestPath, quiet: true });
 }
 
 const defaultPort = 3000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
-      playwright:
-        specifier: ^1.60.0
-        version: 1.60.0
       tailwindcss:
         specifier: ^4
         version: 4.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.12(@types/node@20.19.39)(jiti@2.6.1))
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
@@ -1300,6 +1303,10 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3752,6 +3759,8 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 2.103.2
       next:
         specifier: 16.2.5
-        version: 16.2.5(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.5(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -27,6 +27,9 @@ importers:
         specifier: ^7.72.1
         version: 7.72.1(react@19.2.6)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
@@ -60,6 +63,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -537,6 +543,11 @@ packages:
 
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.0':
     resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
@@ -1526,6 +1537,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2087,6 +2103,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3020,6 +3046,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.129.0': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@rolldown/binding-android-arm64@1.0.0':
     optional: true
@@ -4104,6 +4134,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4527,7 +4560,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.5(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.5(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.5
       '@swc/helpers': 0.5.15
@@ -4546,6 +4579,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.5
       '@next/swc-win32-arm64-msvc': 16.2.5
       '@next/swc-win32-x64-msvc': 16.2.5
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4648,6 +4682,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## 概要

issue #86 のステップ 5。E2E テストの土台として Playwright を導入し、最低限のテスト雛形を追加した。

Closes #91

## 変更内容

### セットアップ
- `playwright` と `@playwright/test` を devDependencies に追加
- `playwright.config.ts` を追加
  - `baseURL` は `PLAYWRIGHT_BASE_URL` で上書き可能（デフォルト `http://localhost:3000`）
  - `webServer` で `pnpm dev` を自動起動（既存サーバーがあれば再利用）
  - Chromium プロジェクトのみ、CI 時は retries=2 / workers=1 / reporter=github
- `package.json` に `test:e2e` / `test:e2e:ui` スクリプトを追加
- `.env.test.example` を追加（`.gitignore` に例外指定）
- `.gitignore` / eslint config に `playwright-report` / `test-results` を追加

### E2E spec（`e2e/`）

| ファイル | 内容 |
| --- | --- |
| `public.spec.ts` | トップページ表示、動画一覧の見出し表示 |
| `auth.spec.ts` | 未ログインで `/admin` → `/auth/login` リダイレクト、ログインフォームの required/type 検証 |
| `admin-flow.spec.ts` | `E2E_TEST_EMAIL` / `E2E_TEST_PASSWORD` が設定されたときのみ動くログイン後フロー。cast-selector とメモは `test.fixme` で TODO として残してある |

## 完了条件との対応

- [x] `playwright.config.ts`（`baseURL`、認証セットアップ用の env を整備）
- [x] `package.json` の scripts に `test:e2e` を追加
- [x] `.env.test`（`.env.test.example` として雛形を追加）
- [x] ローカルで `pnpm test:e2e` を実行できる状態
- [ ] cast-selector で芸人を選択して保存（`test.fixme` で TODO 化）
- [ ] メモの追加・編集（`test.fixme` で TODO 化）

issue 本文どおり「Playwright E2E はローカル実行できる状態 / CI 統合は別 issue でも可」を満たす範囲に留めた。シナリオの本実装は別途追加していく想定。

## Test plan

- [ ] `pnpm install` 後、`pnpm exec playwright install chromium` でブラウザを取得
- [ ] `pnpm dev` を別タブで起動した状態、または webServer 任せで `pnpm test:e2e` を実行し、`public.spec.ts` と `auth.spec.ts` がグリーンになることを確認
- [ ] `.env.test` に有効な `E2E_TEST_EMAIL` / `E2E_TEST_PASSWORD` を設定し、`admin-flow.spec.ts` のログイン後ページ表示が通ることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01S4SyghvUxtLudwaDdkvMng)_