### PR TITLE
cast出演テーブルを単一の casts テーブルに統合 (#47)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@serwist/next':
+        specifier: ^9.5.11
+        version: 9.5.11(next@16.2.5(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       '@supabase/ssr':
         specifier: ^0.10.2
         version: 0.10.2(@supabase/supabase-js@2.103.2)
       '@supabase/supabase-js':
         specifier: ^2.103.2
         version: 2.103.2
+      d3:
+        specifier: ^7.9.0
+        version: 7.9.0
       next:
         specifier: 16.2.5
         version: 16.2.5(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -42,6 +48,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/d3':
+        specifier: ^7.4.3
+        version: 7.4.3
       '@types/node':
         specifier: ^20
         version: 20.19.39
@@ -66,6 +75,12 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      serwist:
+        specifier: ^9.5.11
+        version: 9.5.11(browserslist@4.28.2)(typescript@5.9.3)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -219,9 +234,6 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -653,6 +665,57 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@serwist/build@9.5.11':
+    resolution: {integrity: sha512-PQfW+LhADYFOOp0PhEnjlgJCyKor6cYa06d3rID1OpiKzkmCApJV1WYfdTBB96jXaWv6OWcWSbSV4tqDLxvaVA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@serwist/next@9.5.11':
+    resolution: {integrity: sha512-omT32H7U21ihCymSvOG9QeRJBuOEomJx4JdzKhUoqOW3DR10tH3m84VOHj3BvK0OcA7av3qj5FsyNFBB+f0n8A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@serwist/cli': ^9.5.11
+      next: '>=14.0.0'
+      react: '>=18.0.0'
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      '@serwist/cli':
+        optional: true
+      typescript:
+        optional: true
+
+  '@serwist/utils@9.5.11':
+    resolution: {integrity: sha512-zqxmwuHqWA3OwN82Wo8gFZ9QBemygJP3cap5JWAOG4UyJZgUZfmBXAXj+IMaD4eKZ/6pqrxHHDZ9uSWZmJ1mXA==}
+    peerDependencies:
+      browserslist: '>=4'
+    peerDependenciesMeta:
+      browserslist:
+        optional: true
+
+  '@serwist/webpack-plugin@9.5.11':
+    resolution: {integrity: sha512-SlvO3A1UMcc1htCzMtLCtPQK6yISCO7B859ixLv7EiY/yayXjVxGm9vHqkJYpQ768PWyjEZXRY/X6EGRMA6wJQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+      webpack: 4.4.0 || ^5.9.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      webpack:
+        optional: true
+
+  '@serwist/window@9.5.11':
+    resolution: {integrity: sha512-OrH9srhmifUvY36NuukHSZby24XTEk4pHh3pfY0GBQzA9ouU1fYh+ORWhKxH7/wkVHRr3sc4YAhjtpfL14PjjQ==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -821,11 +884,107 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -843,6 +1002,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1209,6 +1371,14 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  common-tags@1.8.2:
+    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
+    engines: {node: '>=4.0.0'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -1232,6 +1402,133 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -1282,6 +1579,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1592,6 +1892,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -1652,6 +1956,13 @@ packages:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  idb@8.0.3:
+    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1675,6 +1986,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1842,6 +2157,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -1934,6 +2252,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1980,6 +2301,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2094,6 +2419,10 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -2137,6 +2466,10 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pretty-bytes@6.1.1:
+    resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -2205,6 +2538,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.0.0:
     resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2212,6 +2548,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -2224,6 +2563,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -2240,6 +2582,14 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  serwist@9.5.11:
+    resolution: {integrity: sha512-Bq6uwJFd4ET60BWI77v3VbazKHv6k7lECOiiCFwKyBu/slaCn0GHJ5L5RfsuJUKrnbD9lYUCDo6sqaKRM5M2vA==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2287,6 +2637,11 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.8.0-beta.0:
+    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
+    engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -2360,6 +2715,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
@@ -2397,6 +2756,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@1.0.1:
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -2416,6 +2778,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -2556,6 +2922,9 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -2567,6 +2936,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@7.1.0:
+    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2632,6 +3004,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zod@4.4.1:
+    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
 snapshots:
 
@@ -2806,11 +3181,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
@@ -2875,8 +3245,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -2960,7 +3329,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -2994,7 +3363,7 @@ snapshots:
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -3109,6 +3478,63 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@rtsao/scc@1.1.0': {}
+
+  '@serwist/build@9.5.11(browserslist@4.28.2)(typescript@5.9.3)':
+    dependencies:
+      '@serwist/utils': 9.5.11(browserslist@4.28.2)
+      common-tags: 1.8.2
+      glob: 13.0.6
+      pretty-bytes: 6.1.1
+      source-map: 0.8.0-beta.0
+      type-fest: 5.6.0
+      zod: 4.4.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - browserslist
+
+  '@serwist/next@9.5.11(next@16.2.5(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3)':
+    dependencies:
+      '@serwist/build': 9.5.11(browserslist@4.28.2)(typescript@5.9.3)
+      '@serwist/utils': 9.5.11(browserslist@4.28.2)
+      '@serwist/webpack-plugin': 9.5.11(browserslist@4.28.2)(typescript@5.9.3)
+      '@serwist/window': 9.5.11(browserslist@4.28.2)(typescript@5.9.3)
+      browserslist: 4.28.2
+      glob: 13.0.6
+      kolorist: 1.8.0
+      next: 16.2.5(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      semver: 7.7.4
+      serwist: 9.5.11(browserslist@4.28.2)(typescript@5.9.3)
+      zod: 4.4.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - webpack
+
+  '@serwist/utils@9.5.11(browserslist@4.28.2)':
+    optionalDependencies:
+      browserslist: 4.28.2
+
+  '@serwist/webpack-plugin@9.5.11(browserslist@4.28.2)(typescript@5.9.3)':
+    dependencies:
+      '@serwist/build': 9.5.11(browserslist@4.28.2)(typescript@5.9.3)
+      '@serwist/utils': 9.5.11(browserslist@4.28.2)
+      pretty-bytes: 6.1.1
+      zod: 4.4.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - browserslist
+
+  '@serwist/window@9.5.11(browserslist@4.28.2)(typescript@5.9.3)':
+    dependencies:
+      '@types/trusted-types': 2.0.7
+      serwist: 9.5.11(browserslist@4.28.2)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - browserslist
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -3276,9 +3702,128 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -3295,6 +3840,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -3673,6 +4220,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  commander@7.2.0: {}
+
+  common-tags@1.8.2: {}
+
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
@@ -3693,6 +4244,158 @@ snapshots:
   css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
 
   damerau-levenshtein@1.0.8: {}
 
@@ -3744,6 +4447,10 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   dequal@2.0.3: {}
 
@@ -4199,6 +4906,12 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globals@14.0.0: {}
 
   globals@16.4.0: {}
@@ -4248,6 +4961,12 @@ snapshots:
 
   iceberg-js@0.8.1: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  idb@8.0.3: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -4266,6 +4985,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4453,6 +5174,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kolorist@1.8.0: {}
+
   language-subtag-registry@0.3.23: {}
 
   language-tags@1.0.9:
@@ -4519,6 +5242,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash.sortby@4.7.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -4557,6 +5282,8 @@ snapshots:
       brace-expansion: 1.1.14
 
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   ms@2.1.3: {}
 
@@ -4681,6 +5408,11 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.6
+      minipass: 7.1.3
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -4718,6 +5450,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  pretty-bytes@6.1.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -4792,6 +5526,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.0.0:
     dependencies:
       '@oxc-project/types': 0.129.0
@@ -4817,6 +5553,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rw@1.3.3: {}
+
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.9
@@ -4836,6 +5574,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -4845,6 +5585,15 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  serwist@9.5.11(browserslist@4.28.2)(typescript@5.9.3):
+    dependencies:
+      '@serwist/utils': 9.5.11(browserslist@4.28.2)
+      idb: 8.0.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - browserslist
 
   set-function-length@1.2.2:
     dependencies:
@@ -4898,7 +5647,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -4937,6 +5685,10 @@ snapshots:
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  source-map@0.8.0-beta.0:
+    dependencies:
+      whatwg-url: 7.1.0
 
   stable-hash@0.0.5: {}
 
@@ -5022,6 +5774,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tagged-tag@1.0.0: {}
+
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
@@ -5051,6 +5805,10 @@ snapshots:
     dependencies:
       tldts: 7.0.30
 
+  tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -5071,6 +5829,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -5207,6 +5969,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  webidl-conversions@4.0.2: {}
+
   webidl-conversions@8.0.1: {}
 
   whatwg-mimetype@5.0.0: {}
@@ -5218,6 +5982,12 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@7.1.0:
+    dependencies:
+      lodash.sortby: 4.7.0
+      tr46: 1.0.1
+      webidl-conversions: 4.0.2
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -5286,3 +6056,5 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zod@4.4.1: {}

--- a/src/lib/actions/articles.test.ts
+++ b/src/lib/actions/articles.test.ts
@@ -98,12 +98,13 @@ describe("createArticle", () => {
     });
     const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
     const insertChain = vi.fn(() => ({ select: insertSelect }));
-    const deleteEq = vi.fn().mockResolvedValue({ error: null });
-    const deleteChain = vi.fn(() => ({ eq: deleteEq }));
+    const deleteEqContent = vi.fn().mockResolvedValue({ error: null });
+    const deleteEqType = vi.fn(() => ({ eq: deleteEqContent }));
+    const deleteChain = vi.fn(() => ({ eq: deleteEqType }));
 
     supabaseMock.from.mockImplementation((table: string) => {
       if (table === "articles") return { insert: insertChain };
-      if (table === "article_casts") return { delete: deleteChain };
+      if (table === "casts") return { delete: deleteChain };
       throw new Error(`unexpected table: ${table}`);
     });
 

--- a/src/lib/actions/articles.ts
+++ b/src/lib/actions/articles.ts
@@ -193,13 +193,19 @@ export async function updateArticle(
     return { error: "認証が必要です" };
   }
 
-  const { error } = await supabase
+  const { error, count } = await supabase
     .from("articles")
-    .update({ ...values, updated_at: new Date().toISOString() })
+    .update(
+      { ...values, updated_at: new Date().toISOString() },
+      { count: "exact" }
+    )
     .eq("id", id);
 
   if (error) {
     return { error: `記事の更新に失敗しました: ${error.message}` };
+  }
+  if (count !== 1) {
+    return { error: "指定された記事が見つかりません" };
   }
 
   const castsResult = await replaceCasts(supabase, id, casts);

--- a/src/lib/actions/articles.ts
+++ b/src/lib/actions/articles.ts
@@ -107,9 +107,10 @@ async function replaceCasts(
   casts: CastEntry[]
 ): Promise<{ error?: string }> {
   const { error: deleteError } = await supabase
-    .from("article_casts")
+    .from("casts")
     .delete()
-    .eq("article_id", articleId);
+    .eq("content_type", "article")
+    .eq("content_id", articleId);
 
   if (deleteError) {
     return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
@@ -118,15 +119,14 @@ async function replaceCasts(
   if (casts.length === 0) return {};
 
   const rows = casts.map((c) => ({
-    article_id: articleId,
+    content_type: "article",
+    content_id: articleId,
     artist_id: c.type === "artist" ? c.id : null,
     comedy_group_id: c.type === "comedy_group" ? c.id : null,
     unit_id: c.type === "unit" ? c.id : null,
   }));
 
-  const { error: insertError } = await supabase
-    .from("article_casts")
-    .insert(rows);
+  const { error: insertError } = await supabase.from("casts").insert(rows);
 
   if (insertError) {
     return { error: `出演者の追加に失敗しました: ${insertError.message}` };

--- a/src/lib/actions/lives.test.ts
+++ b/src/lib/actions/lives.test.ts
@@ -90,12 +90,13 @@ describe("createLive", () => {
     });
     const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
     const insertChain = vi.fn(() => ({ select: insertSelect }));
-    const deleteEq = vi.fn().mockResolvedValue({ error: null });
-    const deleteChain = vi.fn(() => ({ eq: deleteEq }));
+    const deleteEqContent = vi.fn().mockResolvedValue({ error: null });
+    const deleteEqType = vi.fn(() => ({ eq: deleteEqContent }));
+    const deleteChain = vi.fn(() => ({ eq: deleteEqType }));
 
     supabaseMock.from.mockImplementation((table: string) => {
       if (table === "lives") return { insert: insertChain };
-      if (table === "live_casts") return { delete: deleteChain };
+      if (table === "casts") return { delete: deleteChain };
       throw new Error(`unexpected table: ${table}`);
     });
 
@@ -113,12 +114,13 @@ describe("createLive", () => {
     });
     const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
     const insertChain = vi.fn(() => ({ select: insertSelect }));
-    const deleteEq = vi.fn().mockResolvedValue({ error: null });
-    const deleteChain = vi.fn(() => ({ eq: deleteEq }));
+    const deleteEqContent = vi.fn().mockResolvedValue({ error: null });
+    const deleteEqType = vi.fn(() => ({ eq: deleteEqContent }));
+    const deleteChain = vi.fn(() => ({ eq: deleteEqType }));
 
     supabaseMock.from.mockImplementation((table: string) => {
       if (table === "lives") return { insert: insertChain };
-      if (table === "live_casts") return { delete: deleteChain };
+      if (table === "casts") return { delete: deleteChain };
       throw new Error(`unexpected table: ${table}`);
     });
 

--- a/src/lib/actions/lives.ts
+++ b/src/lib/actions/lives.ts
@@ -112,9 +112,10 @@ async function replaceCasts(
   casts: CastEntry[]
 ): Promise<{ error?: string }> {
   const { error: deleteError } = await supabase
-    .from("live_casts")
+    .from("casts")
     .delete()
-    .eq("live_id", liveId);
+    .eq("content_type", "live")
+    .eq("content_id", liveId);
 
   if (deleteError) {
     return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
@@ -123,15 +124,14 @@ async function replaceCasts(
   if (casts.length === 0) return {};
 
   const rows = casts.map((c) => ({
-    live_id: liveId,
+    content_type: "live",
+    content_id: liveId,
     artist_id: c.type === "artist" ? c.id : null,
     comedy_group_id: c.type === "comedy_group" ? c.id : null,
     unit_id: c.type === "unit" ? c.id : null,
   }));
 
-  const { error: insertError } = await supabase
-    .from("live_casts")
-    .insert(rows);
+  const { error: insertError } = await supabase.from("casts").insert(rows);
 
   if (insertError) {
     return { error: `出演者の追加に失敗しました: ${insertError.message}` };

--- a/src/lib/actions/radios.ts
+++ b/src/lib/actions/radios.ts
@@ -170,13 +170,19 @@ export async function updateRadio(
     return { error: "認証が必要です" };
   }
 
-  const { error } = await supabase
+  const { error, count } = await supabase
     .from("radios")
-    .update({ ...values, updated_at: new Date().toISOString() })
+    .update(
+      { ...values, updated_at: new Date().toISOString() },
+      { count: "exact" }
+    )
     .eq("id", id);
 
   if (error) {
     return { error: `ラジオの更新に失敗しました: ${error.message}` };
+  }
+  if (count !== 1) {
+    return { error: "指定されたラジオが見つかりません" };
   }
 
   const castsResult = await replaceCasts(supabase, id, casts);

--- a/src/lib/actions/radios.ts
+++ b/src/lib/actions/radios.ts
@@ -84,9 +84,10 @@ async function replaceCasts(
   casts: CastEntry[]
 ): Promise<{ error?: string }> {
   const { error: deleteError } = await supabase
-    .from("radio_casts")
+    .from("casts")
     .delete()
-    .eq("radio_id", radioId);
+    .eq("content_type", "radio")
+    .eq("content_id", radioId);
 
   if (deleteError) {
     return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
@@ -95,15 +96,14 @@ async function replaceCasts(
   if (casts.length === 0) return {};
 
   const rows = casts.map((c) => ({
-    radio_id: radioId,
+    content_type: "radio",
+    content_id: radioId,
     artist_id: c.type === "artist" ? c.id : null,
     comedy_group_id: c.type === "comedy_group" ? c.id : null,
     unit_id: c.type === "unit" ? c.id : null,
   }));
 
-  const { error: insertError } = await supabase
-    .from("radio_casts")
-    .insert(rows);
+  const { error: insertError } = await supabase.from("casts").insert(rows);
 
   if (insertError) {
     return { error: `出演者の追加に失敗しました: ${insertError.message}` };

--- a/src/lib/actions/topics.ts
+++ b/src/lib/actions/topics.ts
@@ -170,13 +170,19 @@ export async function updateTopic(
     return { error: "認証が必要です" };
   }
 
-  const { error } = await supabase
+  const { error, count } = await supabase
     .from("topics")
-    .update({ ...values, updated_at: new Date().toISOString() })
+    .update(
+      { ...values, updated_at: new Date().toISOString() },
+      { count: "exact" }
+    )
     .eq("id", id);
 
   if (error) {
     return { error: `トピックの更新に失敗しました: ${error.message}` };
+  }
+  if (count !== 1) {
+    return { error: "指定されたトピックが見つかりません" };
   }
 
   const castsResult = await replaceCasts(supabase, id, casts);

--- a/src/lib/actions/topics.ts
+++ b/src/lib/actions/topics.ts
@@ -84,9 +84,10 @@ async function replaceCasts(
   casts: CastEntry[]
 ): Promise<{ error?: string }> {
   const { error: deleteError } = await supabase
-    .from("topic_casts")
+    .from("casts")
     .delete()
-    .eq("topic_id", topicId);
+    .eq("content_type", "topic")
+    .eq("content_id", topicId);
 
   if (deleteError) {
     return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
@@ -95,15 +96,14 @@ async function replaceCasts(
   if (casts.length === 0) return {};
 
   const rows = casts.map((c) => ({
-    topic_id: topicId,
+    content_type: "topic",
+    content_id: topicId,
     artist_id: c.type === "artist" ? c.id : null,
     comedy_group_id: c.type === "comedy_group" ? c.id : null,
     unit_id: c.type === "unit" ? c.id : null,
   }));
 
-  const { error: insertError } = await supabase
-    .from("topic_casts")
-    .insert(rows);
+  const { error: insertError } = await supabase.from("casts").insert(rows);
 
   if (insertError) {
     return { error: `出演者の追加に失敗しました: ${insertError.message}` };

--- a/src/lib/actions/tv-shows.ts
+++ b/src/lib/actions/tv-shows.ts
@@ -171,13 +171,19 @@ export async function updateTvShow(
     return { error: "認証が必要です" };
   }
 
-  const { error } = await supabase
+  const { error, count } = await supabase
     .from("tv_shows")
-    .update({ ...values, updated_at: new Date().toISOString() })
+    .update(
+      { ...values, updated_at: new Date().toISOString() },
+      { count: "exact" }
+    )
     .eq("id", id);
 
   if (error) {
     return { error: `TV番組の更新に失敗しました: ${error.message}` };
+  }
+  if (count !== 1) {
+    return { error: "指定されたTV番組が見つかりません" };
   }
 
   const castsResult = await replaceCasts(supabase, id, casts);

--- a/src/lib/actions/tv-shows.ts
+++ b/src/lib/actions/tv-shows.ts
@@ -85,9 +85,10 @@ async function replaceCasts(
   casts: CastEntry[]
 ): Promise<{ error?: string }> {
   const { error: deleteError } = await supabase
-    .from("tv_show_casts")
+    .from("casts")
     .delete()
-    .eq("tv_show_id", tvShowId);
+    .eq("content_type", "tv_show")
+    .eq("content_id", tvShowId);
 
   if (deleteError) {
     return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
@@ -96,15 +97,14 @@ async function replaceCasts(
   if (casts.length === 0) return {};
 
   const rows = casts.map((c) => ({
-    tv_show_id: tvShowId,
+    content_type: "tv_show",
+    content_id: tvShowId,
     artist_id: c.type === "artist" ? c.id : null,
     comedy_group_id: c.type === "comedy_group" ? c.id : null,
     unit_id: c.type === "unit" ? c.id : null,
   }));
 
-  const { error: insertError } = await supabase
-    .from("tv_show_casts")
-    .insert(rows);
+  const { error: insertError } = await supabase.from("casts").insert(rows);
 
   if (insertError) {
     return { error: `出演者の追加に失敗しました: ${insertError.message}` };

--- a/src/lib/actions/videos.test.ts
+++ b/src/lib/actions/videos.test.ts
@@ -71,14 +71,15 @@ describe("createVideo", () => {
     });
     const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
     const insertChain = vi.fn(() => ({ select: insertSelect }));
-    const deleteEq = vi.fn().mockResolvedValue({ error: null });
-    const deleteChain = vi.fn(() => ({ eq: deleteEq }));
+    const deleteEqContent = vi.fn().mockResolvedValue({ error: null });
+    const deleteEqType = vi.fn(() => ({ eq: deleteEqContent }));
+    const deleteChain = vi.fn(() => ({ eq: deleteEqType }));
 
     supabaseMock.from.mockImplementation((table: string) => {
       if (table === "videos") {
         return { insert: insertChain };
       }
-      if (table === "video_casts") {
+      if (table === "casts") {
         return { delete: deleteChain };
       }
       throw new Error(`unexpected table: ${table}`);
@@ -102,12 +103,13 @@ describe("createVideo", () => {
     });
     const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
     const insertChain = vi.fn(() => ({ select: insertSelect }));
-    const deleteEq = vi.fn().mockResolvedValue({ error: null });
-    const deleteChain = vi.fn(() => ({ eq: deleteEq }));
+    const deleteEqContent = vi.fn().mockResolvedValue({ error: null });
+    const deleteEqType = vi.fn(() => ({ eq: deleteEqContent }));
+    const deleteChain = vi.fn(() => ({ eq: deleteEqType }));
 
     supabaseMock.from.mockImplementation((table: string) => {
       if (table === "videos") return { insert: insertChain };
-      if (table === "video_casts") return { delete: deleteChain };
+      if (table === "casts") return { delete: deleteChain };
       throw new Error(`unexpected table: ${table}`);
     });
 

--- a/src/lib/actions/videos.test.ts
+++ b/src/lib/actions/videos.test.ts
@@ -94,6 +94,12 @@ describe("createVideo", () => {
     expect(insertChain).toHaveBeenCalledWith(
       expect.objectContaining({ youtube_video_id: "abcDEF12345" })
     );
+    expect(supabaseMock.from).toHaveBeenCalledWith("casts");
+    expect(deleteEqType).toHaveBeenCalledWith("content_type", "video");
+    expect(deleteEqContent).toHaveBeenCalledWith(
+      "content_id",
+      "11111111-1111-4111-8111-111111111111"
+    );
   });
 
   it("youtube_url から動画IDを抽出する", async () => {
@@ -121,6 +127,12 @@ describe("createVideo", () => {
     await expect(createVideo({}, fd)).rejects.toThrow(/__REDIRECT__/);
     expect(insertChain).toHaveBeenCalledWith(
       expect.objectContaining({ youtube_video_id: "abcDEF12345" })
+    );
+    expect(supabaseMock.from).toHaveBeenCalledWith("casts");
+    expect(deleteEqType).toHaveBeenCalledWith("content_type", "video");
+    expect(deleteEqContent).toHaveBeenCalledWith(
+      "content_id",
+      "11111111-1111-4111-8111-111111111111"
     );
   });
 

--- a/src/lib/actions/videos.ts
+++ b/src/lib/actions/videos.ts
@@ -99,9 +99,10 @@ async function replaceCasts(
   casts: CastEntry[]
 ): Promise<{ error?: string }> {
   const { error: deleteError } = await supabase
-    .from("video_casts")
+    .from("casts")
     .delete()
-    .eq("video_id", videoId);
+    .eq("content_type", "video")
+    .eq("content_id", videoId);
 
   if (deleteError) {
     return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
@@ -110,15 +111,14 @@ async function replaceCasts(
   if (casts.length === 0) return {};
 
   const rows = casts.map((c) => ({
-    video_id: videoId,
+    content_type: "video",
+    content_id: videoId,
     artist_id: c.type === "artist" ? c.id : null,
     comedy_group_id: c.type === "comedy_group" ? c.id : null,
     unit_id: c.type === "unit" ? c.id : null,
   }));
 
-  const { error: insertError } = await supabase
-    .from("video_casts")
-    .insert(rows);
+  const { error: insertError } = await supabase.from("casts").insert(rows);
 
   if (insertError) {
     return { error: `出演者の追加に失敗しました: ${insertError.message}` };

--- a/src/lib/actions/videos.ts
+++ b/src/lib/actions/videos.ts
@@ -185,13 +185,19 @@ export async function updateVideo(
     return { error: "認証が必要です" };
   }
 
-  const { error } = await supabase
+  const { error, count } = await supabase
     .from("videos")
-    .update({ ...values, updated_at: new Date().toISOString() })
+    .update(
+      { ...values, updated_at: new Date().toISOString() },
+      { count: "exact" }
+    )
     .eq("id", id);
 
   if (error) {
     return { error: `動画の更新に失敗しました: ${error.message}` };
+  }
+  if (count !== 1) {
+    return { error: "指定された動画が見つかりません" };
   }
 
   const castsResult = await replaceCasts(supabase, id, casts);

--- a/src/lib/queries/_casts.ts
+++ b/src/lib/queries/_casts.ts
@@ -1,4 +1,5 @@
-import type { CastEntry } from "@/lib/types";
+import type { createClient } from "@/lib/supabase/server";
+import type { CastEntry, ContentType } from "@/lib/types";
 
 export type CastRow = {
   artist_id: string | null;
@@ -8,6 +9,21 @@ export type CastRow = {
   comedy_group: { id: string; name: string } | null;
   unit: { id: string; name: string } | null;
 };
+
+type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
+
+// casts はポリモーフィック設計（content_type + content_id）で content 側へ
+// FK を張れないため、PostgREST の自動埋め込み（videos.select("*, casts(...)")）が
+// 使えない。出演者の埋め込みは artist/comedy_group/unit への FK 経由で行う。
+const CAST_EMBED_SELECT = `
+  content_id,
+  artist_id,
+  comedy_group_id,
+  unit_id,
+  artist:artists(id, name),
+  comedy_group:comedy_groups(id, name),
+  unit:units(id, name)
+`;
 
 export function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
   return (rows ?? []).flatMap((c) => {
@@ -22,4 +38,41 @@ export function mapCasts(rows: CastRow[] | null | undefined): CastEntry[] {
     }
     return [];
   });
+}
+
+/**
+ * 指定コンテンツ群の出演者を casts テーブルからまとめて取得し、
+ * content_id ごとの CastEntry[] にマップする。
+ */
+export async function fetchCastsByContent(
+  supabase: SupabaseClient,
+  contentType: ContentType,
+  contentIds: string[]
+): Promise<Map<string, CastEntry[]>> {
+  const result = new Map<string, CastEntry[]>();
+  if (contentIds.length === 0) return result;
+
+  const { data, error } = await supabase
+    .from("casts")
+    .select(CAST_EMBED_SELECT)
+    .eq("content_type", contentType)
+    .in("content_id", contentIds);
+
+  if (error) {
+    throw new Error(`出演者情報の取得に失敗しました: ${error.message}`);
+  }
+
+  const rowsByContent = new Map<string, CastRow[]>();
+  for (const row of (data ?? []) as unknown as Array<
+    CastRow & { content_id: string }
+  >) {
+    const list = rowsByContent.get(row.content_id);
+    if (list) list.push(row);
+    else rowsByContent.set(row.content_id, [row]);
+  }
+
+  for (const [contentId, rows] of rowsByContent) {
+    result.set(contentId, mapCasts(rows));
+  }
+  return result;
 }

--- a/src/lib/queries/_co-casts.ts
+++ b/src/lib/queries/_co-casts.ts
@@ -84,12 +84,22 @@ export async function listDondecorteContents(
 
 /**
  * 指定したコンテンツ群に出演する全 casts 行を取得する。
+ *
+ * PostgREST では複合キー (content_type, content_id) の IN 条件を直接
+ * 表現できないため content_id で取得し、ポリモーフィックモデルの論理キー
+ * (content_type, content_id) で JS 側で絞り込む（content_id が
+ * コンテンツ種別をまたいで衝突しても誤った行を拾わないようにするため）。
  */
 export async function listCastsForContents(
   supabase: SupabaseClient,
-  contentIds: string[]
+  refs: ContentRef[]
 ): Promise<CoCastRow[]> {
-  if (contentIds.length === 0) return [];
+  if (refs.length === 0) return [];
+
+  const contentIds = Array.from(new Set(refs.map((r) => r.contentId)));
+  const allowed = new Set(
+    refs.map((r) => `${r.contentType}:${r.contentId}`)
+  );
 
   const { data, error } = await supabase
     .from("casts")
@@ -100,7 +110,9 @@ export async function listCastsForContents(
     throw new Error(`共演者情報の取得に失敗しました: ${error.message}`);
   }
 
-  return (data ?? []) as unknown as CoCastRow[];
+  return ((data ?? []) as unknown as CoCastRow[]).filter((row) =>
+    allowed.has(`${row.content_type}:${row.content_id}`)
+  );
 }
 
 export function entryFromRow(row: CoCastRow): CastEntry | null {

--- a/src/lib/queries/_co-casts.ts
+++ b/src/lib/queries/_co-casts.ts
@@ -5,46 +5,14 @@ export const DONDECORTE_COMBO_NAME = "ドンデコルテ";
 
 export type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
 
-export type CastTable =
-  | "video_casts"
-  | "live_casts"
-  | "radio_casts"
-  | "article_casts"
-  | "tv_show_casts"
-  | "topic_casts";
-
-export type ParentIdField =
-  | "video_id"
-  | "live_id"
-  | "radio_id"
-  | "article_id"
-  | "tv_show_id"
-  | "topic_id";
-
-export type CastTableSpec = {
-  table: CastTable;
-  parentIdField: ParentIdField;
+export type ContentRef = {
   contentType: ContentType;
+  contentId: string;
 };
 
-export const CAST_TABLES: CastTableSpec[] = [
-  { table: "video_casts", parentIdField: "video_id", contentType: "video" },
-  { table: "live_casts", parentIdField: "live_id", contentType: "live" },
-  { table: "radio_casts", parentIdField: "radio_id", contentType: "radio" },
-  {
-    table: "article_casts",
-    parentIdField: "article_id",
-    contentType: "article",
-  },
-  {
-    table: "tv_show_casts",
-    parentIdField: "tv_show_id",
-    contentType: "tv_show",
-  },
-  { table: "topic_casts", parentIdField: "topic_id", contentType: "topic" },
-];
-
 export type CoCastRow = {
+  content_type: ContentType;
+  content_id: string;
   artist_id: string | null;
   comedy_group_id: string | null;
   unit_id: string | null;
@@ -53,7 +21,16 @@ export type CoCastRow = {
   unit: { id: string; name: string } | null;
 };
 
-export type RawCoCastRow = CoCastRow & Record<ParentIdField, string>;
+const CO_CAST_SELECT = `
+  content_type,
+  content_id,
+  artist_id,
+  comedy_group_id,
+  unit_id,
+  artist:artists(id, name),
+  comedy_group:comedy_groups(id, name),
+  unit:units(id, name)
+`;
 
 export async function getDondecorteComedyGroupId(
   supabase: SupabaseClient
@@ -73,55 +50,57 @@ export async function getDondecorteComedyGroupId(
   return rows[0]?.id ?? null;
 }
 
-export async function listOwnParentIds(
+/**
+ * ドンデコルテが出演しているコンテンツの一覧（重複排除済み）。
+ * 旧実装では 6 つの cast テーブルを個別に走査していたが、
+ * casts 統合テーブルにより 1 クエリで取得できる。
+ */
+export async function listDondecorteContents(
   supabase: SupabaseClient,
-  spec: CastTableSpec,
   dondecorteId: string
-): Promise<string[]> {
+): Promise<ContentRef[]> {
   const { data, error } = await supabase
-    .from(spec.table)
-    .select(spec.parentIdField)
+    .from("casts")
+    .select("content_type, content_id")
     .eq("comedy_group_id", dondecorteId);
 
   if (error) {
-    throw new Error(
-      `共演者情報の取得に失敗しました(${spec.table}): ${error.message}`
-    );
+    throw new Error(`共演者情報の取得に失敗しました: ${error.message}`);
   }
 
-  const ids = ((data ?? []) as Array<Record<ParentIdField, string>>).map(
-    (row) => row[spec.parentIdField]
-  );
-  return Array.from(new Set(ids));
+  const seen = new Set<string>();
+  const refs: ContentRef[] = [];
+  for (const row of (data ?? []) as Array<{
+    content_type: ContentType;
+    content_id: string;
+  }>) {
+    const key = `${row.content_type}:${row.content_id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    refs.push({ contentType: row.content_type, contentId: row.content_id });
+  }
+  return refs;
 }
 
-export async function listCoCastRows(
+/**
+ * 指定したコンテンツ群に出演する全 casts 行を取得する。
+ */
+export async function listCastsForContents(
   supabase: SupabaseClient,
-  spec: CastTableSpec,
-  parentIds: string[]
-): Promise<RawCoCastRow[]> {
-  if (parentIds.length === 0) return [];
+  contentIds: string[]
+): Promise<CoCastRow[]> {
+  if (contentIds.length === 0) return [];
 
   const { data, error } = await supabase
-    .from(spec.table)
-    .select(
-      `${spec.parentIdField},
-       artist_id,
-       comedy_group_id,
-       unit_id,
-       artist:artists(id, name),
-       comedy_group:comedy_groups(id, name),
-       unit:units(id, name)`
-    )
-    .in(spec.parentIdField, parentIds);
+    .from("casts")
+    .select(CO_CAST_SELECT)
+    .in("content_id", contentIds);
 
   if (error) {
-    throw new Error(
-      `共演者情報の取得に失敗しました(${spec.table}): ${error.message}`
-    );
+    throw new Error(`共演者情報の取得に失敗しました: ${error.message}`);
   }
 
-  return (data ?? []) as unknown as RawCoCastRow[];
+  return (data ?? []) as unknown as CoCastRow[];
 }
 
 export function entryFromRow(row: CoCastRow): CastEntry | null {

--- a/src/lib/queries/_list-options.ts
+++ b/src/lib/queries/_list-options.ts
@@ -1,5 +1,5 @@
 import type { createClient } from "@/lib/supabase/server";
-import type { CastType } from "@/lib/types";
+import type { CastType, ContentType } from "@/lib/types";
 
 export type SortOrder = "newest" | "oldest";
 
@@ -15,14 +15,6 @@ export type ListOptions = {
 
 type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
 
-type CastTable =
-  | "video_casts"
-  | "live_casts"
-  | "radio_casts"
-  | "article_casts"
-  | "tv_show_casts"
-  | "topic_casts";
-
 function castFieldFor(
   type: CastType
 ): "artist_id" | "comedy_group_id" | "unit_id" {
@@ -31,23 +23,23 @@ function castFieldFor(
   return "unit_id";
 }
 
-export async function getIdsForPerformer<K extends string>(
+export async function getIdsForPerformer(
   supabase: SupabaseClient,
-  castTable: CastTable,
-  parentIdField: K,
+  contentType: ContentType,
   performer: PerformerFilter
 ): Promise<string[]> {
   const { data, error } = await supabase
-    .from(castTable)
-    .select(parentIdField)
+    .from("casts")
+    .select("content_id")
+    .eq("content_type", contentType)
     .eq(castFieldFor(performer.type), performer.id);
 
   if (error) {
     throw new Error(`出演者による絞り込みに失敗しました: ${error.message}`);
   }
 
-  const ids = ((data ?? []) as Array<Record<K, string>>).map(
-    (row) => row[parentIdField]
+  const ids = ((data ?? []) as Array<{ content_id: string }>).map(
+    (row) => row.content_id
   );
   return Array.from(new Set(ids));
 }

--- a/src/lib/queries/articles.ts
+++ b/src/lib/queries/articles.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { fetchCastsByContent } from "@/lib/queries/_casts";
 import {
   getIdsForPerformer,
   type ListOptions,
@@ -29,8 +29,7 @@ export async function listArticles(
   if (options.performer) {
     allowedIds = await getIdsForPerformer(
       supabase,
-      "article_casts",
-      "article_id",
+      "article",
       options.performer
     );
     if (allowedIds.length === 0) return [];
@@ -65,8 +64,7 @@ export async function listArticlesWithCasts(
   if (options.performer) {
     allowedIds = await getIdsForPerformer(
       supabase,
-      "article_casts",
-      "article_id",
+      "article",
       options.performer
     );
     if (allowedIds.length === 0) return [];
@@ -74,18 +72,7 @@ export async function listArticlesWithCasts(
 
   let query = supabase
     .from("articles")
-    .select(
-      `*,
-       article_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .order("published_at", { ascending, nullsFirst: false })
     .order("created_at", { ascending });
 
@@ -99,29 +86,26 @@ export async function listArticlesWithCasts(
     throw new Error(`記事一覧の取得に失敗しました: ${error.message}`);
   }
 
-  return (data ?? []).map((row) => {
-    const record = row as Record<string, unknown>;
-    const casts = mapCasts(record.article_casts as CastRow[] | null | undefined);
-    return { ...toArticleBase(record), casts };
-  });
+  const articles = (data ?? []).map((row) =>
+    toArticleBase(row as Record<string, unknown>)
+  );
+  const castsByContent = await fetchCastsByContent(
+    supabase,
+    "article",
+    articles.map((a) => a.id)
+  );
+
+  return articles.map((article) => ({
+    ...article,
+    casts: castsByContent.get(article.id) ?? [],
+  }));
 }
 
 export async function getArticle(id: string): Promise<ArticleWithCasts | null> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("articles")
-    .select(
-      `*,
-       article_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .eq("id", id)
     .maybeSingle();
 
@@ -131,7 +115,9 @@ export async function getArticle(id: string): Promise<ArticleWithCasts | null> {
 
   if (!data) return null;
 
-  const record = data as Record<string, unknown>;
-  const casts = mapCasts(record.article_casts as CastRow[] | null | undefined);
-  return { ...toArticleBase(record), casts };
+  const castsByContent = await fetchCastsByContent(supabase, "article", [id]);
+  return {
+    ...toArticleBase(data as Record<string, unknown>),
+    casts: castsByContent.get(id) ?? [],
+  };
 }

--- a/src/lib/queries/co-appearance-graph.test.ts
+++ b/src/lib/queries/co-appearance-graph.test.ts
@@ -15,8 +15,8 @@ const DONDECORTE_ID = "dd-id";
 type AnyRow = Record<string, unknown>;
 
 function buildQueryStub(responses: {
-  ownParents: Record<string, string[]>;
-  coCasts: Record<string, AnyRow[]>;
+  ownContents: Array<{ content_type: string; content_id: string }>;
+  coCasts: AnyRow[];
   dondecorteId?: string | null;
 }) {
   supabaseMock.from.mockImplementation((table: string) => {
@@ -38,33 +38,30 @@ function buildQueryStub(responses: {
       };
     }
 
-    return {
-      select: (cols: string) => {
-        if (cols.includes("artist:artists")) {
+    if (table === "casts") {
+      return {
+        select: (cols: string) => {
+          // 出演者埋め込みの有無で 2 種類のクエリを判別する
+          if (cols.includes("artist:artists")) {
+            return {
+              in: async () => ({ data: responses.coCasts, error: null }),
+            };
+          }
           return {
-            in: async () => ({
-              data: responses.coCasts[table] ?? [],
-              error: null,
-            }),
+            eq: async () => ({ data: responses.ownContents, error: null }),
           };
-        }
-        return {
-          eq: async () => ({
-            data: (responses.ownParents[table] ?? []).map((id) => {
-              const field = cols.trim();
-              return { [field]: id };
-            }),
-            error: null,
-          }),
-        };
-      },
-    };
+        },
+      };
+    }
+
+    throw new Error(`unexpected table: ${table}`);
   });
 }
 
-function ddRow(parentField: string, parentId: string): AnyRow {
+function ddRow(contentType: string, contentId: string): AnyRow {
   return {
-    [parentField]: parentId,
+    content_type: contentType,
+    content_id: contentId,
     artist_id: null,
     comedy_group_id: DONDECORTE_ID,
     unit_id: null,
@@ -75,13 +72,14 @@ function ddRow(parentField: string, parentId: string): AnyRow {
 }
 
 function comboRow(
-  parentField: string,
-  parentId: string,
+  contentType: string,
+  contentId: string,
   id: string,
   name: string
 ): AnyRow {
   return {
-    [parentField]: parentId,
+    content_type: contentType,
+    content_id: contentId,
     artist_id: null,
     comedy_group_id: id,
     unit_id: null,
@@ -92,13 +90,14 @@ function comboRow(
 }
 
 function artistRow(
-  parentField: string,
-  parentId: string,
+  contentType: string,
+  contentId: string,
   id: string,
   name: string
 ): AnyRow {
   return {
-    [parentField]: parentId,
+    content_type: contentType,
+    content_id: contentId,
     artist_id: id,
     comedy_group_id: null,
     unit_id: null,
@@ -109,13 +108,14 @@ function artistRow(
 }
 
 function unitRow(
-  parentField: string,
-  parentId: string,
+  contentType: string,
+  contentId: string,
   id: string,
   name: string
 ): AnyRow {
   return {
-    [parentField]: parentId,
+    content_type: contentType,
+    content_id: contentId,
     artist_id: null,
     comedy_group_id: null,
     unit_id: id,
@@ -131,7 +131,7 @@ beforeEach(() => {
 
 describe("getCoAppearanceGraph", () => {
   it("ドンデコルテが見つからない場合は found=false を返す", async () => {
-    buildQueryStub({ ownParents: {}, coCasts: {}, dondecorteId: null });
+    buildQueryStub({ ownContents: [], coCasts: [], dondecorteId: null });
 
     const result = await getCoAppearanceGraph();
     expect(result.found).toBe(false);
@@ -141,28 +141,21 @@ describe("getCoAppearanceGraph", () => {
 
   it("共演データからノードとエッジを生成する", async () => {
     buildQueryStub({
-      ownParents: {
-        video_casts: ["v1", "v2"],
-        live_casts: ["l1"],
-        radio_casts: [],
-        article_casts: [],
-        tv_show_casts: [],
-        topic_casts: [],
-      },
-      coCasts: {
-        video_casts: [
-          ddRow("video_id", "v1"),
-          comboRow("video_id", "v1", "combo-a", "コンビA"),
-          ddRow("video_id", "v2"),
-          comboRow("video_id", "v2", "combo-a", "コンビA"),
-          artistRow("video_id", "v2", "artist-x", "芸人X"),
-        ],
-        live_casts: [
-          ddRow("live_id", "l1"),
-          comboRow("live_id", "l1", "combo-b", "コンビB"),
-          unitRow("live_id", "l1", "unit-1", "ユニット1"),
-        ],
-      },
+      ownContents: [
+        { content_type: "video", content_id: "v1" },
+        { content_type: "video", content_id: "v2" },
+        { content_type: "live", content_id: "l1" },
+      ],
+      coCasts: [
+        ddRow("video", "v1"),
+        comboRow("video", "v1", "combo-a", "コンビA"),
+        ddRow("video", "v2"),
+        comboRow("video", "v2", "combo-a", "コンビA"),
+        artistRow("video", "v2", "artist-x", "芸人X"),
+        ddRow("live", "l1"),
+        comboRow("live", "l1", "combo-b", "コンビB"),
+        unitRow("live", "l1", "unit-1", "ユニット1"),
+      ],
     });
 
     const result = await getCoAppearanceGraph();
@@ -197,17 +190,8 @@ describe("getCoAppearanceGraph", () => {
 
   it("共演者がいない場合は中心ノードのみを返す", async () => {
     buildQueryStub({
-      ownParents: {
-        video_casts: ["v1"],
-        live_casts: [],
-        radio_casts: [],
-        article_casts: [],
-        tv_show_casts: [],
-        topic_casts: [],
-      },
-      coCasts: {
-        video_casts: [ddRow("video_id", "v1")],
-      },
+      ownContents: [{ content_type: "video", content_id: "v1" }],
+      coCasts: [ddRow("video", "v1")],
     });
 
     const result = await getCoAppearanceGraph();

--- a/src/lib/queries/co-appearance-graph.ts
+++ b/src/lib/queries/co-appearance-graph.ts
@@ -47,23 +47,14 @@ export async function getCoAppearanceGraph(): Promise<CoAppearanceGraph> {
 
   const ownContents = await listDondecorteContents(supabase, dondecorteId);
   const totalContentCount = ownContents.length;
-  const ownKeys = new Set(
-    ownContents.map((c) => `${c.contentType}:${c.contentId}`)
-  );
 
-  const rows = await listCastsForContents(
-    supabase,
-    ownContents.map((c) => c.contentId)
-  );
+  const rows = await listCastsForContents(supabase, ownContents);
 
   const performers = new Map<string, CastEntry>();
   const contentPerformers = new Map<string, Set<string>>();
 
   for (const row of rows) {
     const contentKey = `${row.content_type}:${row.content_id}`;
-    // content_id だけで取得しているため、ドンデコルテ出演コンテンツに
-    // 属する行のみを対象にする。
-    if (!ownKeys.has(contentKey)) continue;
 
     const performer = entryFromRow(row);
     if (!performer) continue;

--- a/src/lib/queries/co-appearance-graph.ts
+++ b/src/lib/queries/co-appearance-graph.ts
@@ -1,11 +1,10 @@
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import {
-  CAST_TABLES,
   entryFromRow,
   getDondecorteComedyGroupId,
-  listCoCastRows,
-  listOwnParentIds,
+  listCastsForContents,
+  listDondecorteContents,
 } from "./_co-casts";
 
 export type CoAppearanceGraphNode = {
@@ -46,40 +45,39 @@ export async function getCoAppearanceGraph(): Promise<CoAppearanceGraph> {
 
   const dondecorteKey = `comedy_group:${dondecorteId}`;
 
-  const ownParentIdsPerTable = await Promise.all(
-    CAST_TABLES.map((spec) => listOwnParentIds(supabase, spec, dondecorteId))
-  );
-  const totalContentCount = ownParentIdsPerTable.reduce(
-    (sum, ids) => sum + ids.length,
-    0
+  const ownContents = await listDondecorteContents(supabase, dondecorteId);
+  const totalContentCount = ownContents.length;
+  const ownKeys = new Set(
+    ownContents.map((c) => `${c.contentType}:${c.contentId}`)
   );
 
-  const coCastRowsPerTable = await Promise.all(
-    CAST_TABLES.map((spec, index) =>
-      listCoCastRows(supabase, spec, ownParentIdsPerTable[index])
-    )
+  const rows = await listCastsForContents(
+    supabase,
+    ownContents.map((c) => c.contentId)
   );
 
   const performers = new Map<string, CastEntry>();
   const contentPerformers = new Map<string, Set<string>>();
 
-  CAST_TABLES.forEach((spec, index) => {
-    for (const row of coCastRowsPerTable[index]) {
-      const performer = entryFromRow(row);
-      if (!performer) continue;
+  for (const row of rows) {
+    const contentKey = `${row.content_type}:${row.content_id}`;
+    // content_id だけで取得しているため、ドンデコルテ出演コンテンツに
+    // 属する行のみを対象にする。
+    if (!ownKeys.has(contentKey)) continue;
 
-      const key = performerKey(performer);
-      performers.set(key, performer);
+    const performer = entryFromRow(row);
+    if (!performer) continue;
 
-      const contentKey = `${spec.contentType}:${row[spec.parentIdField]}`;
-      let members = contentPerformers.get(contentKey);
-      if (!members) {
-        members = new Set<string>();
-        contentPerformers.set(contentKey, members);
-      }
-      members.add(key);
+    const key = performerKey(performer);
+    performers.set(key, performer);
+
+    let members = contentPerformers.get(contentKey);
+    if (!members) {
+      members = new Set<string>();
+      contentPerformers.set(contentKey, members);
     }
-  });
+    members.add(key);
+  }
 
   const nodeCounts = new Map<string, number>();
   const edgeWeights = new Map<string, number>();

--- a/src/lib/queries/co-appearances.test.ts
+++ b/src/lib/queries/co-appearances.test.ts
@@ -15,8 +15,8 @@ const DONDECORTE_ID = "dd-id";
 type AnyRow = Record<string, unknown>;
 
 function buildQueryStub(responses: {
-  ownParents: Record<string, string[]>;
-  coCasts: Record<string, AnyRow[]>;
+  ownContents: Array<{ content_type: string; content_id: string }>;
+  coCasts: AnyRow[];
   dondecorteId?: string | null;
 }) {
   supabaseMock.from.mockImplementation((table: string) => {
@@ -38,28 +38,78 @@ function buildQueryStub(responses: {
       };
     }
 
-    return {
-      select: (cols: string) => {
-        if (cols.includes("artist:artists")) {
+    if (table === "casts") {
+      return {
+        select: (cols: string) => {
+          // 出演者埋め込みの有無で 2 種類のクエリを判別する
+          if (cols.includes("artist:artists")) {
+            return {
+              in: async () => ({ data: responses.coCasts, error: null }),
+            };
+          }
           return {
-            in: async () => ({
-              data: responses.coCasts[table] ?? [],
-              error: null,
-            }),
+            eq: async () => ({ data: responses.ownContents, error: null }),
           };
-        }
-        return {
-          eq: async () => ({
-            data: (responses.ownParents[table] ?? []).map((id) => {
-              const field = cols.trim();
-              return { [field]: id };
-            }),
-            error: null,
-          }),
-        };
-      },
-    };
+        },
+      };
+    }
+
+    throw new Error(`unexpected table: ${table}`);
   });
+}
+
+function comboRow(
+  contentType: string,
+  contentId: string,
+  id: string,
+  name: string
+): AnyRow {
+  return {
+    content_type: contentType,
+    content_id: contentId,
+    artist_id: null,
+    comedy_group_id: id,
+    unit_id: null,
+    artist: null,
+    comedy_group: { id, name },
+    unit: null,
+  };
+}
+
+function artistRow(
+  contentType: string,
+  contentId: string,
+  id: string,
+  name: string
+): AnyRow {
+  return {
+    content_type: contentType,
+    content_id: contentId,
+    artist_id: id,
+    comedy_group_id: null,
+    unit_id: null,
+    artist: { id, name },
+    comedy_group: null,
+    unit: null,
+  };
+}
+
+function unitRow(
+  contentType: string,
+  contentId: string,
+  id: string,
+  name: string
+): AnyRow {
+  return {
+    content_type: contentType,
+    content_id: contentId,
+    artist_id: null,
+    comedy_group_id: null,
+    unit_id: id,
+    artist: null,
+    comedy_group: null,
+    unit: { id, name },
+  };
 }
 
 beforeEach(() => {
@@ -69,8 +119,8 @@ beforeEach(() => {
 describe("getCoAppearanceRanking", () => {
   it("ドンデコルテが見つからない場合は found=false を返す", async () => {
     buildQueryStub({
-      ownParents: {},
-      coCasts: {},
+      ownContents: [],
+      coCasts: [],
       dondecorteId: null,
     });
 
@@ -83,74 +133,19 @@ describe("getCoAppearanceRanking", () => {
 
   it("コンビ・芸人・ユニットそれぞれを共演回数でランキングする", async () => {
     buildQueryStub({
-      ownParents: {
-        video_casts: ["v1", "v2"],
-        live_casts: ["l1"],
-        radio_casts: [],
-        article_casts: [],
-        tv_show_casts: [],
-        topic_casts: [],
-      },
-      coCasts: {
-        video_casts: [
-          {
-            video_id: "v1",
-            artist_id: null,
-            comedy_group_id: DONDECORTE_ID,
-            unit_id: null,
-            artist: null,
-            comedy_group: { id: DONDECORTE_ID, name: "ドンデコルテ" },
-            unit: null,
-          },
-          {
-            video_id: "v1",
-            artist_id: null,
-            comedy_group_id: "combo-a",
-            unit_id: null,
-            artist: null,
-            comedy_group: { id: "combo-a", name: "コンビA" },
-            unit: null,
-          },
-          {
-            video_id: "v2",
-            artist_id: null,
-            comedy_group_id: "combo-a",
-            unit_id: null,
-            artist: null,
-            comedy_group: { id: "combo-a", name: "コンビA" },
-            unit: null,
-          },
-          {
-            video_id: "v2",
-            artist_id: "artist-x",
-            comedy_group_id: null,
-            unit_id: null,
-            artist: { id: "artist-x", name: "芸人X" },
-            comedy_group: null,
-            unit: null,
-          },
-        ],
-        live_casts: [
-          {
-            live_id: "l1",
-            artist_id: null,
-            comedy_group_id: "combo-b",
-            unit_id: null,
-            artist: null,
-            comedy_group: { id: "combo-b", name: "コンビB" },
-            unit: null,
-          },
-          {
-            live_id: "l1",
-            artist_id: null,
-            comedy_group_id: null,
-            unit_id: "unit-1",
-            artist: null,
-            comedy_group: null,
-            unit: { id: "unit-1", name: "ユニット1" },
-          },
-        ],
-      },
+      ownContents: [
+        { content_type: "video", content_id: "v1" },
+        { content_type: "video", content_id: "v2" },
+        { content_type: "live", content_id: "l1" },
+      ],
+      coCasts: [
+        comboRow("video", "v1", DONDECORTE_ID, "ドンデコルテ"),
+        comboRow("video", "v1", "combo-a", "コンビA"),
+        comboRow("video", "v2", "combo-a", "コンビA"),
+        artistRow("video", "v2", "artist-x", "芸人X"),
+        comboRow("live", "l1", "combo-b", "コンビB"),
+        unitRow("live", "l1", "unit-1", "ユニット1"),
+      ],
     });
 
     const result = await getCoAppearanceRanking();
@@ -192,27 +187,8 @@ describe("getCoAppearanceRanking", () => {
 
   it("ドンデコルテ自身は集計対象から除外する", async () => {
     buildQueryStub({
-      ownParents: {
-        video_casts: ["v1"],
-        live_casts: [],
-        radio_casts: [],
-        article_casts: [],
-        tv_show_casts: [],
-        topic_casts: [],
-      },
-      coCasts: {
-        video_casts: [
-          {
-            video_id: "v1",
-            artist_id: null,
-            comedy_group_id: DONDECORTE_ID,
-            unit_id: null,
-            artist: null,
-            comedy_group: { id: DONDECORTE_ID, name: "ドンデコルテ" },
-            unit: null,
-          },
-        ],
-      },
+      ownContents: [{ content_type: "video", content_id: "v1" }],
+      coCasts: [comboRow("video", "v1", DONDECORTE_ID, "ドンデコルテ")],
     });
 
     const result = await getCoAppearanceRanking();

--- a/src/lib/queries/co-appearances.test.ts
+++ b/src/lib/queries/co-appearances.test.ts
@@ -145,6 +145,9 @@ describe("getCoAppearanceRanking", () => {
         artistRow("video", "v2", "artist-x", "芸人X"),
         comboRow("live", "l1", "combo-b", "コンビB"),
         unitRow("live", "l1", "unit-1", "ユニット1"),
+        // content_id "v1" は video のドンデコルテ出演コンテンツだが、
+        // content_type が "live" のため別コンテンツ。集計対象外になること。
+        comboRow("live", "v1", "combo-c", "コンビC"),
       ],
     });
 
@@ -152,6 +155,11 @@ describe("getCoAppearanceRanking", () => {
 
     expect(result.found).toBe(true);
     expect(result.totalContentCount).toBe(3);
+
+    // (live, v1) は (video, v1) と content_id が衝突するが別コンテンツ
+    expect(
+      result.combos.find((c) => c.performer.id === "combo-c")
+    ).toBeUndefined();
 
     expect(result.combos).toHaveLength(2);
     expect(result.combos[0]).toMatchObject({

--- a/src/lib/queries/co-appearances.ts
+++ b/src/lib/queries/co-appearances.ts
@@ -102,21 +102,12 @@ export async function getCoAppearanceRanking(): Promise<CoAppearanceRanking> {
 
   const ownContents = await listDondecorteContents(supabase, dondecorteId);
   const totalContentCount = ownContents.length;
-  const ownKeys = new Set(
-    ownContents.map((c) => `${c.contentType}:${c.contentId}`)
-  );
 
-  const rows = await listCastsForContents(
-    supabase,
-    ownContents.map((c) => c.contentId)
-  );
+  const rows = await listCastsForContents(supabase, ownContents);
 
   const acc: Accumulator = new Map();
 
   for (const row of rows) {
-    // content_id だけで取得しているため、ドンデコルテ出演コンテンツに
-    // 属する行のみを集計対象にする。
-    if (!ownKeys.has(`${row.content_type}:${row.content_id}`)) continue;
     if (row.comedy_group_id === dondecorteId) continue;
     const performer = entryFromRow(row);
     if (!performer) continue;

--- a/src/lib/queries/co-appearances.ts
+++ b/src/lib/queries/co-appearances.ts
@@ -1,11 +1,9 @@
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry, ContentType } from "@/lib/types";
 import {
-  CAST_TABLES,
-  type CoCastRow,
   getDondecorteComedyGroupId,
-  listCoCastRows,
-  listOwnParentIds,
+  listCastsForContents,
+  listDondecorteContents,
   entryFromRow,
 } from "./_co-casts";
 
@@ -102,33 +100,28 @@ export async function getCoAppearanceRanking(): Promise<CoAppearanceRanking> {
 
   if (!dondecorteId) return EMPTY_RANKING;
 
-  const ownParentIdsPerTable = await Promise.all(
-    CAST_TABLES.map((spec) => listOwnParentIds(supabase, spec, dondecorteId))
+  const ownContents = await listDondecorteContents(supabase, dondecorteId);
+  const totalContentCount = ownContents.length;
+  const ownKeys = new Set(
+    ownContents.map((c) => `${c.contentType}:${c.contentId}`)
   );
 
-  const totalContentCount = ownParentIdsPerTable.reduce(
-    (sum, ids) => sum + ids.length,
-    0
-  );
-
-  const coCastRowsPerTable = await Promise.all(
-    CAST_TABLES.map((spec, index) =>
-      listCoCastRows(supabase, spec, ownParentIdsPerTable[index])
-    )
+  const rows = await listCastsForContents(
+    supabase,
+    ownContents.map((c) => c.contentId)
   );
 
   const acc: Accumulator = new Map();
 
-  CAST_TABLES.forEach((spec, index) => {
-    const rows = coCastRowsPerTable[index];
-    for (const row of rows) {
-      if (row.comedy_group_id === dondecorteId) continue;
-      const performer = entryFromRow(row as CoCastRow);
-      if (!performer) continue;
-      const parentId = row[spec.parentIdField];
-      accumulate(acc, performer, spec.contentType, parentId);
-    }
-  });
+  for (const row of rows) {
+    // content_id だけで取得しているため、ドンデコルテ出演コンテンツに
+    // 属する行のみを集計対象にする。
+    if (!ownKeys.has(`${row.content_type}:${row.content_id}`)) continue;
+    if (row.comedy_group_id === dondecorteId) continue;
+    const performer = entryFromRow(row);
+    if (!performer) continue;
+    accumulate(acc, performer, row.content_type, row.content_id);
+  }
 
   const combos: CoAppearanceEntry[] = [];
   const artists: CoAppearanceEntry[] = [];

--- a/src/lib/queries/lives.ts
+++ b/src/lib/queries/lives.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { fetchCastsByContent } from "@/lib/queries/_casts";
 import {
   getIdsForPerformer,
   type ListOptions,
@@ -27,12 +27,7 @@ export async function listLives(options: ListOptions = {}): Promise<Live[]> {
 
   let allowedIds: string[] | null = null;
   if (options.performer) {
-    allowedIds = await getIdsForPerformer(
-      supabase,
-      "live_casts",
-      "live_id",
-      options.performer
-    );
+    allowedIds = await getIdsForPerformer(supabase, "live", options.performer);
     if (allowedIds.length === 0) return [];
   }
 
@@ -63,29 +58,13 @@ export async function listLivesWithCasts(
 
   let allowedIds: string[] | null = null;
   if (options.performer) {
-    allowedIds = await getIdsForPerformer(
-      supabase,
-      "live_casts",
-      "live_id",
-      options.performer
-    );
+    allowedIds = await getIdsForPerformer(supabase, "live", options.performer);
     if (allowedIds.length === 0) return [];
   }
 
   let query = supabase
     .from("lives")
-    .select(
-      `*,
-       live_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .order("event_date", { ascending, nullsFirst: false })
     .order("start_time", { ascending, nullsFirst: false })
     .order("created_at", { ascending });
@@ -100,29 +79,24 @@ export async function listLivesWithCasts(
     throw new Error(`ライブ一覧の取得に失敗しました: ${error.message}`);
   }
 
-  return (data ?? []).map((row) => {
-    const record = row as Record<string, unknown>;
-    const casts = mapCasts(record.live_casts as CastRow[] | null | undefined);
-    return { ...toLiveBase(record), casts };
-  });
+  const lives = (data ?? []).map((row) => toLiveBase(row as Record<string, unknown>));
+  const castsByContent = await fetchCastsByContent(
+    supabase,
+    "live",
+    lives.map((l) => l.id)
+  );
+
+  return lives.map((live) => ({
+    ...live,
+    casts: castsByContent.get(live.id) ?? [],
+  }));
 }
 
 export async function getLive(id: string): Promise<LiveWithCasts | null> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("lives")
-    .select(
-      `*,
-       live_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .eq("id", id)
     .maybeSingle();
 
@@ -132,7 +106,9 @@ export async function getLive(id: string): Promise<LiveWithCasts | null> {
 
   if (!data) return null;
 
-  const record = data as Record<string, unknown>;
-  const casts = mapCasts(record.live_casts as CastRow[] | null | undefined);
-  return { ...toLiveBase(record), casts };
+  const castsByContent = await fetchCastsByContent(supabase, "live", [id]);
+  return {
+    ...toLiveBase(data as Record<string, unknown>),
+    casts: castsByContent.get(id) ?? [],
+  };
 }

--- a/src/lib/queries/performer-contents.ts
+++ b/src/lib/queries/performer-contents.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
-import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { fetchCastsByContent } from "@/lib/queries/_casts";
+import type { ContentType } from "@/lib/types";
 import type { ArticleWithCasts } from "@/lib/types/article";
 import type { LiveWithCasts } from "@/lib/types/live";
 import type { RadioWithCasts } from "@/lib/types/radio";
@@ -19,47 +20,29 @@ export type PerformerContents = {
   tvShows: TvShowWithCasts[];
 };
 
-const CAST_SUBSELECT = `
-  id,
-  artist_id,
-  comedy_group_id,
-  unit_id,
-  artist:artists(id, name),
-  comedy_group:comedy_groups(id, name),
-  unit:units(id, name)
-`;
-
 type Row = Record<string, unknown>;
 type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
 
-function castsOf(record: Row, key: string) {
-  return mapCasts(record[key] as CastRow[] | null | undefined);
-}
-
-async function listMatchingIds<K extends string>(
+async function listMatchingContentIds(
   supabase: SupabaseClient,
-  castTable:
-    | "video_casts"
-    | "live_casts"
-    | "radio_casts"
-    | "article_casts"
-    | "tv_show_casts",
-  parentIdField: K,
+  contentType: ContentType,
   field: PerformerField,
   id: string
 ): Promise<string[]> {
   const { data, error } = await supabase
-    .from(castTable)
-    .select(parentIdField)
+    .from("casts")
+    .select("content_id")
+    .eq("content_type", contentType)
     .eq(field, id);
 
   if (error) {
     throw new Error(`出演コンテンツの取得に失敗しました: ${error.message}`);
   }
 
-  return ((data ?? []) as Array<Record<K, string>>).map(
-    (row) => row[parentIdField]
+  const ids = ((data ?? []) as Array<{ content_id: string }>).map(
+    (row) => row.content_id
   );
+  return Array.from(new Set(ids));
 }
 
 export async function getPerformerContents(
@@ -70,11 +53,11 @@ export async function getPerformerContents(
 
   const [videoIds, liveIds, radioIds, articleIds, tvShowIds] =
     await Promise.all([
-      listMatchingIds(supabase, "video_casts", "video_id", field, id),
-      listMatchingIds(supabase, "live_casts", "live_id", field, id),
-      listMatchingIds(supabase, "radio_casts", "radio_id", field, id),
-      listMatchingIds(supabase, "article_casts", "article_id", field, id),
-      listMatchingIds(supabase, "tv_show_casts", "tv_show_id", field, id),
+      listMatchingContentIds(supabase, "video", field, id),
+      listMatchingContentIds(supabase, "live", field, id),
+      listMatchingContentIds(supabase, "radio", field, id),
+      listMatchingContentIds(supabase, "article", field, id),
+      listMatchingContentIds(supabase, "tv_show", field, id),
     ]);
 
   const [videosRes, livesRes, radiosRes, articlesRes, tvShowsRes] =
@@ -82,7 +65,7 @@ export async function getPerformerContents(
       videoIds.length > 0
         ? supabase
             .from("videos")
-            .select(`*, video_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", videoIds)
             .order("published_at", { ascending: false, nullsFirst: false })
             .order("created_at", { ascending: false })
@@ -90,7 +73,7 @@ export async function getPerformerContents(
       liveIds.length > 0
         ? supabase
             .from("lives")
-            .select(`*, live_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", liveIds)
             .order("event_date", { ascending: false, nullsFirst: false })
             .order("start_time", { ascending: false, nullsFirst: false })
@@ -99,7 +82,7 @@ export async function getPerformerContents(
       radioIds.length > 0
         ? supabase
             .from("radios")
-            .select(`*, radio_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", radioIds)
             .order("published_at", { ascending: false, nullsFirst: false })
             .order("created_at", { ascending: false })
@@ -107,7 +90,7 @@ export async function getPerformerContents(
       articleIds.length > 0
         ? supabase
             .from("articles")
-            .select(`*, article_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", articleIds)
             .order("published_at", { ascending: false, nullsFirst: false })
             .order("created_at", { ascending: false })
@@ -115,7 +98,7 @@ export async function getPerformerContents(
       tvShowIds.length > 0
         ? supabase
             .from("tv_shows")
-            .select(`*, tv_show_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", tvShowIds)
             .order("air_date", { ascending: false, nullsFirst: false })
             .order("air_time", { ascending: false, nullsFirst: false })
@@ -130,7 +113,24 @@ export async function getPerformerContents(
     throw new Error(`出演コンテンツの取得に失敗しました: ${errors[0].message}`);
   }
 
-  const videos: VideoWithCasts[] = ((videosRes.data ?? []) as Row[]).map((r) => ({
+  const videoRows = (videosRes.data ?? []) as Row[];
+  const liveRows = (livesRes.data ?? []) as Row[];
+  const radioRows = (radiosRes.data ?? []) as Row[];
+  const articleRows = (articlesRes.data ?? []) as Row[];
+  const tvShowRows = (tvShowsRes.data ?? []) as Row[];
+
+  const idsOf = (rows: Row[]) => rows.map((r) => r.id as string);
+
+  const [videoCasts, liveCasts, radioCasts, articleCasts, tvShowCasts] =
+    await Promise.all([
+      fetchCastsByContent(supabase, "video", idsOf(videoRows)),
+      fetchCastsByContent(supabase, "live", idsOf(liveRows)),
+      fetchCastsByContent(supabase, "radio", idsOf(radioRows)),
+      fetchCastsByContent(supabase, "article", idsOf(articleRows)),
+      fetchCastsByContent(supabase, "tv_show", idsOf(tvShowRows)),
+    ]);
+
+  const videos: VideoWithCasts[] = videoRows.map((r) => ({
     id: r.id as string,
     title: r.title as string,
     youtube_url: (r.youtube_url as string | null) ?? null,
@@ -141,10 +141,10 @@ export async function getPerformerContents(
     description: (r.description as string | null) ?? null,
     created_at: r.created_at as string,
     updated_at: r.updated_at as string,
-    casts: castsOf(r, "video_casts"),
+    casts: videoCasts.get(r.id as string) ?? [],
   }));
 
-  const lives: LiveWithCasts[] = ((livesRes.data ?? []) as Row[]).map((r) => ({
+  const lives: LiveWithCasts[] = liveRows.map((r) => ({
     id: r.id as string,
     title: r.title as string,
     event_date: (r.event_date as string | null) ?? null,
@@ -155,10 +155,10 @@ export async function getPerformerContents(
     is_notified: r.is_notified as boolean,
     created_at: r.created_at as string,
     updated_at: r.updated_at as string,
-    casts: castsOf(r, "live_casts"),
+    casts: liveCasts.get(r.id as string) ?? [],
   }));
 
-  const radios: RadioWithCasts[] = ((radiosRes.data ?? []) as Row[]).map((r) => ({
+  const radios: RadioWithCasts[] = radioRows.map((r) => ({
     id: r.id as string,
     title: r.title as string,
     platform: (r.platform as string | null) ?? null,
@@ -167,37 +167,33 @@ export async function getPerformerContents(
     description: (r.description as string | null) ?? null,
     created_at: r.created_at as string,
     updated_at: r.updated_at as string,
-    casts: castsOf(r, "radio_casts"),
+    casts: radioCasts.get(r.id as string) ?? [],
   }));
 
-  const articles: ArticleWithCasts[] = ((articlesRes.data ?? []) as Row[]).map(
-    (r) => ({
-      id: r.id as string,
-      title: r.title as string,
-      url: (r.url as string | null) ?? null,
-      source: (r.source as string | null) ?? null,
-      published_at: (r.published_at as string | null) ?? null,
-      content: (r.content as string | null) ?? null,
-      created_at: r.created_at as string,
-      updated_at: r.updated_at as string,
-      casts: castsOf(r, "article_casts"),
-    })
-  );
+  const articles: ArticleWithCasts[] = articleRows.map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    url: (r.url as string | null) ?? null,
+    source: (r.source as string | null) ?? null,
+    published_at: (r.published_at as string | null) ?? null,
+    content: (r.content as string | null) ?? null,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: articleCasts.get(r.id as string) ?? [],
+  }));
 
-  const tvShows: TvShowWithCasts[] = ((tvShowsRes.data ?? []) as Row[]).map(
-    (r) => ({
-      id: r.id as string,
-      title: r.title as string,
-      network: (r.network as string | null) ?? null,
-      air_date: (r.air_date as string | null) ?? null,
-      air_time: (r.air_time as string | null) ?? null,
-      description: (r.description as string | null) ?? null,
-      url: (r.url as string | null) ?? null,
-      created_at: r.created_at as string,
-      updated_at: r.updated_at as string,
-      casts: castsOf(r, "tv_show_casts"),
-    })
-  );
+  const tvShows: TvShowWithCasts[] = tvShowRows.map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    network: (r.network as string | null) ?? null,
+    air_date: (r.air_date as string | null) ?? null,
+    air_time: (r.air_time as string | null) ?? null,
+    description: (r.description as string | null) ?? null,
+    url: (r.url as string | null) ?? null,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: tvShowCasts.get(r.id as string) ?? [],
+  }));
 
   return { videos, lives, radios, articles, tvShows };
 }

--- a/src/lib/queries/radios.ts
+++ b/src/lib/queries/radios.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { fetchCastsByContent } from "@/lib/queries/_casts";
 import {
   getIdsForPerformer,
   type ListOptions,
@@ -25,12 +25,7 @@ export async function listRadios(options: ListOptions = {}): Promise<Radio[]> {
 
   let allowedIds: string[] | null = null;
   if (options.performer) {
-    allowedIds = await getIdsForPerformer(
-      supabase,
-      "radio_casts",
-      "radio_id",
-      options.performer
-    );
+    allowedIds = await getIdsForPerformer(supabase, "radio", options.performer);
     if (allowedIds.length === 0) return [];
   }
 
@@ -61,29 +56,13 @@ export async function listRadiosWithCasts(
 
   let allowedIds: string[] | null = null;
   if (options.performer) {
-    allowedIds = await getIdsForPerformer(
-      supabase,
-      "radio_casts",
-      "radio_id",
-      options.performer
-    );
+    allowedIds = await getIdsForPerformer(supabase, "radio", options.performer);
     if (allowedIds.length === 0) return [];
   }
 
   let query = supabase
     .from("radios")
-    .select(
-      `*,
-       radio_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .order("published_at", { ascending, nullsFirst: false })
     .order("created_at", { ascending });
 
@@ -97,29 +76,26 @@ export async function listRadiosWithCasts(
     throw new Error(`ラジオ一覧の取得に失敗しました: ${error.message}`);
   }
 
-  return (data ?? []).map((row) => {
-    const record = row as Record<string, unknown>;
-    const casts = mapCasts(record.radio_casts as CastRow[] | null | undefined);
-    return { ...toRadioBase(record), casts };
-  });
+  const radios = (data ?? []).map((row) =>
+    toRadioBase(row as Record<string, unknown>)
+  );
+  const castsByContent = await fetchCastsByContent(
+    supabase,
+    "radio",
+    radios.map((r) => r.id)
+  );
+
+  return radios.map((radio) => ({
+    ...radio,
+    casts: castsByContent.get(radio.id) ?? [],
+  }));
 }
 
 export async function getRadio(id: string): Promise<RadioWithCasts | null> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("radios")
-    .select(
-      `*,
-       radio_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .eq("id", id)
     .maybeSingle();
 
@@ -129,7 +105,9 @@ export async function getRadio(id: string): Promise<RadioWithCasts | null> {
 
   if (!data) return null;
 
-  const record = data as Record<string, unknown>;
-  const casts = mapCasts(record.radio_casts as CastRow[] | null | undefined);
-  return { ...toRadioBase(record), casts };
+  const castsByContent = await fetchCastsByContent(supabase, "radio", [id]);
+  return {
+    ...toRadioBase(data as Record<string, unknown>),
+    casts: castsByContent.get(id) ?? [],
+  };
 }

--- a/src/lib/queries/rankings.ts
+++ b/src/lib/queries/rankings.ts
@@ -2,19 +2,10 @@ import { mapCasts, type CastRow } from "@/lib/queries/_casts";
 import { createClient } from "@/lib/supabase/server";
 import { CONTENT_TYPES, type CastEntry, type ContentType } from "@/lib/types";
 
-const CAST_TABLE_BY_CONTENT = {
-  video: "video_casts",
-  live: "live_casts",
-  radio: "radio_casts",
-  article: "article_casts",
-  tv_show: "tv_show_casts",
-  topic: "topic_casts",
-} as const satisfies Record<ContentType, string>;
-
-type CastTable = (typeof CAST_TABLE_BY_CONTENT)[ContentType];
 type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
 
-const CAST_SUBSELECT = `
+const CAST_SELECT = `
+  content_type,
   artist_id,
   comedy_group_id,
   unit_id,
@@ -26,6 +17,8 @@ const CAST_SUBSELECT = `
 // PostgREST は 1 リクエストあたりの返却行数に上限があるため、
 // 全行を range で分割取得して集計漏れを防ぐ。
 const PAGE_SIZE = 1000;
+
+type CastWithTypeRow = CastRow & { content_type: ContentType };
 
 export type AppearanceRankingEntry = {
   performer: CastEntry;
@@ -63,15 +56,14 @@ export function aggregateAppearanceRanking(
 }
 
 async function selectAllCastRows(
-  supabase: SupabaseClient,
-  table: CastTable
-): Promise<CastRow[]> {
-  const rows: CastRow[] = [];
+  supabase: SupabaseClient
+): Promise<CastWithTypeRow[]> {
+  const rows: CastWithTypeRow[] = [];
 
   for (let from = 0; ; from += PAGE_SIZE) {
     const { data, error } = await supabase
-      .from(table)
-      .select(CAST_SUBSELECT)
+      .from("casts")
+      .select(CAST_SELECT)
       .order("id", { ascending: true })
       .range(from, from + PAGE_SIZE - 1);
 
@@ -82,8 +74,8 @@ async function selectAllCastRows(
     }
 
     // Supabase は埋め込みリレーションを配列型として推論するため、
-    // CastRow[] への単一キャストでは型エラーになる（実行時の形状は一致する）。
-    const page = (data ?? []) as unknown as CastRow[];
+    // CastWithTypeRow[] への単一キャストでは型エラーになる（実行時の形状は一致する）。
+    const page = (data ?? []) as unknown as CastWithTypeRow[];
     rows.push(...page);
     if (page.length < PAGE_SIZE) break;
   }
@@ -95,22 +87,21 @@ export async function listAppearanceRanking(): Promise<
   AppearanceRankingEntry[]
 > {
   const supabase = await createClient();
+  const rows = await selectAllCastRows(supabase);
 
-  const castRowsByContentType = await Promise.all(
-    CONTENT_TYPES.map((contentType) =>
-      selectAllCastRows(supabase, CAST_TABLE_BY_CONTENT[contentType])
-    )
-  );
+  const castsByContentType: Record<ContentType, CastEntry[]> = {
+    video: [],
+    live: [],
+    radio: [],
+    article: [],
+    tv_show: [],
+    topic: [],
+  };
 
-  const castsByContentType = CONTENT_TYPES.reduce<
-    Record<ContentType, CastEntry[]>
-  >(
-    (acc, contentType, index) => {
-      acc[contentType] = mapCasts(castRowsByContentType[index]);
-      return acc;
-    },
-    { video: [], live: [], radio: [], article: [], tv_show: [], topic: [] }
-  );
+  for (const row of rows) {
+    const [entry] = mapCasts([row]);
+    if (entry) castsByContentType[row.content_type].push(entry);
+  }
 
   return aggregateAppearanceRanking(castsByContentType);
 }

--- a/src/lib/queries/related-contents.ts
+++ b/src/lib/queries/related-contents.ts
@@ -1,4 +1,4 @@
-import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { fetchCastsByContent } from "@/lib/queries/_casts";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry, ContentType } from "@/lib/types";
 import type { ArticleWithCasts } from "@/lib/types/article";
@@ -26,26 +26,8 @@ const EMPTY: RelatedContents = {
   topics: [],
 };
 
-const CAST_SUBSELECT = `
-  id,
-  artist_id,
-  comedy_group_id,
-  unit_id,
-  artist:artists(id, name),
-  comedy_group:comedy_groups(id, name),
-  unit:units(id, name)
-`;
-
 type Row = Record<string, unknown>;
 type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
-
-type CastTable =
-  | "video_casts"
-  | "live_casts"
-  | "radio_casts"
-  | "article_casts"
-  | "tv_show_casts"
-  | "topic_casts";
 
 function partitionCasts(casts: CastEntry[]): {
   artistIds: string[];
@@ -63,10 +45,9 @@ function partitionCasts(casts: CastEntry[]): {
   return { artistIds, comedyGroupIds, unitIds };
 }
 
-async function listMatchingParentIds<K extends string>(
+async function listMatchingContentIds(
   supabase: SupabaseClient,
-  castTable: CastTable,
-  parentIdField: K,
+  contentType: ContentType,
   partitioned: ReturnType<typeof partitionCasts>
 ): Promise<string[]> {
   const { artistIds, comedyGroupIds, unitIds } = partitioned;
@@ -83,25 +64,22 @@ async function listMatchingParentIds<K extends string>(
   if (filters.length === 0) return [];
 
   const { data, error } = await supabase
-    .from(castTable)
-    .select(parentIdField)
+    .from("casts")
+    .select("content_id")
+    .eq("content_type", contentType)
     .or(filters.join(","));
 
   if (error) {
     console.warn(
-      `関連コンテンツ(${castTable})の取得に失敗しました: ${error.message}`
+      `関連コンテンツ(${contentType})の取得に失敗しました: ${error.message}`
     );
     return [];
   }
 
-  const ids = ((data ?? []) as Array<Record<K, string>>).map(
-    (row) => row[parentIdField]
+  const ids = ((data ?? []) as Array<{ content_id: string }>).map(
+    (row) => row.content_id
   );
   return Array.from(new Set(ids));
-}
-
-function castsOf(record: Row, key: string) {
-  return mapCasts(record[key] as CastRow[] | null | undefined);
 }
 
 export async function getRelatedContents(
@@ -116,22 +94,12 @@ export async function getRelatedContents(
 
   const [videoIds, liveIds, radioIds, articleIds, tvShowIds, topicIds] =
     await Promise.all([
-      listMatchingParentIds(supabase, "video_casts", "video_id", partitioned),
-      listMatchingParentIds(supabase, "live_casts", "live_id", partitioned),
-      listMatchingParentIds(supabase, "radio_casts", "radio_id", partitioned),
-      listMatchingParentIds(
-        supabase,
-        "article_casts",
-        "article_id",
-        partitioned
-      ),
-      listMatchingParentIds(
-        supabase,
-        "tv_show_casts",
-        "tv_show_id",
-        partitioned
-      ),
-      listMatchingParentIds(supabase, "topic_casts", "topic_id", partitioned),
+      listMatchingContentIds(supabase, "video", partitioned),
+      listMatchingContentIds(supabase, "live", partitioned),
+      listMatchingContentIds(supabase, "radio", partitioned),
+      listMatchingContentIds(supabase, "article", partitioned),
+      listMatchingContentIds(supabase, "tv_show", partitioned),
+      listMatchingContentIds(supabase, "topic", partitioned),
     ]);
 
   const filterIds = (ids: string[], excludeType: ContentType) =>
@@ -149,7 +117,7 @@ export async function getRelatedContents(
       videoTargets.length > 0
         ? supabase
             .from("videos")
-            .select(`*, video_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", videoTargets)
             .order("published_at", { ascending: false, nullsFirst: false })
             .order("created_at", { ascending: false })
@@ -158,7 +126,7 @@ export async function getRelatedContents(
       liveTargets.length > 0
         ? supabase
             .from("lives")
-            .select(`*, live_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", liveTargets)
             .order("event_date", { ascending: false, nullsFirst: false })
             .order("start_time", { ascending: false, nullsFirst: false })
@@ -168,7 +136,7 @@ export async function getRelatedContents(
       radioTargets.length > 0
         ? supabase
             .from("radios")
-            .select(`*, radio_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", radioTargets)
             .order("published_at", { ascending: false, nullsFirst: false })
             .order("created_at", { ascending: false })
@@ -177,7 +145,7 @@ export async function getRelatedContents(
       articleTargets.length > 0
         ? supabase
             .from("articles")
-            .select(`*, article_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", articleTargets)
             .order("published_at", { ascending: false, nullsFirst: false })
             .order("created_at", { ascending: false })
@@ -186,7 +154,7 @@ export async function getRelatedContents(
       tvShowTargets.length > 0
         ? supabase
             .from("tv_shows")
-            .select(`*, tv_show_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", tvShowTargets)
             .order("air_date", { ascending: false, nullsFirst: false })
             .order("air_time", { ascending: false, nullsFirst: false })
@@ -196,7 +164,7 @@ export async function getRelatedContents(
       topicTargets.length > 0
         ? supabase
             .from("topics")
-            .select(`*, topic_casts(${CAST_SUBSELECT})`)
+            .select("*")
             .in("id", topicTargets)
             .order("topic_date", { ascending: false, nullsFirst: false })
             .order("created_at", { ascending: false })
@@ -222,23 +190,46 @@ export async function getRelatedContents(
     );
   }
 
-  const videos: VideoWithCasts[] = ((videosRes.data ?? []) as Row[]).map(
-    (r) => ({
-      id: r.id as string,
-      title: r.title as string,
-      youtube_url: (r.youtube_url as string | null) ?? null,
-      youtube_video_id: (r.youtube_video_id as string | null) ?? null,
-      youtube_channel_id: (r.youtube_channel_id as string | null) ?? null,
-      thumbnail_url: (r.thumbnail_url as string | null) ?? null,
-      published_at: (r.published_at as string | null) ?? null,
-      description: (r.description as string | null) ?? null,
-      created_at: r.created_at as string,
-      updated_at: r.updated_at as string,
-      casts: castsOf(r, "video_casts"),
-    })
-  );
+  const videoRows = (videosRes.data ?? []) as Row[];
+  const liveRows = (livesRes.data ?? []) as Row[];
+  const radioRows = (radiosRes.data ?? []) as Row[];
+  const articleRows = (articlesRes.data ?? []) as Row[];
+  const tvShowRows = (tvShowsRes.data ?? []) as Row[];
+  const topicRows = (topicsRes.data ?? []) as Row[];
 
-  const lives: LiveWithCasts[] = ((livesRes.data ?? []) as Row[]).map((r) => ({
+  const idsOf = (rows: Row[]) => rows.map((r) => r.id as string);
+
+  const [
+    videoCasts,
+    liveCasts,
+    radioCasts,
+    articleCasts,
+    tvShowCasts,
+    topicCasts,
+  ] = await Promise.all([
+    fetchCastsByContent(supabase, "video", idsOf(videoRows)),
+    fetchCastsByContent(supabase, "live", idsOf(liveRows)),
+    fetchCastsByContent(supabase, "radio", idsOf(radioRows)),
+    fetchCastsByContent(supabase, "article", idsOf(articleRows)),
+    fetchCastsByContent(supabase, "tv_show", idsOf(tvShowRows)),
+    fetchCastsByContent(supabase, "topic", idsOf(topicRows)),
+  ]);
+
+  const videos: VideoWithCasts[] = videoRows.map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    youtube_url: (r.youtube_url as string | null) ?? null,
+    youtube_video_id: (r.youtube_video_id as string | null) ?? null,
+    youtube_channel_id: (r.youtube_channel_id as string | null) ?? null,
+    thumbnail_url: (r.thumbnail_url as string | null) ?? null,
+    published_at: (r.published_at as string | null) ?? null,
+    description: (r.description as string | null) ?? null,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: videoCasts.get(r.id as string) ?? [],
+  }));
+
+  const lives: LiveWithCasts[] = liveRows.map((r) => ({
     id: r.id as string,
     title: r.title as string,
     event_date: (r.event_date as string | null) ?? null,
@@ -249,65 +240,57 @@ export async function getRelatedContents(
     is_notified: r.is_notified as boolean,
     created_at: r.created_at as string,
     updated_at: r.updated_at as string,
-    casts: castsOf(r, "live_casts"),
+    casts: liveCasts.get(r.id as string) ?? [],
   }));
 
-  const radios: RadioWithCasts[] = ((radiosRes.data ?? []) as Row[]).map(
-    (r) => ({
-      id: r.id as string,
-      title: r.title as string,
-      platform: (r.platform as string | null) ?? null,
-      url: (r.url as string | null) ?? null,
-      published_at: (r.published_at as string | null) ?? null,
-      description: (r.description as string | null) ?? null,
-      created_at: r.created_at as string,
-      updated_at: r.updated_at as string,
-      casts: castsOf(r, "radio_casts"),
-    })
-  );
+  const radios: RadioWithCasts[] = radioRows.map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    platform: (r.platform as string | null) ?? null,
+    url: (r.url as string | null) ?? null,
+    published_at: (r.published_at as string | null) ?? null,
+    description: (r.description as string | null) ?? null,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: radioCasts.get(r.id as string) ?? [],
+  }));
 
-  const articles: ArticleWithCasts[] = ((articlesRes.data ?? []) as Row[]).map(
-    (r) => ({
-      id: r.id as string,
-      title: r.title as string,
-      url: (r.url as string | null) ?? null,
-      source: (r.source as string | null) ?? null,
-      published_at: (r.published_at as string | null) ?? null,
-      content: (r.content as string | null) ?? null,
-      created_at: r.created_at as string,
-      updated_at: r.updated_at as string,
-      casts: castsOf(r, "article_casts"),
-    })
-  );
+  const articles: ArticleWithCasts[] = articleRows.map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    url: (r.url as string | null) ?? null,
+    source: (r.source as string | null) ?? null,
+    published_at: (r.published_at as string | null) ?? null,
+    content: (r.content as string | null) ?? null,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: articleCasts.get(r.id as string) ?? [],
+  }));
 
-  const tvShows: TvShowWithCasts[] = ((tvShowsRes.data ?? []) as Row[]).map(
-    (r) => ({
-      id: r.id as string,
-      title: r.title as string,
-      network: (r.network as string | null) ?? null,
-      air_date: (r.air_date as string | null) ?? null,
-      air_time: (r.air_time as string | null) ?? null,
-      description: (r.description as string | null) ?? null,
-      url: (r.url as string | null) ?? null,
-      created_at: r.created_at as string,
-      updated_at: r.updated_at as string,
-      casts: castsOf(r, "tv_show_casts"),
-    })
-  );
+  const tvShows: TvShowWithCasts[] = tvShowRows.map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    network: (r.network as string | null) ?? null,
+    air_date: (r.air_date as string | null) ?? null,
+    air_time: (r.air_time as string | null) ?? null,
+    description: (r.description as string | null) ?? null,
+    url: (r.url as string | null) ?? null,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: tvShowCasts.get(r.id as string) ?? [],
+  }));
 
-  const topics: TopicWithCasts[] = ((topicsRes.data ?? []) as Row[]).map(
-    (r) => ({
-      id: r.id as string,
-      title: r.title as string,
-      content: (r.content as string | null) ?? null,
-      url: (r.url as string | null) ?? null,
-      source: (r.source as string | null) ?? null,
-      topic_date: (r.topic_date as string | null) ?? null,
-      created_at: r.created_at as string,
-      updated_at: r.updated_at as string,
-      casts: castsOf(r, "topic_casts"),
-    })
-  );
+  const topics: TopicWithCasts[] = topicRows.map((r) => ({
+    id: r.id as string,
+    title: r.title as string,
+    content: (r.content as string | null) ?? null,
+    url: (r.url as string | null) ?? null,
+    source: (r.source as string | null) ?? null,
+    topic_date: (r.topic_date as string | null) ?? null,
+    created_at: r.created_at as string,
+    updated_at: r.updated_at as string,
+    casts: topicCasts.get(r.id as string) ?? [],
+  }));
 
   return { videos, lives, radios, articles, tvShows, topics };
 }

--- a/src/lib/queries/timeline.ts
+++ b/src/lib/queries/timeline.ts
@@ -1,6 +1,6 @@
-import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { fetchCastsByContent } from "@/lib/queries/_casts";
 import { createClient } from "@/lib/supabase/server";
-import type { CastEntry, ContentType } from "@/lib/types";
+import { type CastEntry, type ContentType } from "@/lib/types";
 
 export type TimelineItem = {
   type: ContentType;
@@ -11,16 +11,6 @@ export type TimelineItem = {
   createdAt: string;
   casts: CastEntry[];
 };
-
-const CAST_SUBSELECT = `
-  id,
-  artist_id,
-  comedy_group_id,
-  unit_id,
-  artist:artists(id, name),
-  comedy_group:comedy_groups(id, name),
-  unit:units(id, name)
-`;
 
 type Row = Record<string, unknown>;
 
@@ -34,32 +24,32 @@ export async function listTimeline(limit?: number): Promise<TimelineItem[]> {
   const [videos, lives, radios, articles, tvShows, topics] = await Promise.all([
     supabase
       .from("videos")
-      .select(`id, title, published_at, created_at, video_casts(${CAST_SUBSELECT})`)
+      .select("id, title, published_at, created_at")
       .order("published_at", { ascending: false, nullsFirst: false })
       .order("created_at", { ascending: false }),
     supabase
       .from("lives")
-      .select(`id, title, event_date, created_at, live_casts(${CAST_SUBSELECT})`)
+      .select("id, title, event_date, created_at")
       .order("event_date", { ascending: false, nullsFirst: false })
       .order("created_at", { ascending: false }),
     supabase
       .from("radios")
-      .select(`id, title, published_at, created_at, radio_casts(${CAST_SUBSELECT})`)
+      .select("id, title, published_at, created_at")
       .order("published_at", { ascending: false, nullsFirst: false })
       .order("created_at", { ascending: false }),
     supabase
       .from("articles")
-      .select(`id, title, published_at, created_at, article_casts(${CAST_SUBSELECT})`)
+      .select("id, title, published_at, created_at")
       .order("published_at", { ascending: false, nullsFirst: false })
       .order("created_at", { ascending: false }),
     supabase
       .from("tv_shows")
-      .select(`id, title, air_date, created_at, tv_show_casts(${CAST_SUBSELECT})`)
+      .select("id, title, air_date, created_at")
       .order("air_date", { ascending: false, nullsFirst: false })
       .order("created_at", { ascending: false }),
     supabase
       .from("topics")
-      .select(`id, title, topic_date, created_at, topic_casts(${CAST_SUBSELECT})`)
+      .select("id, title, topic_date, created_at")
       .order("topic_date", { ascending: false, nullsFirst: false })
       .order("created_at", { ascending: false }),
   ]);
@@ -71,54 +61,79 @@ export async function listTimeline(limit?: number): Promise<TimelineItem[]> {
     throw new Error(`タイムラインの取得に失敗しました: ${errors[0].message}`);
   }
 
+  const videoRows = (videos.data ?? []) as Row[];
+  const liveRows = (lives.data ?? []) as Row[];
+  const radioRows = (radios.data ?? []) as Row[];
+  const articleRows = (articles.data ?? []) as Row[];
+  const tvShowRows = (tvShows.data ?? []) as Row[];
+  const topicRows = (topics.data ?? []) as Row[];
+
+  const idsOf = (rows: Row[]) => rows.map((r) => r.id as string);
+
+  const [
+    videoCasts,
+    liveCasts,
+    radioCasts,
+    articleCasts,
+    tvShowCasts,
+    topicCasts,
+  ] = await Promise.all([
+    fetchCastsByContent(supabase, "video", idsOf(videoRows)),
+    fetchCastsByContent(supabase, "live", idsOf(liveRows)),
+    fetchCastsByContent(supabase, "radio", idsOf(radioRows)),
+    fetchCastsByContent(supabase, "article", idsOf(articleRows)),
+    fetchCastsByContent(supabase, "tv_show", idsOf(tvShowRows)),
+    fetchCastsByContent(supabase, "topic", idsOf(topicRows)),
+  ]);
+
   const items: TimelineItem[] = [
-    ...((videos.data ?? []) as Row[]).map((r) => ({
+    ...videoRows.map((r) => ({
       type: "video" as const,
       id: r.id as string,
       title: r.title as string,
       date: (r.published_at as string | null) ?? null,
       createdAt: r.created_at as string,
-      casts: mapCasts(r.video_casts as CastRow[] | null | undefined),
+      casts: videoCasts.get(r.id as string) ?? [],
     })),
-    ...((lives.data ?? []) as Row[]).map((r) => ({
+    ...liveRows.map((r) => ({
       type: "live" as const,
       id: r.id as string,
       title: r.title as string,
       date: (r.event_date as string | null) ?? null,
       createdAt: r.created_at as string,
-      casts: mapCasts(r.live_casts as CastRow[] | null | undefined),
+      casts: liveCasts.get(r.id as string) ?? [],
     })),
-    ...((radios.data ?? []) as Row[]).map((r) => ({
+    ...radioRows.map((r) => ({
       type: "radio" as const,
       id: r.id as string,
       title: r.title as string,
       date: (r.published_at as string | null) ?? null,
       createdAt: r.created_at as string,
-      casts: mapCasts(r.radio_casts as CastRow[] | null | undefined),
+      casts: radioCasts.get(r.id as string) ?? [],
     })),
-    ...((articles.data ?? []) as Row[]).map((r) => ({
+    ...articleRows.map((r) => ({
       type: "article" as const,
       id: r.id as string,
       title: r.title as string,
       date: (r.published_at as string | null) ?? null,
       createdAt: r.created_at as string,
-      casts: mapCasts(r.article_casts as CastRow[] | null | undefined),
+      casts: articleCasts.get(r.id as string) ?? [],
     })),
-    ...((tvShows.data ?? []) as Row[]).map((r) => ({
+    ...tvShowRows.map((r) => ({
       type: "tv_show" as const,
       id: r.id as string,
       title: r.title as string,
       date: (r.air_date as string | null) ?? null,
       createdAt: r.created_at as string,
-      casts: mapCasts(r.tv_show_casts as CastRow[] | null | undefined),
+      casts: tvShowCasts.get(r.id as string) ?? [],
     })),
-    ...((topics.data ?? []) as Row[]).map((r) => ({
+    ...topicRows.map((r) => ({
       type: "topic" as const,
       id: r.id as string,
       title: r.title as string,
       date: (r.topic_date as string | null) ?? null,
       createdAt: r.created_at as string,
-      casts: mapCasts(r.topic_casts as CastRow[] | null | undefined),
+      casts: topicCasts.get(r.id as string) ?? [],
     })),
   ];
 

--- a/src/lib/queries/topics.ts
+++ b/src/lib/queries/topics.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { fetchCastsByContent } from "@/lib/queries/_casts";
 import {
   getIdsForPerformer,
   type ListOptions,
@@ -27,12 +27,7 @@ export async function listTopics(
 
   let allowedIds: string[] | null = null;
   if (options.performer) {
-    allowedIds = await getIdsForPerformer(
-      supabase,
-      "topic_casts",
-      "topic_id",
-      options.performer
-    );
+    allowedIds = await getIdsForPerformer(supabase, "topic", options.performer);
     if (allowedIds.length === 0) return [];
   }
 
@@ -63,29 +58,13 @@ export async function listTopicsWithCasts(
 
   let allowedIds: string[] | null = null;
   if (options.performer) {
-    allowedIds = await getIdsForPerformer(
-      supabase,
-      "topic_casts",
-      "topic_id",
-      options.performer
-    );
+    allowedIds = await getIdsForPerformer(supabase, "topic", options.performer);
     if (allowedIds.length === 0) return [];
   }
 
   let query = supabase
     .from("topics")
-    .select(
-      `*,
-       topic_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .order("topic_date", { ascending, nullsFirst: false })
     .order("created_at", { ascending });
 
@@ -99,29 +78,26 @@ export async function listTopicsWithCasts(
     throw new Error(`トピック一覧の取得に失敗しました: ${error.message}`);
   }
 
-  return (data ?? []).map((row) => {
-    const record = row as Record<string, unknown>;
-    const casts = mapCasts(record.topic_casts as CastRow[] | null | undefined);
-    return { ...toTopicBase(record), casts };
-  });
+  const topics = (data ?? []).map((row) =>
+    toTopicBase(row as Record<string, unknown>)
+  );
+  const castsByContent = await fetchCastsByContent(
+    supabase,
+    "topic",
+    topics.map((t) => t.id)
+  );
+
+  return topics.map((topic) => ({
+    ...topic,
+    casts: castsByContent.get(topic.id) ?? [],
+  }));
 }
 
 export async function getTopic(id: string): Promise<TopicWithCasts | null> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("topics")
-    .select(
-      `*,
-       topic_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .eq("id", id)
     .maybeSingle();
 
@@ -131,7 +107,9 @@ export async function getTopic(id: string): Promise<TopicWithCasts | null> {
 
   if (!data) return null;
 
-  const record = data as Record<string, unknown>;
-  const casts = mapCasts(record.topic_casts as CastRow[] | null | undefined);
-  return { ...toTopicBase(record), casts };
+  const castsByContent = await fetchCastsByContent(supabase, "topic", [id]);
+  return {
+    ...toTopicBase(data as Record<string, unknown>),
+    casts: castsByContent.get(id) ?? [],
+  };
 }

--- a/src/lib/queries/tv-shows.ts
+++ b/src/lib/queries/tv-shows.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { fetchCastsByContent } from "@/lib/queries/_casts";
 import {
   getIdsForPerformer,
   type ListOptions,
@@ -30,8 +30,7 @@ export async function listTvShows(
   if (options.performer) {
     allowedIds = await getIdsForPerformer(
       supabase,
-      "tv_show_casts",
-      "tv_show_id",
+      "tv_show",
       options.performer
     );
     if (allowedIds.length === 0) return [];
@@ -66,8 +65,7 @@ export async function listTvShowsWithCasts(
   if (options.performer) {
     allowedIds = await getIdsForPerformer(
       supabase,
-      "tv_show_casts",
-      "tv_show_id",
+      "tv_show",
       options.performer
     );
     if (allowedIds.length === 0) return [];
@@ -75,18 +73,7 @@ export async function listTvShowsWithCasts(
 
   let query = supabase
     .from("tv_shows")
-    .select(
-      `*,
-       tv_show_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .order("air_date", { ascending, nullsFirst: false })
     .order("air_time", { ascending, nullsFirst: false })
     .order("created_at", { ascending });
@@ -101,29 +88,26 @@ export async function listTvShowsWithCasts(
     throw new Error(`TV番組一覧の取得に失敗しました: ${error.message}`);
   }
 
-  return (data ?? []).map((row) => {
-    const record = row as Record<string, unknown>;
-    const casts = mapCasts(record.tv_show_casts as CastRow[] | null | undefined);
-    return { ...toTvShowBase(record), casts };
-  });
+  const tvShows = (data ?? []).map((row) =>
+    toTvShowBase(row as Record<string, unknown>)
+  );
+  const castsByContent = await fetchCastsByContent(
+    supabase,
+    "tv_show",
+    tvShows.map((t) => t.id)
+  );
+
+  return tvShows.map((tvShow) => ({
+    ...tvShow,
+    casts: castsByContent.get(tvShow.id) ?? [],
+  }));
 }
 
 export async function getTvShow(id: string): Promise<TvShowWithCasts | null> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("tv_shows")
-    .select(
-      `*,
-       tv_show_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .eq("id", id)
     .maybeSingle();
 
@@ -133,7 +117,9 @@ export async function getTvShow(id: string): Promise<TvShowWithCasts | null> {
 
   if (!data) return null;
 
-  const record = data as Record<string, unknown>;
-  const casts = mapCasts(record.tv_show_casts as CastRow[] | null | undefined);
-  return { ...toTvShowBase(record), casts };
+  const castsByContent = await fetchCastsByContent(supabase, "tv_show", [id]);
+  return {
+    ...toTvShowBase(data as Record<string, unknown>),
+    casts: castsByContent.get(id) ?? [],
+  };
 }

--- a/src/lib/queries/videos.ts
+++ b/src/lib/queries/videos.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { mapCasts, type CastRow } from "@/lib/queries/_casts";
+import { fetchCastsByContent } from "@/lib/queries/_casts";
 import {
   getIdsForPerformer,
   type ListOptions,
@@ -12,12 +12,7 @@ export async function listVideos(options: ListOptions = {}): Promise<Video[]> {
 
   let allowedIds: string[] | null = null;
   if (options.performer) {
-    allowedIds = await getIdsForPerformer(
-      supabase,
-      "video_casts",
-      "video_id",
-      options.performer
-    );
+    allowedIds = await getIdsForPerformer(supabase, "video", options.performer);
     if (allowedIds.length === 0) return [];
   }
 
@@ -44,18 +39,7 @@ export async function getVideo(id: string): Promise<VideoWithCasts | null> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("videos")
-    .select(
-      `*,
-       video_casts(
-         id,
-         artist_id,
-         comedy_group_id,
-         unit_id,
-         artist:artists(id, name),
-         comedy_group:comedy_groups(id, name),
-         unit:units(id, name)
-       )`
-    )
+    .select("*")
     .eq("id", id)
     .maybeSingle();
 
@@ -65,22 +49,7 @@ export async function getVideo(id: string): Promise<VideoWithCasts | null> {
 
   if (!data) return null;
 
-  const casts = mapCasts(
-    (data as Record<string, unknown>).video_casts as CastRow[] | null | undefined
-  );
+  const castsByContent = await fetchCastsByContent(supabase, "video", [id]);
 
-  const videoBase: Video = {
-    id: (data as { id: string }).id,
-    title: (data as { title: string }).title,
-    youtube_url: (data as { youtube_url: string | null }).youtube_url,
-    youtube_video_id: (data as { youtube_video_id: string | null }).youtube_video_id,
-    youtube_channel_id: (data as { youtube_channel_id: string | null }).youtube_channel_id,
-    thumbnail_url: (data as { thumbnail_url: string | null }).thumbnail_url,
-    published_at: (data as { published_at: string | null }).published_at,
-    description: (data as { description: string | null }).description,
-    created_at: (data as { created_at: string }).created_at,
-    updated_at: (data as { updated_at: string }).updated_at,
-  };
-
-  return { ...videoBase, casts };
+  return { ...(data as Video), casts: castsByContent.get(id) ?? [] };
 }

--- a/supabase/migrations/005_unified_casts.sql
+++ b/supabase/migrations/005_unified_casts.sql
@@ -106,7 +106,52 @@ create trigger trg_topics_delete_casts before delete on topics
   for each row execute function delete_casts_on_content_delete('topic');
 
 -- ============================================
--- 5. RLS（読み取りは公開、書き込みは認証ユーザーのみ）
+-- 5. 親コンテンツの存在チェック（旧 cast テーブルの外部キー相当）
+-- ============================================
+-- ポリモーフィックなため content 側へ FK を張れない。INSERT / UPDATE 時に
+-- content_id が content_type に対応する親テーブルに存在するかをトリガーで
+-- 検証し、旧 cast テーブルの外部キー制約と同等の整合性を担保する。
+create or replace function validate_cast_content()
+returns trigger
+language plpgsql
+as $$
+declare
+  content_exists boolean;
+begin
+  case new.content_type
+    when 'video' then
+      select exists(select 1 from videos where id = new.content_id) into content_exists;
+    when 'live' then
+      select exists(select 1 from lives where id = new.content_id) into content_exists;
+    when 'radio' then
+      select exists(select 1 from radios where id = new.content_id) into content_exists;
+    when 'article' then
+      select exists(select 1 from articles where id = new.content_id) into content_exists;
+    when 'tv_show' then
+      select exists(select 1 from tv_shows where id = new.content_id) into content_exists;
+    when 'topic' then
+      select exists(select 1 from topics where id = new.content_id) into content_exists;
+    else
+      raise exception 'casts.content_type が不正です: %', new.content_type;
+  end case;
+
+  if not content_exists then
+    raise exception 'casts.content_id (%) が % テーブルに存在しません',
+      new.content_id, new.content_type;
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function validate_cast_content() is
+  'casts の content_id が content_type に対応する親テーブルに存在することを検証する（旧 cast テーブルの外部キー相当）';
+
+create trigger trg_casts_validate_content before insert or update on casts
+  for each row execute function validate_cast_content();
+
+-- ============================================
+-- 6. RLS（読み取りは公開、書き込みは認証ユーザーのみ）
 -- ============================================
 alter table casts enable row level security;
 
@@ -116,7 +161,7 @@ create policy casts_update on casts for update to authenticated using (true) wit
 create policy casts_delete on casts for delete to authenticated using (true);
 
 -- ============================================
--- 6. 旧 cast テーブルを削除
+-- 7. 旧 cast テーブルを削除
 -- ============================================
 -- 付随するインデックス・RLS ポリシーも一緒に削除される。
 drop table video_casts;

--- a/supabase/migrations/005_unified_casts.sql
+++ b/supabase/migrations/005_unified_casts.sql
@@ -1,0 +1,127 @@
+-- ============================================
+-- cast テーブルの統合（casts）
+-- ============================================
+-- video_casts / live_casts / radio_casts / article_casts /
+-- tv_show_casts / topic_casts の 6 テーブルを、memos / taggings と同じ
+-- ポリモーフィック設計（content_type + content_id）の単一 casts テーブルに統合する。
+--
+-- 目的:
+--   - 共演分析（co-appearances / co-appearance-graph / rankings）で
+--     6 テーブルを UNION する必要をなくす
+--   - cast 関連ロジックを 1 テーブルに集約する
+--
+-- 親コンテンツ削除時の cascade は、旧 cast テーブルの
+-- `on delete cascade` 相当をトリガーで再現する（ポリモーフィックなため FK は張れない）。
+
+-- ============================================
+-- 1. casts テーブル
+-- ============================================
+create table casts (
+  id uuid primary key default gen_random_uuid(),
+  content_type text not null
+    check (content_type in ('video', 'live', 'radio', 'article', 'tv_show', 'topic')),
+  content_id uuid not null,
+  artist_id uuid references artists(id) on delete cascade,
+  comedy_group_id uuid references comedy_groups(id) on delete cascade,
+  unit_id uuid references units(id) on delete cascade,
+  created_at timestamptz not null default now(),
+
+  -- ピン/コンビ/ユニットのいずれか1つだけ
+  check (
+    (artist_id is not null)::int +
+    (comedy_group_id is not null)::int +
+    (unit_id is not null)::int = 1
+  )
+);
+
+comment on table casts is
+  '全コンテンツ共通の出演者テーブル（ポリモーフィック設計）。ピン/コンビ/ユニットのいずれか';
+
+-- ============================================
+-- 2. 既存データの移行
+-- ============================================
+-- 旧 cast テーブルの id をそのまま引き継ぐ（gen_random_uuid のため衝突しない）。
+insert into casts (id, content_type, content_id, artist_id, comedy_group_id, unit_id, created_at)
+select id, 'video',   video_id,    artist_id, comedy_group_id, unit_id, created_at from video_casts
+union all
+select id, 'live',    live_id,     artist_id, comedy_group_id, unit_id, created_at from live_casts
+union all
+select id, 'radio',   radio_id,    artist_id, comedy_group_id, unit_id, created_at from radio_casts
+union all
+select id, 'article', article_id,  artist_id, comedy_group_id, unit_id, created_at from article_casts
+union all
+select id, 'tv_show', tv_show_id,  artist_id, comedy_group_id, unit_id, created_at from tv_show_casts
+union all
+select id, 'topic',   topic_id,    artist_id, comedy_group_id, unit_id, created_at from topic_casts;
+
+-- ============================================
+-- 3. インデックス
+-- ============================================
+-- コンテンツから出演者を引く
+create index idx_casts_content on casts(content_type, content_id);
+
+-- 出演者からコンテンツを引く
+create index idx_casts_artist on casts(artist_id) where artist_id is not null;
+create index idx_casts_group on casts(comedy_group_id) where comedy_group_id is not null;
+create index idx_casts_unit on casts(unit_id) where unit_id is not null;
+
+-- 重複出演防止（旧テーブルの unique partial index 相当）
+create unique index idx_casts_uniq_artist
+  on casts(content_type, content_id, artist_id) where artist_id is not null;
+create unique index idx_casts_uniq_group
+  on casts(content_type, content_id, comedy_group_id) where comedy_group_id is not null;
+create unique index idx_casts_uniq_unit
+  on casts(content_type, content_id, unit_id) where unit_id is not null;
+
+-- ============================================
+-- 4. 親コンテンツ削除時の cascade（旧 on delete cascade 相当）
+-- ============================================
+-- casts は content 側へ FK を張れないため、各コンテンツの DELETE トリガーで掃除する。
+create or replace function delete_casts_on_content_delete()
+returns trigger
+language plpgsql
+as $$
+begin
+  delete from casts
+  where content_type = tg_argv[0]
+    and content_id = old.id;
+  return old;
+end;
+$$;
+
+comment on function delete_casts_on_content_delete() is
+  '親コンテンツ削除時に対応する casts 行を削除する（旧 cast テーブルの on delete cascade 相当）';
+
+create trigger trg_videos_delete_casts before delete on videos
+  for each row execute function delete_casts_on_content_delete('video');
+create trigger trg_lives_delete_casts before delete on lives
+  for each row execute function delete_casts_on_content_delete('live');
+create trigger trg_radios_delete_casts before delete on radios
+  for each row execute function delete_casts_on_content_delete('radio');
+create trigger trg_articles_delete_casts before delete on articles
+  for each row execute function delete_casts_on_content_delete('article');
+create trigger trg_tv_shows_delete_casts before delete on tv_shows
+  for each row execute function delete_casts_on_content_delete('tv_show');
+create trigger trg_topics_delete_casts before delete on topics
+  for each row execute function delete_casts_on_content_delete('topic');
+
+-- ============================================
+-- 5. RLS（読み取りは公開、書き込みは認証ユーザーのみ）
+-- ============================================
+alter table casts enable row level security;
+
+create policy casts_select on casts for select to anon, authenticated using (true);
+create policy casts_insert on casts for insert to authenticated with check (true);
+create policy casts_update on casts for update to authenticated using (true) with check (true);
+create policy casts_delete on casts for delete to authenticated using (true);
+
+-- ============================================
+-- 6. 旧 cast テーブルを削除
+-- ============================================
+-- 付随するインデックス・RLS ポリシーも一緒に削除される。
+drop table video_casts;
+drop table live_casts;
+drop table radio_casts;
+drop table article_casts;
+drop table tv_show_casts;
+drop table topic_casts;


### PR DESCRIPTION
## 概要

issue #47「cast統合テーブル」の対応です。`video_casts` / `live_casts` / `radio_casts` / `article_casts` / `tv_show_casts` / `topic_casts` の 6 テーブルを、`memos` / `taggings` と同じポリモーフィック設計（`content_type` + `content_id`）の単一 **`casts`** テーブルに統合します。

Closes #47

## DB（migration 005）

- `casts` テーブルを新設（`content_type` / `content_id` + `artist_id` / `comedy_group_id` / `unit_id`、CHECK 制約付き）
- 旧 6 テーブルのデータを `union all` で移行（旧 `id` を引き継ぎ、再実行を避けるため一度きりの移行）
- インデックス・ユニーク制約・RLS を移植
- 親コンテンツ削除時の `on delete cascade` を、各コンテンツ 6 テーブルの `before delete` トリガー（`delete_casts_on_content_delete`）で再現
  - `casts` は content 側へ FK を張れない（ポリモーフィック）ため
- 旧 6 テーブルを `drop`

## アプリコード

- **共演分析の UNION 回避**（issue の主目的）
  - `co-appearances` / `co-appearance-graph` … 6 テーブルのループ（最大 12 クエリ）→ `casts` への 2 クエリに簡素化
  - `rankings` … 6 テーブル走査 → 1 テーブルへ
- `casts` は content 側 FK がなく PostgREST の自動埋め込み（`videos.select("*, casts(...)")`）が使えないため、`_casts.ts` に `fetchCastsByContent` ヘルパーを追加し、各コンテンツの一覧/詳細クエリを 2 段階フェッチに変更
- Server Action の `replaceCasts`、`related-contents` / `performer-contents` / `timeline` / `_list-options` を `casts` 対応へ更新

## テスト

- co-appearance 系 2 ファイル、Server Action 3 ファイルのモックを新スキーマに合わせて更新
- `vitest`: 112/112 パス
- `eslint`: 変更ファイルすべてクリーン

## 補足

- `pnpm-lock.yaml` の同期コミットを 1 件含みます。`package.json` にある依存（d3 / @serwist/next / sharp 等）がロックファイルに未反映で `pnpm install --frozen-lockfile` が失敗する既存の不整合の修正で、#47 とは独立しています。
- `CLAUDE.md` / `docs/design.md` の cast 系記述（「6 テーブル」）は本 PR では未更新です。

## 完了条件

- [x] `casts` 統合テーブルへの移行（migration 005）
- [x] 共演分析の UNION 回避
- [x] 既存テストの更新・パス
- [ ] マイグレーション適用後、公開ページ・管理画面で出演者表示/編集を確認（マージ後に Supabase へ適用して確認）

https://claude.ai/code/session_01MMFENYYKCnAZThUCGNXFVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMFENYYKCnAZThUCGNXFVY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal database structure for managing cast associations across articles, videos, lives, radios, TV shows, and topics. Cast data retrieval and management operations updated to use the new unified system. All existing functionality and user-facing features remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->