### PR TITLE
feat(public): 出演回数ランキングページを追加

### DIFF
--- a/src/app/(public)/rankings/page.tsx
+++ b/src/app/(public)/rankings/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import { AppearanceRankingBoard } from "@/components/features/ranking/appearance-ranking-board";
+import { listAppearanceRanking } from "@/lib/queries/rankings";
+
+export const dynamic = "force-dynamic";
+
+const DESCRIPTION =
+  "ドンデコルテさん関連の出演者を、コンテンツ種別ごとの出演回数で集計したランキング。";
+
+export const metadata: Metadata = {
+  title: "出演回数ランキング",
+  description: DESCRIPTION,
+  alternates: { canonical: "/rankings" },
+  openGraph: {
+    title: "出演回数ランキング",
+    description: DESCRIPTION,
+    url: "/rankings",
+  },
+};
+
+export default async function RankingsPage() {
+  const ranking = await listAppearanceRanking();
+
+  return (
+    <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          出演回数ランキング
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          コンテンツ種別ごとの出演回数を集計したランキング。
+        </p>
+      </header>
+
+      <AppearanceRankingBoard ranking={ranking} />
+    </div>
+  );
+}

--- a/src/components/features/ranking/appearance-ranking-board.tsx
+++ b/src/components/features/ranking/appearance-ranking-board.tsx
@@ -4,18 +4,9 @@ import { useRef, useState } from "react";
 import { getContentTypeLabel } from "@/components/shared/content-type-badge";
 import { PerformerTag } from "@/components/shared/performer-tags";
 import type { AppearanceRankingEntry } from "@/lib/queries/rankings";
-import type { ContentType } from "@/lib/types";
+import { CONTENT_TYPES, type ContentType } from "@/lib/types";
 
 type TabKey = "total" | ContentType;
-
-const CONTENT_TYPES: ContentType[] = [
-  "video",
-  "live",
-  "radio",
-  "article",
-  "tv_show",
-  "topic",
-];
 
 const TABS: TabKey[] = ["total", ...CONTENT_TYPES];
 

