### PR TITLE
feat(public): 共演分析ページを追加

### DIFF
--- a/src/app/(public)/co-stars/page.tsx
+++ b/src/app/(public)/co-stars/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getContentTypeLabel } from "@/components/shared/content-type-badge";
 import {
   getCoAppearanceRanking,
   type CoAppearanceBreakdown,
@@ -15,14 +16,14 @@ const DESCRIPTION =
 
 const TOP_LIMIT = 20;
 
-const CONTENT_TYPE_SHORT_LABEL: Record<ContentType, string> = {
-  video: "動画",
-  live: "ライブ",
-  radio: "ラジオ",
-  article: "記事",
-  tv_show: "TV",
-  topic: "トピック",
-};
+const CONTENT_TYPE_ORDER: ContentType[] = [
+  "video",
+  "live",
+  "radio",
+  "article",
+  "tv_show",
+  "topic",
+];
 
 const PERFORMER_PATH: Record<CastType, string> = {
   artist: "artists",
@@ -182,9 +183,9 @@ function RankBadge({ rank }: { rank: number }) {
 }
 
 function BreakdownLine({ breakdown }: { breakdown: CoAppearanceBreakdown }) {
-  const parts = (Object.keys(CONTENT_TYPE_SHORT_LABEL) as ContentType[])
-    .filter((type) => breakdown[type] > 0)
-    .map((type) => `${CONTENT_TYPE_SHORT_LABEL[type]} ${breakdown[type]}`);
+  const parts = CONTENT_TYPE_ORDER.filter(
+    (type) => breakdown[type] > 0
+  ).map((type) => `${getContentTypeLabel(type)} ${breakdown[type]}`);
 
   if (parts.length === 0) return null;
 

--- a/src/app/(public)/co-stars/page.tsx
+++ b/src/app/(public)/co-stars/page.tsx
@@ -1,0 +1,199 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  getCoAppearanceRanking,
+  type CoAppearanceBreakdown,
+  type CoAppearanceEntry,
+} from "@/lib/queries/co-appearances";
+import type { CastType, ContentType } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+const TITLE = "共演分析";
+const DESCRIPTION =
+  "ドンデコルテさんと最も共演が多いコンビ・芸人・ユニットのランキング。";
+
+const TOP_LIMIT = 20;
+
+const CONTENT_TYPE_SHORT_LABEL: Record<ContentType, string> = {
+  video: "動画",
+  live: "ライブ",
+  radio: "ラジオ",
+  article: "記事",
+  tv_show: "TV",
+  topic: "トピック",
+};
+
+const PERFORMER_PATH: Record<CastType, string> = {
+  artist: "artists",
+  comedy_group: "combos",
+  unit: "units",
+};
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: "/co-stars" },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: "/co-stars",
+  },
+};
+
+export default async function CoStarsPage() {
+  const ranking = await getCoAppearanceRanking();
+
+  return (
+    <div className="mx-auto w-full max-w-4xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          {TITLE}
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          {DESCRIPTION}
+        </p>
+        {ranking.found ? (
+          <p className="mt-1 text-xs text-brand-muted">
+            集計対象: ドンデコルテさんの登録コンテンツ {ranking.totalContentCount} 件
+          </p>
+        ) : null}
+      </header>
+
+      {!ranking.found ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          ドンデコルテさんの情報がまだ登録されていません。
+        </p>
+      ) : (
+        <div className="space-y-8 md:space-y-10">
+          <RankingSection
+            title="コンビ"
+            description="ドンデコルテさんと共演が多いコンビ・トリオ"
+            entries={ranking.combos}
+          />
+          <RankingSection
+            title="芸人"
+            description="ピンで共演している芸人"
+            entries={ranking.artists}
+          />
+          <RankingSection
+            title="ユニット"
+            description="共演しているユニット"
+            entries={ranking.units}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RankingSection({
+  title,
+  description,
+  entries,
+}: {
+  title: string;
+  description: string;
+  entries: CoAppearanceEntry[];
+}) {
+  const items = entries.slice(0, TOP_LIMIT);
+
+  return (
+    <section>
+      <div className="mb-3 flex items-end justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-brand-cream md:text-lg">
+            {title}
+          </h2>
+          <p className="mt-0.5 text-xs text-brand-muted md:text-sm">
+            {description}
+          </p>
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+          共演データがまだありません。
+        </p>
+      ) : (
+        <ol className="overflow-hidden rounded-lg border border-brand-border-dark bg-brand-card-dark">
+          {items.map((entry, index) => (
+            <li
+              key={`${entry.performer.type}-${entry.performer.id}`}
+              className="border-b border-brand-border-dark last:border-b-0"
+            >
+              <RankingRow rank={index + 1} entry={entry} />
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+function RankingRow({
+  rank,
+  entry,
+}: {
+  rank: number;
+  entry: CoAppearanceEntry;
+}) {
+  const href = `/${PERFORMER_PATH[entry.performer.type]}/${entry.performer.id}`;
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-4 px-4 py-3 transition hover:bg-brand-bg-dark/40"
+    >
+      <RankBadge rank={rank} />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-brand-cream md:text-base">
+          {entry.performer.name}
+        </p>
+        <BreakdownLine breakdown={entry.breakdown} />
+      </div>
+      <div
+        className="shrink-0 text-right"
+        style={{ fontVariantNumeric: "tabular-nums" }}
+      >
+        <div className="text-lg font-bold leading-none text-brand-sky-light md:text-xl">
+          {entry.count}
+        </div>
+        <div className="mt-1 text-[11px] text-brand-muted">共演</div>
+      </div>
+    </Link>
+  );
+}
+
+function RankBadge({ rank }: { rank: number }) {
+  const isTop3 = rank <= 3;
+  return (
+    <div
+      className={
+        isTop3
+          ? "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-sky-pale/15 text-sm font-bold text-brand-sky-light md:h-10 md:w-10 md:text-base"
+          : "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-bg-dark text-sm font-semibold text-brand-gold md:h-10 md:w-10"
+      }
+      style={{ fontVariantNumeric: "tabular-nums" }}
+      aria-label={`${rank}位`}
+    >
+      {rank}
+    </div>
+  );
+}
+
+function BreakdownLine({ breakdown }: { breakdown: CoAppearanceBreakdown }) {
+  const parts = (Object.keys(CONTENT_TYPE_SHORT_LABEL) as ContentType[])
+    .filter((type) => breakdown[type] > 0)
+    .map((type) => `${CONTENT_TYPE_SHORT_LABEL[type]} ${breakdown[type]}`);
+
+  if (parts.length === 0) return null;
+
+  return (
+    <p
+      className="mt-1 truncate text-xs text-brand-muted"
+      style={{ fontVariantNumeric: "tabular-nums" }}
+    >
+      {parts.join(" / ")}
+    </p>
+  );
+}

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -24,6 +24,7 @@ const MORE_ITEMS: NavItem[] = [
   { href: "/articles", label: "記事" },
   { href: "/tv", label: "TV" },
   { href: "/topics", label: "トピック" },
+  { href: "/co-stars", label: "共演分析" },
 ];
 
 function isActive(pathname: string, href: string) {

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -14,6 +14,7 @@ const NAV_ITEMS = [
   { href: "/combos", label: "コンビ" },
   { href: "/units", label: "ユニット" },
   { href: "/artists", label: "芸人" },
+  { href: "/co-stars", label: "共演分析" },
 ];
 
 function isActive(pathname: string, href: string) {

--- a/src/lib/queries/co-appearances.test.ts
+++ b/src/lib/queries/co-appearances.test.ts
@@ -24,12 +24,14 @@ function buildQueryStub(responses: {
       return {
         select: () => ({
           eq: () => ({
-            maybeSingle: async () => ({
-              data:
-                responses.dondecorteId === null
-                  ? null
-                  : { id: responses.dondecorteId ?? DONDECORTE_ID },
-              error: null,
+            order: () => ({
+              limit: async () => ({
+                data:
+                  responses.dondecorteId === null
+                    ? []
+                    : [{ id: responses.dondecorteId ?? DONDECORTE_ID }],
+                error: null,
+              }),
             }),
           }),
         }),

--- a/src/lib/queries/co-appearances.test.ts
+++ b/src/lib/queries/co-appearances.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const supabaseMock = vi.hoisted(() => ({
+  from: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => supabaseMock),
+}));
+
+import { getCoAppearanceRanking } from "./co-appearances";
+
+const DONDECORTE_ID = "dd-id";
+
+type AnyRow = Record<string, unknown>;
+
+function buildQueryStub(responses: {
+  ownParents: Record<string, string[]>;
+  coCasts: Record<string, AnyRow[]>;
+  dondecorteId?: string | null;
+}) {
+  supabaseMock.from.mockImplementation((table: string) => {
+    if (table === "comedy_groups") {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({
+              data:
+                responses.dondecorteId === null
+                  ? null
+                  : { id: responses.dondecorteId ?? DONDECORTE_ID },
+              error: null,
+            }),
+          }),
+        }),
+      };
+    }
+
+    return {
+      select: (cols: string) => {
+        if (cols.includes("artist:artists")) {
+          return {
+            in: async () => ({
+              data: responses.coCasts[table] ?? [],
+              error: null,
+            }),
+          };
+        }
+        return {
+          eq: async () => ({
+            data: (responses.ownParents[table] ?? []).map((id) => {
+              const field = cols.trim();
+              return { [field]: id };
+            }),
+            error: null,
+          }),
+        };
+      },
+    };
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getCoAppearanceRanking", () => {
+  it("ドンデコルテが見つからない場合は found=false を返す", async () => {
+    buildQueryStub({
+      ownParents: {},
+      coCasts: {},
+      dondecorteId: null,
+    });
+
+    const result = await getCoAppearanceRanking();
+    expect(result.found).toBe(false);
+    expect(result.combos).toEqual([]);
+    expect(result.artists).toEqual([]);
+    expect(result.units).toEqual([]);
+  });
+
+  it("コンビ・芸人・ユニットそれぞれを共演回数でランキングする", async () => {
+    buildQueryStub({
+      ownParents: {
+        video_casts: ["v1", "v2"],
+        live_casts: ["l1"],
+        radio_casts: [],
+        article_casts: [],
+        tv_show_casts: [],
+        topic_casts: [],
+      },
+      coCasts: {
+        video_casts: [
+          {
+            video_id: "v1",
+            artist_id: null,
+            comedy_group_id: DONDECORTE_ID,
+            unit_id: null,
+            artist: null,
+            comedy_group: { id: DONDECORTE_ID, name: "ドンデコルテ" },
+            unit: null,
+          },
+          {
+            video_id: "v1",
+            artist_id: null,
+            comedy_group_id: "combo-a",
+            unit_id: null,
+            artist: null,
+            comedy_group: { id: "combo-a", name: "コンビA" },
+            unit: null,
+          },
+          {
+            video_id: "v2",
+            artist_id: null,
+            comedy_group_id: "combo-a",
+            unit_id: null,
+            artist: null,
+            comedy_group: { id: "combo-a", name: "コンビA" },
+            unit: null,
+          },
+          {
+            video_id: "v2",
+            artist_id: "artist-x",
+            comedy_group_id: null,
+            unit_id: null,
+            artist: { id: "artist-x", name: "芸人X" },
+            comedy_group: null,
+            unit: null,
+          },
+        ],
+        live_casts: [
+          {
+            live_id: "l1",
+            artist_id: null,
+            comedy_group_id: "combo-b",
+            unit_id: null,
+            artist: null,
+            comedy_group: { id: "combo-b", name: "コンビB" },
+            unit: null,
+          },
+          {
+            live_id: "l1",
+            artist_id: null,
+            comedy_group_id: null,
+            unit_id: "unit-1",
+            artist: null,
+            comedy_group: null,
+            unit: { id: "unit-1", name: "ユニット1" },
+          },
+        ],
+      },
+    });
+
+    const result = await getCoAppearanceRanking();
+
+    expect(result.found).toBe(true);
+    expect(result.totalContentCount).toBe(3);
+
+    expect(result.combos).toHaveLength(2);
+    expect(result.combos[0]).toMatchObject({
+      performer: { type: "comedy_group", id: "combo-a", name: "コンビA" },
+      count: 2,
+    });
+    expect(result.combos[0].breakdown.video).toBe(2);
+    expect(result.combos[1]).toMatchObject({
+      performer: { type: "comedy_group", id: "combo-b", name: "コンビB" },
+      count: 1,
+    });
+    expect(result.combos[1].breakdown.live).toBe(1);
+
+    expect(result.artists).toEqual([
+      {
+        performer: { type: "artist", id: "artist-x", name: "芸人X" },
+        count: 1,
+        breakdown: {
+          video: 1,
+          live: 0,
+          radio: 0,
+          article: 0,
+          tv_show: 0,
+          topic: 0,
+        },
+      },
+    ]);
+
+    expect(result.units).toHaveLength(1);
+    expect(result.units[0].performer.name).toBe("ユニット1");
+    expect(result.units[0].breakdown.live).toBe(1);
+  });
+
+  it("ドンデコルテ自身は集計対象から除外する", async () => {
+    buildQueryStub({
+      ownParents: {
+        video_casts: ["v1"],
+        live_casts: [],
+        radio_casts: [],
+        article_casts: [],
+        tv_show_casts: [],
+        topic_casts: [],
+      },
+      coCasts: {
+        video_casts: [
+          {
+            video_id: "v1",
+            artist_id: null,
+            comedy_group_id: DONDECORTE_ID,
+            unit_id: null,
+            artist: null,
+            comedy_group: { id: DONDECORTE_ID, name: "ドンデコルテ" },
+            unit: null,
+          },
+        ],
+      },
+    });
+
+    const result = await getCoAppearanceRanking();
+    expect(result.combos).toEqual([]);
+    expect(result.artists).toEqual([]);
+    expect(result.units).toEqual([]);
+  });
+});

--- a/src/lib/queries/co-appearances.ts
+++ b/src/lib/queries/co-appearances.ts
@@ -1,0 +1,285 @@
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry, ContentType } from "@/lib/types";
+
+const DONDECORTE_COMBO_NAME = "ドンデコルテ";
+
+type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
+
+type CastTable =
+  | "video_casts"
+  | "live_casts"
+  | "radio_casts"
+  | "article_casts"
+  | "tv_show_casts"
+  | "topic_casts";
+
+type ParentIdField =
+  | "video_id"
+  | "live_id"
+  | "radio_id"
+  | "article_id"
+  | "tv_show_id"
+  | "topic_id";
+
+type CastTableSpec = {
+  table: CastTable;
+  parentIdField: ParentIdField;
+  contentType: ContentType;
+};
+
+const CAST_TABLES: CastTableSpec[] = [
+  { table: "video_casts", parentIdField: "video_id", contentType: "video" },
+  { table: "live_casts", parentIdField: "live_id", contentType: "live" },
+  { table: "radio_casts", parentIdField: "radio_id", contentType: "radio" },
+  {
+    table: "article_casts",
+    parentIdField: "article_id",
+    contentType: "article",
+  },
+  {
+    table: "tv_show_casts",
+    parentIdField: "tv_show_id",
+    contentType: "tv_show",
+  },
+  { table: "topic_casts", parentIdField: "topic_id", contentType: "topic" },
+];
+
+export type CoAppearanceBreakdown = Record<ContentType, number>;
+
+export type CoAppearanceEntry = {
+  performer: CastEntry;
+  count: number;
+  breakdown: CoAppearanceBreakdown;
+};
+
+export type CoAppearanceRanking = {
+  combos: CoAppearanceEntry[];
+  artists: CoAppearanceEntry[];
+  units: CoAppearanceEntry[];
+  totalContentCount: number;
+  found: boolean;
+};
+
+const EMPTY_RANKING: CoAppearanceRanking = {
+  combos: [],
+  artists: [],
+  units: [],
+  totalContentCount: 0,
+  found: false,
+};
+
+function emptyBreakdown(): CoAppearanceBreakdown {
+  return {
+    video: 0,
+    live: 0,
+    radio: 0,
+    article: 0,
+    tv_show: 0,
+    topic: 0,
+  };
+}
+
+async function getDondecorteComedyGroupId(
+  supabase: SupabaseClient
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("comedy_groups")
+    .select("id")
+    .eq("name", DONDECORTE_COMBO_NAME)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`コンビ情報の取得に失敗しました: ${error.message}`);
+  }
+
+  return (data?.id as string | undefined) ?? null;
+}
+
+type CoCastRow = {
+  artist_id: string | null;
+  comedy_group_id: string | null;
+  unit_id: string | null;
+  artist: { id: string; name: string } | null;
+  comedy_group: { id: string; name: string } | null;
+  unit: { id: string; name: string } | null;
+};
+
+type RawCoCastRow = CoCastRow & Record<ParentIdField, string>;
+
+async function listOwnParentIds(
+  supabase: SupabaseClient,
+  spec: CastTableSpec,
+  dondecorteId: string
+): Promise<string[]> {
+  const { data, error } = await supabase
+    .from(spec.table)
+    .select(spec.parentIdField)
+    .eq("comedy_group_id", dondecorteId);
+
+  if (error) {
+    throw new Error(
+      `共演者情報の取得に失敗しました(${spec.table}): ${error.message}`
+    );
+  }
+
+  const ids = ((data ?? []) as Array<Record<ParentIdField, string>>).map(
+    (row) => row[spec.parentIdField]
+  );
+  return Array.from(new Set(ids));
+}
+
+async function listCoCastRows(
+  supabase: SupabaseClient,
+  spec: CastTableSpec,
+  parentIds: string[]
+): Promise<RawCoCastRow[]> {
+  if (parentIds.length === 0) return [];
+
+  const { data, error } = await supabase
+    .from(spec.table)
+    .select(
+      `${spec.parentIdField},
+       artist_id,
+       comedy_group_id,
+       unit_id,
+       artist:artists(id, name),
+       comedy_group:comedy_groups(id, name),
+       unit:units(id, name)`
+    )
+    .in(spec.parentIdField, parentIds);
+
+  if (error) {
+    throw new Error(
+      `共演者情報の取得に失敗しました(${spec.table}): ${error.message}`
+    );
+  }
+
+  return (data ?? []) as unknown as RawCoCastRow[];
+}
+
+type Accumulator = Map<
+  string,
+  {
+    performer: CastEntry;
+    contentKeys: Set<string>;
+    breakdown: CoAppearanceBreakdown;
+    breakdownKeys: Record<ContentType, Set<string>>;
+  }
+>;
+
+function entryFromRow(row: CoCastRow): CastEntry | null {
+  if (row.artist_id && row.artist) {
+    return { type: "artist", id: row.artist.id, name: row.artist.name };
+  }
+  if (row.comedy_group_id && row.comedy_group) {
+    return {
+      type: "comedy_group",
+      id: row.comedy_group.id,
+      name: row.comedy_group.name,
+    };
+  }
+  if (row.unit_id && row.unit) {
+    return { type: "unit", id: row.unit.id, name: row.unit.name };
+  }
+  return null;
+}
+
+function accumulate(
+  acc: Accumulator,
+  performer: CastEntry,
+  contentType: ContentType,
+  parentId: string
+) {
+  const key = `${performer.type}:${performer.id}`;
+  let entry = acc.get(key);
+  if (!entry) {
+    entry = {
+      performer,
+      contentKeys: new Set<string>(),
+      breakdown: emptyBreakdown(),
+      breakdownKeys: {
+        video: new Set<string>(),
+        live: new Set<string>(),
+        radio: new Set<string>(),
+        article: new Set<string>(),
+        tv_show: new Set<string>(),
+        topic: new Set<string>(),
+      },
+    };
+    acc.set(key, entry);
+  }
+
+  const contentKey = `${contentType}:${parentId}`;
+  entry.contentKeys.add(contentKey);
+
+  const perTypeKeys = entry.breakdownKeys[contentType];
+  if (!perTypeKeys.has(parentId)) {
+    perTypeKeys.add(parentId);
+    entry.breakdown[contentType] += 1;
+  }
+}
+
+function sortEntries(entries: CoAppearanceEntry[]): CoAppearanceEntry[] {
+  return entries.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.performer.name.localeCompare(b.performer.name, "ja");
+  });
+}
+
+export async function getCoAppearanceRanking(): Promise<CoAppearanceRanking> {
+  const supabase = await createClient();
+  const dondecorteId = await getDondecorteComedyGroupId(supabase);
+
+  if (!dondecorteId) return EMPTY_RANKING;
+
+  const ownParentIdsPerTable = await Promise.all(
+    CAST_TABLES.map((spec) => listOwnParentIds(supabase, spec, dondecorteId))
+  );
+
+  const totalContentCount = ownParentIdsPerTable.reduce(
+    (sum, ids) => sum + ids.length,
+    0
+  );
+
+  const coCastRowsPerTable = await Promise.all(
+    CAST_TABLES.map((spec, index) =>
+      listCoCastRows(supabase, spec, ownParentIdsPerTable[index])
+    )
+  );
+
+  const acc: Accumulator = new Map();
+
+  CAST_TABLES.forEach((spec, index) => {
+    const rows = coCastRowsPerTable[index];
+    for (const row of rows) {
+      if (row.comedy_group_id === dondecorteId) continue;
+      const performer = entryFromRow(row);
+      if (!performer) continue;
+      const parentId = row[spec.parentIdField];
+      accumulate(acc, performer, spec.contentType, parentId);
+    }
+  });
+
+  const combos: CoAppearanceEntry[] = [];
+  const artists: CoAppearanceEntry[] = [];
+  const units: CoAppearanceEntry[] = [];
+
+  for (const entry of acc.values()) {
+    const result: CoAppearanceEntry = {
+      performer: entry.performer,
+      count: entry.contentKeys.size,
+      breakdown: entry.breakdown,
+    };
+    if (entry.performer.type === "comedy_group") combos.push(result);
+    else if (entry.performer.type === "artist") artists.push(result);
+    else units.push(result);
+  }
+
+  return {
+    combos: sortEntries(combos),
+    artists: sortEntries(artists),
+    units: sortEntries(units),
+    totalContentCount,
+    found: true,
+  };
+}

--- a/src/lib/queries/co-appearances.ts
+++ b/src/lib/queries/co-appearances.ts
@@ -86,13 +86,15 @@ async function getDondecorteComedyGroupId(
     .from("comedy_groups")
     .select("id")
     .eq("name", DONDECORTE_COMBO_NAME)
-    .maybeSingle();
+    .order("created_at", { ascending: true })
+    .limit(1);
 
   if (error) {
     throw new Error(`コンビ情報の取得に失敗しました: ${error.message}`);
   }
 
-  return (data?.id as string | undefined) ?? null;
+  const rows = (data ?? []) as Array<{ id: string }>;
+  return rows[0]?.id ?? null;
 }
 
 type CoCastRow = {


### PR DESCRIPTION
## 概要

issue #44 の対応。`/co-stars` にドンデコルテさんと共演が多いコンビ・芸人・ユニットのランキングを表示する共演分析ページを追加した。

Closes #44

## 主な変更

- **`src/lib/queries/co-appearances.ts`** を追加
  - `comedy_groups.name = "ドンデコルテ"` でメインコンビを特定
  - 全6種類のコンテンツ (`video` / `live` / `radio` / `article` / `tv_show` / `topic`) を横断し、各 `*_casts` テーブルから共演レコードを集計
  - パフォーマンスタイプ (artist / comedy_group / unit) ごとに共演回数を算出し、ランキング配列で返却
  - コンテンツ ID ごとに集計するため、同一コンテンツに複数キャストが入っていても重複カウントしない
  - ドンデコルテ自身は集計対象から除外
- **`src/app/(public)/co-stars/page.tsx`** を追加
  - Server Component として共演ランキングを 3 セクション (コンビ / 芸人 / ユニット) で表示
  - 各エントリで順位バッジ、名前、コンテンツ種別ごとの内訳、共演総数を表示
  - 1〜3 位はアクセントカラー (`brand-sky-light`) で強調
  - ドンデコルテ未登録時のフォールバックメッセージを表示
- **ナビゲーション導線**
  - PC ヘッダー (`src/components/layout/header.tsx`) と モバイル More メニュー (`src/components/layout/bottom-nav.tsx`) に「共演分析」リンクを追加

## テスト

- `src/lib/queries/co-appearances.test.ts` を追加 (vitest)
  - ドンデコルテ未登録時に `found=false` を返す
  - 各キャストタイプを共演回数でランキングし内訳が正しく算出される
  - ドンデコルテ自身が集計から除外される
- `pnpm test` — 105 件パス (新規 3 件含む)
- `pnpm lint` — クリーン

## 動作確認 TODO

- [ ] `/co-stars` で各ランキングが表示されること
- [ ] ヘッダーとモバイル More メニューに「共演分析」リンクが表示されること
- [ ] 各エントリのリンクが該当の `/combos/[id]` `/artists/[id]` `/units/[id]` に遷移すること
- [ ] ドンデコルテのデータが空の状態でフォールバックメッセージが表示されること


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vwoe2hWAp5oXcX2YqL1KQY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced co-stars analysis page displaying co-appearance rankings across three categories: combos, artists, and units.
  * Added navigation links to the new page in both the main header and "More" menu for easy access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->