--- a/src/components/features/ranking/appearance-ranking-board.tsx
+++ b/src/components/features/ranking/appearance-ranking-board.tsx
@@ -104,6 +104,7 @@ export function AppearanceRankingBoard({
         role="tabpanel"
         id="ranking-tabpanel"
         aria-labelledby={`ranking-tab-${active}`}
+        tabIndex={0}
       >
         {rows.length === 0 ? (
           <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
@@ -124,10 +125,7 @@ export function AppearanceRankingBoard({
                   ) : null}
                 </div>
                 <p className="shrink-0 text-right">
-                  <span
-                    className="text-lg font-bold text-brand-cream sm:text-xl"
-                    style={{ fontVariantNumeric: "tabular-nums" }}
-                  >
+                  <span className="text-lg font-bold tabular-nums text-brand-cream sm:text-xl">
                     {metricOf(entry, active)}
                   </span>
                   <span className="ml-0.5 text-xs text-brand-muted">回</span>
@@ -152,8 +150,8 @@ function RankBadge({ rank }: { rank: number }) {
           : "bg-brand-bg-dark text-brand-muted";
   return (
     <span
-      className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-sm font-bold ${tone}`}
-      style={{ fontVariantNumeric: "tabular-nums" }}
+      className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-sm font-bold tabular-nums ${tone}`}
+      aria-label={`${rank}位`}
     >
       {rank}
     </span>
@@ -168,10 +166,7 @@ function Breakdown({ counts }: { counts: Record<ContentType, number> }) {
       {items.map((type) => (
         <li key={type} className="text-xs text-brand-muted">
           {getContentTypeLabel(type)}
-          <span
-            className="ml-1 font-semibold text-brand-gold"
-            style={{ fontVariantNumeric: "tabular-nums" }}
-          >
+          <span className="ml-1 font-semibold tabular-nums text-brand-gold">
             {counts[type]}
           </span>
         </li>

--- a/src/components/features/ranking/appearance-ranking-board.tsx
+++ b/src/components/features/ranking/appearance-ranking-board.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { getContentTypeLabel } from "@/components/shared/content-type-badge";
+import { PerformerTag } from "@/components/shared/performer-tags";
+import type { AppearanceRankingEntry } from "@/lib/queries/rankings";
+import type { ContentType } from "@/lib/types";
+
+type TabKey = "total" | ContentType;
+
+const CONTENT_TYPES: ContentType[] = [
+  "video",
+  "live",
+  "radio",
+  "article",
+  "tv_show",
+  "topic",
+];
+
+const TABS: TabKey[] = ["total", ...CONTENT_TYPES];
+
+function tabLabel(tab: TabKey): string {
+  return tab === "total" ? "総合" : getContentTypeLabel(tab);
+}
+
+function metricOf(entry: AppearanceRankingEntry, tab: TabKey): number {
+  return tab === "total" ? entry.total : entry.counts[tab];
+}
+
+export function AppearanceRankingBoard({
+  ranking,
+}: {
+  ranking: AppearanceRankingEntry[];
+}) {
+  const [active, setActive] = useState<TabKey>("total");
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const onTabKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    const last = TABS.length - 1;
+    let next = index;
+    if (e.key === "ArrowRight") next = index === last ? 0 : index + 1;
+    else if (e.key === "ArrowLeft") next = index === 0 ? last : index - 1;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = last;
+    else return;
+
+    e.preventDefault();
+    setActive(TABS[next]);
+    tabRefs.current[next]?.focus();
+  };
+
+  const rows = ranking
+    .filter((entry) => metricOf(entry, active) > 0)
+    .sort(
+      (a, b) =>
+        metricOf(b, active) - metricOf(a, active) ||
+        b.total - a.total ||
+        a.performer.name.localeCompare(b.performer.name, "ja")
+    );
+
+  return (
+    <section>
+      <div
+        role="tablist"
+        aria-label="コンテンツ種別"
+        className="mb-4 flex flex-nowrap gap-1 overflow-x-auto border-b border-brand-border-dark [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {TABS.map((tab, index) => {
+          const isActive = tab === active;
+          const count = ranking.filter(
+            (entry) => metricOf(entry, tab) > 0
+          ).length;
+          return (
+            <button
+              key={tab}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              id={`ranking-tab-${tab}`}
+              role="tab"
+              type="button"
+              aria-controls="ranking-tabpanel"
+              aria-selected={isActive}
+              tabIndex={isActive ? 0 : -1}
+              onKeyDown={(e) => onTabKeyDown(e, index)}
+              onClick={() => setActive(tab)}
+              className={`-mb-px shrink-0 border-b-2 px-3 py-2 text-sm transition ${
+                isActive
+                  ? "border-brand-sky text-brand-sky-light"
+                  : "border-transparent text-brand-muted hover:text-brand-cream"
+              }`}
+            >
+              {tabLabel(tab)}
+              <span className="ml-1 text-xs text-brand-muted">{count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        role="tabpanel"
+        id="ranking-tabpanel"
+        aria-labelledby={`ranking-tab-${active}`}
+      >
+        {rows.length === 0 ? (
+          <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark px-4 py-6 text-sm text-brand-muted">
+            出演データがまだありません。
+          </p>
+        ) : (
+          <ol className="divide-y divide-brand-border-dark overflow-hidden rounded-lg border border-brand-border-dark bg-brand-card-dark">
+            {rows.map((entry, index) => (
+              <li
+                key={`${entry.performer.type}-${entry.performer.id}`}
+                className="flex items-center gap-3 px-3 py-3 sm:gap-4 sm:px-4"
+              >
+                <RankBadge rank={index + 1} />
+                <div className="min-w-0 flex-1">
+                  <PerformerTag performer={entry.performer} />
+                  {active === "total" ? (
+                    <Breakdown counts={entry.counts} />
+                  ) : null}
+                </div>
+                <p className="shrink-0 text-right">
+                  <span
+                    className="text-lg font-bold text-brand-cream sm:text-xl"
+                    style={{ fontVariantNumeric: "tabular-nums" }}
+                  >
+                    {metricOf(entry, active)}
+                  </span>
+                  <span className="ml-0.5 text-xs text-brand-muted">回</span>
+                </p>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function RankBadge({ rank }: { rank: number }) {
+  const tone =
+    rank === 1
+      ? "bg-brand-gold text-brand-bg-dark"
+      : rank === 2
+        ? "bg-brand-muted text-brand-bg-dark"
+        : rank === 3
+          ? "bg-brand-brown-light text-brand-cream"
+          : "bg-brand-bg-dark text-brand-muted";
+  return (
+    <span
+      className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-sm font-bold ${tone}`}
+      style={{ fontVariantNumeric: "tabular-nums" }}
+    >
+      {rank}
+    </span>
+  );
+}
+
+function Breakdown({ counts }: { counts: Record<ContentType, number> }) {
+  const items = CONTENT_TYPES.filter((type) => counts[type] > 0);
+  if (items.length === 0) return null;
+  return (
+    <ul className="mt-1.5 flex flex-wrap gap-x-2.5 gap-y-1">
+      {items.map((type) => (
+        <li key={type} className="text-xs text-brand-muted">
+          {getContentTypeLabel(type)}
+          <span
+            className="ml-1 font-semibold text-brand-gold"
+            style={{ fontVariantNumeric: "tabular-nums" }}
+          >
+            {counts[type]}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -24,6 +24,7 @@ const MORE_ITEMS: NavItem[] = [
   { href: "/articles", label: "記事" },
   { href: "/tv", label: "TV" },
   { href: "/topics", label: "トピック" },
+  { href: "/rankings", label: "ランキング" },
 ];
 
 function isActive(pathname: string, href: string) {

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -14,6 +14,7 @@ const NAV_ITEMS = [
   { href: "/combos", label: "コンビ" },
   { href: "/units", label: "ユニット" },
   { href: "/artists", label: "芸人" },
+  { href: "/rankings", label: "ランキング" },
 ];
 
 function isActive(pathname: string, href: string) {

--- a/src/lib/queries/rankings.test.ts
+++ b/src/lib/queries/rankings.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { aggregateAppearanceRanking } from "@/lib/queries/rankings";
+import type { CastEntry, ContentType } from "@/lib/types";
+
+const dondecorte: CastEntry = {
+  type: "comedy_group",
+  id: "g1",
+  name: "ドンデコルテ",
+};
+const ginji: CastEntry = { type: "artist", id: "a1", name: "渡辺銀次" };
+const kyosaku: CastEntry = { type: "artist", id: "a2", name: "小橋共作" };
+const aoi: CastEntry = { type: "artist", id: "x1", name: "あおい" };
+const kaede: CastEntry = { type: "artist", id: "x2", name: "かえで" };
+
+function castsByContentType(
+  partial: Partial<Record<ContentType, CastEntry[]>>
+): Record<ContentType, CastEntry[]> {
+  return {
+    video: [],
+    live: [],
+    radio: [],
+    article: [],
+    tv_show: [],
+    topic: [],
+    ...partial,
+  };
+}
+
+describe("aggregateAppearanceRanking", () => {
+  it("counts appearances per content type and computes totals", () => {
+    const result = aggregateAppearanceRanking(
+      castsByContentType({
+        video: [dondecorte, dondecorte, ginji],
+        live: [dondecorte],
+        topic: [ginji],
+      })
+    );
+
+    const group = result.find((e) => e.performer.id === "g1");
+    expect(group?.counts.video).toBe(2);
+    expect(group?.counts.live).toBe(1);
+    expect(group?.counts.radio).toBe(0);
+    expect(group?.total).toBe(3);
+
+    const artist = result.find((e) => e.performer.id === "a1");
+    expect(artist?.counts.video).toBe(1);
+    expect(artist?.counts.topic).toBe(1);
+    expect(artist?.total).toBe(2);
+  });
+
+  it("sorts entries by total count descending", () => {
+    const result = aggregateAppearanceRanking(
+      castsByContentType({
+        video: [dondecorte, dondecorte, kyosaku],
+        live: [dondecorte, kyosaku, ginji],
+      })
+    );
+
+    expect(result.map((e) => e.performer.id)).toEqual(["g1", "a2", "a1"]);
+  });
+
+  it("breaks ties by performer name", () => {
+    const result = aggregateAppearanceRanking(
+      castsByContentType({ video: [kaede, aoi] })
+    );
+
+    expect(result.map((e) => e.performer.id)).toEqual(["x1", "x2"]);
+  });
+
+  it("returns an empty array when there are no casts", () => {
+    expect(aggregateAppearanceRanking(castsByContentType({}))).toEqual([]);
+  });
+});

--- a/src/lib/queries/rankings.ts
+++ b/src/lib/queries/rankings.ts
@@ -1,6 +1,6 @@
 import { mapCasts, type CastRow } from "@/lib/queries/_casts";
 import { createClient } from "@/lib/supabase/server";
-import type { CastEntry, ContentType } from "@/lib/types";
+import { CONTENT_TYPES, type CastEntry, type ContentType } from "@/lib/types";
 
 const CAST_TABLE_BY_CONTENT = {
   video: "video_casts",
@@ -10,8 +10,6 @@ const CAST_TABLE_BY_CONTENT = {
   tv_show: "tv_show_casts",
   topic: "topic_casts",
 } as const satisfies Record<ContentType, string>;
-
-const CONTENT_TYPES = Object.keys(CAST_TABLE_BY_CONTENT) as ContentType[];
 
 type CastTable = (typeof CAST_TABLE_BY_CONTENT)[ContentType];
 type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
@@ -83,6 +81,8 @@ async function selectAllCastRows(
       );
     }
 
+    // Supabase は埋め込みリレーションを配列型として推論するため、
+    // CastRow[] への単一キャストでは型エラーになる（実行時の形状は一致する）。
     const page = (data ?? []) as unknown as CastRow[];
     rows.push(...page);
     if (page.length < PAGE_SIZE) break;
@@ -102,10 +102,15 @@ export async function listAppearanceRanking(): Promise<
     )
   );
 
-  const castsByContentType = {} as Record<ContentType, CastEntry[]>;
-  CONTENT_TYPES.forEach((contentType, index) => {
-    castsByContentType[contentType] = mapCasts(castRowsByContentType[index]);
-  });
+  const castsByContentType = CONTENT_TYPES.reduce<
+    Record<ContentType, CastEntry[]>
+  >(
+    (acc, contentType, index) => {
+      acc[contentType] = mapCasts(castRowsByContentType[index]);
+      return acc;
+    },
+    { video: [], live: [], radio: [], article: [], tv_show: [], topic: [] }
+  );
 
   return aggregateAppearanceRanking(castsByContentType);
 }

--- a/src/lib/queries/rankings.ts
+++ b/src/lib/queries/rankings.ts
@@ -1,0 +1,86 @@
+import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { createClient } from "@/lib/supabase/server";
+import type { CastEntry, ContentType } from "@/lib/types";
+
+const CAST_TABLE_BY_CONTENT = {
+  video: "video_casts",
+  live: "live_casts",
+  radio: "radio_casts",
+  article: "article_casts",
+  tv_show: "tv_show_casts",
+  topic: "topic_casts",
+} as const satisfies Record<ContentType, string>;
+
+const CONTENT_TYPES = Object.keys(CAST_TABLE_BY_CONTENT) as ContentType[];
+
+const CAST_SUBSELECT = `
+  artist_id,
+  comedy_group_id,
+  unit_id,
+  artist:artists(id, name),
+  comedy_group:comedy_groups(id, name),
+  unit:units(id, name)
+`;
+
+export type AppearanceRankingEntry = {
+  performer: CastEntry;
+  counts: Record<ContentType, number>;
+  total: number;
+};
+
+function emptyCounts(): Record<ContentType, number> {
+  return { video: 0, live: 0, radio: 0, article: 0, tv_show: 0, topic: 0 };
+}
+
+export function aggregateAppearanceRanking(
+  castsByContentType: Record<ContentType, CastEntry[]>
+): AppearanceRankingEntry[] {
+  const entries = new Map<string, AppearanceRankingEntry>();
+
+  for (const contentType of CONTENT_TYPES) {
+    for (const cast of castsByContentType[contentType]) {
+      const key = `${cast.type}:${cast.id}`;
+      let entry = entries.get(key);
+      if (!entry) {
+        entry = { performer: cast, counts: emptyCounts(), total: 0 };
+        entries.set(key, entry);
+      }
+      entry.counts[contentType] += 1;
+      entry.total += 1;
+    }
+  }
+
+  return [...entries.values()].sort(
+    (a, b) =>
+      b.total - a.total ||
+      a.performer.name.localeCompare(b.performer.name, "ja")
+  );
+}
+
+export async function listAppearanceRanking(): Promise<
+  AppearanceRankingEntry[]
+> {
+  const supabase = await createClient();
+
+  const results = await Promise.all(
+    CONTENT_TYPES.map((contentType) =>
+      supabase.from(CAST_TABLE_BY_CONTENT[contentType]).select(CAST_SUBSELECT)
+    )
+  );
+
+  const failed = results.find((result) => result.error);
+  if (failed?.error) {
+    throw new Error(
+      `出演回数ランキングの取得に失敗しました: ${failed.error.message}`
+    );
+  }
+
+  const castsByContentType = {} as Record<ContentType, CastEntry[]>;
+  CONTENT_TYPES.forEach((contentType, index) => {
+    castsByContentType[contentType] = mapCasts(
+      results[index].data as CastRow[] | null
+    );
+  });
+
+  return aggregateAppearanceRanking(castsByContentType);
+}

--- a/src/lib/queries/rankings.ts
+++ b/src/lib/queries/rankings.ts
@@ -13,6 +13,9 @@ const CAST_TABLE_BY_CONTENT = {
 
 const CONTENT_TYPES = Object.keys(CAST_TABLE_BY_CONTENT) as ContentType[];
 
+type CastTable = (typeof CAST_TABLE_BY_CONTENT)[ContentType];
+type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
+
 const CAST_SUBSELECT = `
   artist_id,
   comedy_group_id,
@@ -21,6 +24,10 @@ const CAST_SUBSELECT = `
   comedy_group:comedy_groups(id, name),
   unit:units(id, name)
 `;
+
+// PostgREST は 1 リクエストあたりの返却行数に上限があるため、
+// 全行を range で分割取得して集計漏れを防ぐ。
+const PAGE_SIZE = 1000;
 
 export type AppearanceRankingEntry = {
   performer: CastEntry;
@@ -57,29 +64,47 @@ export function aggregateAppearanceRanking(
   );
 }
 
+async function selectAllCastRows(
+  supabase: SupabaseClient,
+  table: CastTable
+): Promise<CastRow[]> {
+  const rows: CastRow[] = [];
+
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from(table)
+      .select(CAST_SUBSELECT)
+      .order("id", { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (error) {
+      throw new Error(
+        `出演回数ランキングの取得に失敗しました: ${error.message}`
+      );
+    }
+
+    const page = (data ?? []) as unknown as CastRow[];
+    rows.push(...page);
+    if (page.length < PAGE_SIZE) break;
+  }
+
+  return rows;
+}
+
 export async function listAppearanceRanking(): Promise<
   AppearanceRankingEntry[]
 > {
   const supabase = await createClient();
 
-  const results = await Promise.all(
+  const castRowsByContentType = await Promise.all(
     CONTENT_TYPES.map((contentType) =>
-      supabase.from(CAST_TABLE_BY_CONTENT[contentType]).select(CAST_SUBSELECT)
+      selectAllCastRows(supabase, CAST_TABLE_BY_CONTENT[contentType])
     )
   );
 
-  const failed = results.find((result) => result.error);
-  if (failed?.error) {
-    throw new Error(
-      `出演回数ランキングの取得に失敗しました: ${failed.error.message}`
-    );
-  }
-
   const castsByContentType = {} as Record<ContentType, CastEntry[]>;
   CONTENT_TYPES.forEach((contentType, index) => {
-    castsByContentType[contentType] = mapCasts(
-      results[index].data as CastRow[] | null
-    );
+    castsByContentType[contentType] = mapCasts(castRowsByContentType[index]);
   });
 
   return aggregateAppearanceRanking(castsByContentType);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -6,10 +6,13 @@ export type CastEntry = {
   name: string;
 };
 
-export type ContentType =
-  | "video"
-  | "live"
-  | "radio"
-  | "article"
-  | "tv_show"
-  | "topic";
+export const CONTENT_TYPES = [
+  "video",
+  "live",
+  "radio",
+  "article",
+  "tv_show",
+  "topic",
+] as const;
+
+export type ContentType = (typeof CONTENT_TYPES)[number];


### PR DESCRIPTION
## 概要

issue #45「4-4 出演回数ランキング」の実装です。コンテンツ種別ごとの出演回数を集計し、出演者をランキング表示する公開ページを追加しました。

## 変更内容

- **`src/lib/queries/rankings.ts`** — 6つの cast テーブル（`video_casts` / `live_casts` / `radio_casts` / `article_casts` / `tv_show_casts` / `topic_casts`）を横断して出演者ごとの出演回数を集計するクエリを追加
  - 集計ロジックを純粋関数 `aggregateAppearanceRanking` として切り出し、テスト可能に
- **`src/app/(public)/rankings/page.tsx`** — `/rankings` 公開ページ（Server Component）を追加
- **`src/components/features/ranking/appearance-ranking-board.tsx`** — タブ切り替え式のランキング表示コンポーネント
  - 「総合」タブ：合計出演回数で並び替え、コンテンツ種別ごとの内訳を表示
  - コンテンツ種別タブ（動画/ライブ/ラジオ/記事/TV/トピック）：その種別の出演回数で並び替え
  - 上位3名はランクバッジを色分け
- **ナビゲーション** — ヘッダー・モバイルボトムナビに「ランキング」導線を追加
- **`src/lib/queries/rankings.test.ts`** — 集計ロジックのユニットテストを追加（4ケース、全パス）

## 動作確認

- `npx tsc --noEmit` — 本 PR の新規ファイルに型エラーなし
- `npm run lint` — パス
- `npx vitest run src/lib/queries/rankings.test.ts` — 4件すべてパス
- `next build` — 新規ルートを含むコンパイルは成功（`✓ Compiled successfully`）

### 注意（本 issue 対象外）

ローカル環境での `next build` の型チェックフェーズで、`src/lib/actions/achievements.ts` 等の**既存ファイル**に型エラーが出ています。これらは本 PR の変更とは無関係で、リポジトリに lockfile が無いことによる依存バージョンのドリフトが原因と考えられます。本 issue のスコープ外のため本 PR では修正していません。

## テスト観点

- [ ] `/rankings` ページが表示される
- [ ] 「総合」タブで合計出演回数の降順に並ぶ
- [ ] コンテンツ種別タブを切り替えると該当種別の回数で並び替わる
- [ ] 出演者タグから各出演者の詳細ページに遷移できる
- [ ] ヘッダー / ボトムナビの「ランキング」リンクが機能する

Closes #45

https://claude.ai/code/session_01JoZJtWY5XVX9hTPgN6UowF

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoZJtWY5XVX9hTPgN6UowF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Rankings page displaying performer appearance statistics by content type
  * Includes tabbed interface for filtering rankings across different content categories
  * Accessible keyboard navigation support for browsing rankings
  * Updated header and menu navigation to include Rankings section

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->