### PR TITLE
feat: YouTube動画の自動取得処理を追加 (#38)

### DIFF
--- a/src/lib/integrations/youtube/client.test.ts
+++ b/src/lib/integrations/youtube/client.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchChannelVideos, fetchUploadsPlaylistId } from "./client";
+
+const originalFetch = global.fetch;
+
+function mockResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+beforeEach(() => {
+  process.env.YOUTUBE_API_KEY = "test-key";
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("fetchUploadsPlaylistId", () => {
+  it("YOUTUBE_API_KEY が未設定なら例外を投げる", async () => {
+    delete process.env.YOUTUBE_API_KEY;
+    await expect(fetchUploadsPlaylistId("UC_abc")).rejects.toThrow(
+      "YOUTUBE_API_KEY"
+    );
+  });
+
+  it("アップロード再生リストIDを返す", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        items: [
+          { contentDetails: { relatedPlaylists: { uploads: "UU_abc" } } },
+        ],
+      })
+    );
+    await expect(fetchUploadsPlaylistId("UC_abc")).resolves.toBe("UU_abc");
+  });
+
+  it("チャンネルが見つからない場合は例外を投げる", async () => {
+    global.fetch = vi.fn().mockResolvedValue(mockResponse({ items: [] }));
+    await expect(fetchUploadsPlaylistId("UC_missing")).rejects.toThrow(
+      "チャンネルが見つかりません"
+    );
+  });
+
+  it("API がエラーレスポンスを返したら例外を投げる", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockResponse({ error: "forbidden" }, false, 403));
+    await expect(fetchUploadsPlaylistId("UC_abc")).rejects.toThrow(
+      /YouTube API.*403/
+    );
+  });
+});
+
+describe("fetchChannelVideos", () => {
+  it("複数ページを辿って動画を取得・マッピングする", async () => {
+    global.fetch = vi.fn().mockImplementation((input: URL) => {
+      const url = input.toString();
+      if (url.includes("/channels")) {
+        return Promise.resolve(
+          mockResponse({
+            items: [
+              {
+                contentDetails: { relatedPlaylists: { uploads: "UU_abc" } },
+              },
+            ],
+          })
+        );
+      }
+      if (url.includes("pageToken=PAGE2")) {
+        return Promise.resolve(
+          mockResponse({
+            items: [
+              {
+                contentDetails: {
+                  videoId: "vid2",
+                  videoPublishedAt: "2026-01-02T00:00:00Z",
+                },
+                snippet: {
+                  title: "動画2",
+                  thumbnails: { high: { url: "https://img/high2" } },
+                },
+              },
+            ],
+          })
+        );
+      }
+      return Promise.resolve(
+        mockResponse({
+          nextPageToken: "PAGE2",
+          items: [
+            {
+              contentDetails: {
+                videoId: "vid1",
+                videoPublishedAt: "2026-01-01T00:00:00Z",
+              },
+              snippet: {
+                title: "  動画1  ",
+                description: "  説明  ",
+                thumbnails: {
+                  medium: { url: "https://img/med1" },
+                  maxres: { url: "https://img/maxres1" },
+                },
+              },
+            },
+            // videoId を欠く項目はスキップされる
+            { snippet: { title: "壊れた項目" } },
+          ],
+        })
+      );
+    });
+
+    const result = await fetchChannelVideos("UC_abc");
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      youtubeVideoId: "vid1",
+      title: "動画1",
+      description: "説明",
+      publishedAt: "2026-01-01T00:00:00Z",
+      thumbnailUrl: "https://img/maxres1",
+      channelId: "UC_abc",
+    });
+    expect(result[1]).toEqual({
+      youtubeVideoId: "vid2",
+      title: "動画2",
+      description: null,
+      publishedAt: "2026-01-02T00:00:00Z",
+      thumbnailUrl: "https://img/high2",
+      channelId: "UC_abc",
+    });
+  });
+
+  it("maxPages を超えてページを辿らない", async () => {
+    const fetchMock = vi.fn().mockImplementation((input: URL) => {
+      const url = input.toString();
+      if (url.includes("/channels")) {
+        return Promise.resolve(
+          mockResponse({
+            items: [
+              {
+                contentDetails: { relatedPlaylists: { uploads: "UU_abc" } },
+              },
+            ],
+          })
+        );
+      }
+      // 常に nextPageToken を返し続ける
+      return Promise.resolve(
+        mockResponse({
+          nextPageToken: "NEXT",
+          items: [
+            {
+              contentDetails: { videoId: "vid", videoPublishedAt: null },
+              snippet: { title: "動画" },
+            },
+          ],
+        })
+      );
+    });
+    global.fetch = fetchMock;
+
+    await fetchChannelVideos("UC_abc", { maxPages: 2 });
+
+    // channels 1回 + playlistItems 2回
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/lib/integrations/youtube/client.test.ts
+++ b/src/lib/integrations/youtube/client.test.ts
@@ -55,6 +55,17 @@ describe("fetchUploadsPlaylistId", () => {
       /YouTube API.*403/
     );
   });
+
+  it("リクエストがタイムアウトしたら専用エラーを投げる", async () => {
+    global.fetch = vi.fn().mockRejectedValue(
+      Object.assign(new Error("This operation was aborted"), {
+        name: "AbortError",
+      })
+    );
+    await expect(fetchUploadsPlaylistId("UC_abc")).rejects.toThrow(
+      "タイムアウト"
+    );
+  });
 });
 
 describe("fetchChannelVideos", () => {
@@ -136,7 +147,7 @@ describe("fetchChannelVideos", () => {
     });
   });
 
-  it("maxPages を超えてページを辿らない", async () => {
+  it("maxPages を指定すると、その枚数でページ巡回を打ち切る", async () => {
     const fetchMock = vi.fn().mockImplementation((input: URL) => {
       const url = input.toString();
       if (url.includes("/channels")) {
@@ -169,5 +180,55 @@ describe("fetchChannelVideos", () => {
 
     // channels 1回 + playlistItems 2回
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("maxPages 未指定なら nextPageToken が尽きるまで全ページ取得する", async () => {
+    let playlistCalls = 0;
+    const fetchMock = vi.fn().mockImplementation((input: URL) => {
+      const url = input.toString();
+      if (url.includes("/channels")) {
+        return Promise.resolve(
+          mockResponse({
+            items: [
+              {
+                contentDetails: { relatedPlaylists: { uploads: "UU_abc" } },
+              },
+            ],
+          })
+        );
+      }
+      playlistCalls += 1;
+      return Promise.resolve(
+        mockResponse({
+          // 3ページ目で nextPageToken を返さない
+          nextPageToken: playlistCalls < 3 ? `PAGE${playlistCalls}` : undefined,
+          items: [
+            {
+              contentDetails: {
+                videoId: `vid${playlistCalls}`,
+                videoPublishedAt: null,
+              },
+              snippet: { title: `動画${playlistCalls}` },
+            },
+          ],
+        })
+      );
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchChannelVideos("UC_abc");
+
+    expect(result).toHaveLength(3);
+    expect(playlistCalls).toBe(3);
+  });
+
+  it("maxPages が 0 ならリクエストせず空配列を返す", async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock;
+
+    await expect(
+      fetchChannelVideos("UC_abc", { maxPages: 0 })
+    ).resolves.toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/integrations/youtube/client.ts
+++ b/src/lib/integrations/youtube/client.ts
@@ -2,7 +2,7 @@ import type { YoutubeVideo } from "./types";
 
 const API_BASE = "https://www.googleapis.com/youtube/v3";
 const MAX_RESULTS_PER_PAGE = 50;
-const DEFAULT_MAX_PAGES = 10;
+const REQUEST_TIMEOUT_MS = 10_000;
 
 // 画質の高い順。利用可能な最初のものを採用する
 const THUMBNAIL_PRIORITY = ["maxres", "standard", "high", "medium", "default"];
@@ -56,7 +56,26 @@ async function youtubeRequest<T>(
     url.searchParams.set(key, value);
   }
 
-  const response = await fetch(url, { headers: { accept: "application/json" } });
+  // 外部APIのハングでsyncが固まらないようタイムアウトを設ける
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(
+        `YouTube API リクエストがタイムアウトしました (${REQUEST_TIMEOUT_MS}ms)`
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   if (!response.ok) {
     const body = await response.text();
@@ -88,14 +107,20 @@ export async function fetchChannelVideos(
   channelId: string,
   options: { maxPages?: number } = {}
 ): Promise<YoutubeVideo[]> {
-  const maxPages = options.maxPages ?? DEFAULT_MAX_PAGES;
+  // maxPages 未指定なら全ページ取得（チャンネル全動画の取りこぼしを防ぐ）。
+  // 指定時のみページ数を制限し、0以下/不正値なら何も取得しない
+  const maxPages = options.maxPages;
+  if (maxPages !== undefined && !(maxPages >= 1)) {
+    return [];
+  }
+
   const playlistId = await fetchUploadsPlaylistId(channelId);
 
   const videos: YoutubeVideo[] = [];
   let pageToken: string | undefined;
   let page = 0;
 
-  do {
+  while (maxPages === undefined || page < maxPages) {
     const params: Record<string, string> = {
       part: "snippet,contentDetails",
       playlistId,
@@ -128,9 +153,10 @@ export async function fetchChannelVideos(
       });
     }
 
-    pageToken = data.nextPageToken;
     page += 1;
-  } while (pageToken && page < maxPages);
+    if (!data.nextPageToken) break;
+    pageToken = data.nextPageToken;
+  }
 
   return videos;
 }

--- a/src/lib/integrations/youtube/client.ts
+++ b/src/lib/integrations/youtube/client.ts
@@ -1,0 +1,136 @@
+import type { YoutubeVideo } from "./types";
+
+const API_BASE = "https://www.googleapis.com/youtube/v3";
+const MAX_RESULTS_PER_PAGE = 50;
+const DEFAULT_MAX_PAGES = 10;
+
+// 画質の高い順。利用可能な最初のものを採用する
+const THUMBNAIL_PRIORITY = ["maxres", "standard", "high", "medium", "default"];
+
+type Thumbnails = Record<string, { url?: string } | undefined>;
+
+type ChannelsResponse = {
+  items?: Array<{
+    contentDetails?: { relatedPlaylists?: { uploads?: string } };
+  }>;
+};
+
+type PlaylistItemsResponse = {
+  nextPageToken?: string;
+  items?: Array<{
+    snippet?: {
+      title?: string;
+      description?: string;
+      publishedAt?: string;
+      thumbnails?: Thumbnails;
+      resourceId?: { videoId?: string };
+    };
+    contentDetails?: { videoId?: string; videoPublishedAt?: string };
+  }>;
+};
+
+function getApiKey(): string {
+  const key = process.env.YOUTUBE_API_KEY;
+  if (!key) {
+    throw new Error("YOUTUBE_API_KEY が設定されていません");
+  }
+  return key;
+}
+
+function pickThumbnailUrl(thumbnails: Thumbnails | undefined): string | null {
+  if (!thumbnails) return null;
+  for (const key of THUMBNAIL_PRIORITY) {
+    const url = thumbnails[key]?.url;
+    if (url) return url;
+  }
+  return null;
+}
+
+async function youtubeRequest<T>(
+  endpoint: string,
+  params: Record<string, string>
+): Promise<T> {
+  const url = new URL(`${API_BASE}/${endpoint}`);
+  url.searchParams.set("key", getApiKey());
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url, { headers: { accept: "application/json" } });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `YouTube API リクエストに失敗しました (${response.status}): ${body}`
+    );
+  }
+
+  return response.json() as Promise<T>;
+}
+
+// チャンネルのアップロード再生リストID（search.list より低コストで全動画を辿れる）
+export async function fetchUploadsPlaylistId(
+  channelId: string
+): Promise<string> {
+  const data = await youtubeRequest<ChannelsResponse>("channels", {
+    part: "contentDetails",
+    id: channelId,
+  });
+  const uploads =
+    data.items?.[0]?.contentDetails?.relatedPlaylists?.uploads;
+  if (!uploads) {
+    throw new Error(`チャンネルが見つかりません: ${channelId}`);
+  }
+  return uploads;
+}
+
+export async function fetchChannelVideos(
+  channelId: string,
+  options: { maxPages?: number } = {}
+): Promise<YoutubeVideo[]> {
+  const maxPages = options.maxPages ?? DEFAULT_MAX_PAGES;
+  const playlistId = await fetchUploadsPlaylistId(channelId);
+
+  const videos: YoutubeVideo[] = [];
+  let pageToken: string | undefined;
+  let page = 0;
+
+  do {
+    const params: Record<string, string> = {
+      part: "snippet,contentDetails",
+      playlistId,
+      maxResults: String(MAX_RESULTS_PER_PAGE),
+    };
+    if (pageToken) params.pageToken = pageToken;
+
+    const data = await youtubeRequest<PlaylistItemsResponse>(
+      "playlistItems",
+      params
+    );
+
+    for (const item of data.items ?? []) {
+      const videoId =
+        item.contentDetails?.videoId ?? item.snippet?.resourceId?.videoId;
+      const title = item.snippet?.title?.trim();
+      // videoId / title を欠く項目（削除・非公開動画など）はスキップ
+      if (!videoId || !title) continue;
+
+      videos.push({
+        youtubeVideoId: videoId,
+        title,
+        description: item.snippet?.description?.trim() || null,
+        publishedAt:
+          item.contentDetails?.videoPublishedAt ??
+          item.snippet?.publishedAt ??
+          null,
+        thumbnailUrl: pickThumbnailUrl(item.snippet?.thumbnails),
+        channelId,
+      });
+    }
+
+    pageToken = data.nextPageToken;
+    page += 1;
+  } while (pageToken && page < maxPages);
+
+  return videos;
+}

--- a/src/lib/integrations/youtube/sync.test.ts
+++ b/src/lib/integrations/youtube/sync.test.ts
@@ -20,26 +20,21 @@ function buildVideo(id: string): YoutubeVideo {
   };
 }
 
+// upsert(...).select(...) のチェーンをモックする。
+// inserted には「実際に挿入された行（重複は除外済み）」を渡す
 function setupAdmin(
   options: {
-    existing?: Array<{ youtube_video_id: string | null }>;
-    selectError?: { message: string } | null;
-    insertError?: { message: string } | null;
+    inserted?: Array<{ youtube_video_id: string | null }>;
+    upsertError?: { message: string } | null;
   } = {}
 ) {
-  const inMock = vi.fn().mockResolvedValue({
-    data: options.existing ?? [],
-    error: options.selectError ?? null,
+  const selectMock = vi.fn().mockResolvedValue({
+    data: options.inserted ?? [],
+    error: options.upsertError ?? null,
   });
-  const selectMock = vi.fn(() => ({ in: inMock }));
-  const insertMock = vi
-    .fn()
-    .mockResolvedValue({ error: options.insertError ?? null });
-  adminClientMock.from.mockReturnValue({
-    select: selectMock,
-    insert: insertMock,
-  });
-  return { inMock, selectMock, insertMock };
+  const upsertMock = vi.fn(() => ({ select: selectMock }));
+  adminClientMock.from.mockReturnValue({ upsert: upsertMock });
+  return { upsertMock, selectMock };
 }
 
 beforeEach(() => {
@@ -49,7 +44,7 @@ beforeEach(() => {
 describe("syncChannelVideos", () => {
   it("動画が0件なら何も保存しない", async () => {
     fetchChannelVideosMock.mockResolvedValue([]);
-    const { selectMock, insertMock } = setupAdmin();
+    const { upsertMock } = setupAdmin();
 
     const result = await syncChannelVideos("UC_abc");
 
@@ -59,18 +54,18 @@ describe("syncChannelVideos", () => {
       skipped: 0,
       insertedVideoIds: [],
     });
-    expect(selectMock).not.toHaveBeenCalled();
-    expect(insertMock).not.toHaveBeenCalled();
+    expect(upsertMock).not.toHaveBeenCalled();
   });
 
-  it("未登録の動画だけを保存する", async () => {
+  it("upsert に全件を渡し、挿入された分のみを inserted として集計する", async () => {
     fetchChannelVideosMock.mockResolvedValue([
       buildVideo("a"),
       buildVideo("b"),
       buildVideo("c"),
     ]);
-    const { insertMock } = setupAdmin({
-      existing: [{ youtube_video_id: "b" }],
+    // b は既存のため upsert で挿入されず、a/c のみ返る
+    const { upsertMock } = setupAdmin({
+      inserted: [{ youtube_video_id: "a" }, { youtube_video_id: "c" }],
     });
 
     const result = await syncChannelVideos("UC_abc");
@@ -81,36 +76,47 @@ describe("syncChannelVideos", () => {
       skipped: 1,
       insertedVideoIds: ["a", "c"],
     });
-    expect(insertMock).toHaveBeenCalledWith([
-      expect.objectContaining({
-        youtube_video_id: "a",
-        youtube_url: "https://www.youtube.com/watch?v=a",
-        youtube_channel_id: "UC_abc",
-      }),
-      expect.objectContaining({ youtube_video_id: "c" }),
-    ]);
+    expect(upsertMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          youtube_video_id: "a",
+          youtube_url: "https://www.youtube.com/watch?v=a",
+          youtube_channel_id: "UC_abc",
+        }),
+        expect.objectContaining({ youtube_video_id: "b" }),
+        expect.objectContaining({ youtube_video_id: "c" }),
+      ],
+      { onConflict: "youtube_video_id", ignoreDuplicates: true }
+    );
   });
 
-  it("取得結果内の重複を除外する", async () => {
+  it("取得結果内の重複を除外してから upsert する", async () => {
     fetchChannelVideosMock.mockResolvedValue([
       buildVideo("a"),
       buildVideo("a"),
       buildVideo("b"),
     ]);
-    const { insertMock } = setupAdmin();
+    const { upsertMock } = setupAdmin({
+      inserted: [{ youtube_video_id: "a" }, { youtube_video_id: "b" }],
+    });
 
     const result = await syncChannelVideos("UC_abc");
 
     expect(result.fetched).toBe(2);
     expect(result.inserted).toBe(2);
-    expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    expect(upsertMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ youtube_video_id: "a" }),
+        expect.objectContaining({ youtube_video_id: "b" }),
+      ],
+      { onConflict: "youtube_video_id", ignoreDuplicates: true }
+    );
   });
 
-  it("全て登録済みなら insert を呼ばない", async () => {
+  it("全て登録済みなら inserted=0 を返す", async () => {
     fetchChannelVideosMock.mockResolvedValue([buildVideo("a")]);
-    const { insertMock } = setupAdmin({
-      existing: [{ youtube_video_id: "a" }],
-    });
+    const { upsertMock } = setupAdmin({ inserted: [] });
 
     const result = await syncChannelVideos("UC_abc");
 
@@ -120,24 +126,15 @@ describe("syncChannelVideos", () => {
       skipped: 1,
       insertedVideoIds: [],
     });
-    expect(insertMock).not.toHaveBeenCalled();
-  });
-
-  it("既存動画の確認に失敗したら例外を投げる", async () => {
-    fetchChannelVideosMock.mockResolvedValue([buildVideo("a")]);
-    setupAdmin({ selectError: { message: "select boom" } });
-
-    await expect(syncChannelVideos("UC_abc")).rejects.toThrow(
-      "既存動画の確認に失敗しました: select boom"
-    );
+    expect(upsertMock).toHaveBeenCalledTimes(1);
   });
 
   it("保存に失敗したら例外を投げる", async () => {
     fetchChannelVideosMock.mockResolvedValue([buildVideo("a")]);
-    setupAdmin({ insertError: { message: "insert boom" } });
+    setupAdmin({ upsertError: { message: "upsert boom" } });
 
     await expect(syncChannelVideos("UC_abc")).rejects.toThrow(
-      "動画の保存に失敗しました: insert boom"
+      "動画の保存に失敗しました: upsert boom"
     );
   });
 });

--- a/src/lib/integrations/youtube/sync.test.ts
+++ b/src/lib/integrations/youtube/sync.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { YoutubeVideo } from "./types";
+
+const adminClientMock = vi.hoisted(() => ({ from: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ adminClient: adminClientMock }));
+
+const fetchChannelVideosMock = vi.hoisted(() => vi.fn());
+vi.mock("./client", () => ({ fetchChannelVideos: fetchChannelVideosMock }));
+
+import { syncChannelVideos } from "./sync";
+
+function buildVideo(id: string): YoutubeVideo {
+  return {
+    youtubeVideoId: id,
+    title: `動画-${id}`,
+    description: null,
+    publishedAt: "2026-01-01T00:00:00Z",
+    thumbnailUrl: null,
+    channelId: "UC_abc",
+  };
+}
+
+function setupAdmin(
+  options: {
+    existing?: Array<{ youtube_video_id: string | null }>;
+    selectError?: { message: string } | null;
+    insertError?: { message: string } | null;
+  } = {}
+) {
+  const inMock = vi.fn().mockResolvedValue({
+    data: options.existing ?? [],
+    error: options.selectError ?? null,
+  });
+  const selectMock = vi.fn(() => ({ in: inMock }));
+  const insertMock = vi
+    .fn()
+    .mockResolvedValue({ error: options.insertError ?? null });
+  adminClientMock.from.mockReturnValue({
+    select: selectMock,
+    insert: insertMock,
+  });
+  return { inMock, selectMock, insertMock };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("syncChannelVideos", () => {
+  it("動画が0件なら何も保存しない", async () => {
+    fetchChannelVideosMock.mockResolvedValue([]);
+    const { selectMock, insertMock } = setupAdmin();
+
+    const result = await syncChannelVideos("UC_abc");
+
+    expect(result).toEqual({
+      fetched: 0,
+      inserted: 0,
+      skipped: 0,
+      insertedVideoIds: [],
+    });
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("未登録の動画だけを保存する", async () => {
+    fetchChannelVideosMock.mockResolvedValue([
+      buildVideo("a"),
+      buildVideo("b"),
+      buildVideo("c"),
+    ]);
+    const { insertMock } = setupAdmin({
+      existing: [{ youtube_video_id: "b" }],
+    });
+
+    const result = await syncChannelVideos("UC_abc");
+
+    expect(result).toEqual({
+      fetched: 3,
+      inserted: 2,
+      skipped: 1,
+      insertedVideoIds: ["a", "c"],
+    });
+    expect(insertMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        youtube_video_id: "a",
+        youtube_url: "https://www.youtube.com/watch?v=a",
+        youtube_channel_id: "UC_abc",
+      }),
+      expect.objectContaining({ youtube_video_id: "c" }),
+    ]);
+  });
+
+  it("取得結果内の重複を除外する", async () => {
+    fetchChannelVideosMock.mockResolvedValue([
+      buildVideo("a"),
+      buildVideo("a"),
+      buildVideo("b"),
+    ]);
+    const { insertMock } = setupAdmin();
+
+    const result = await syncChannelVideos("UC_abc");
+
+    expect(result.fetched).toBe(2);
+    expect(result.inserted).toBe(2);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("全て登録済みなら insert を呼ばない", async () => {
+    fetchChannelVideosMock.mockResolvedValue([buildVideo("a")]);
+    const { insertMock } = setupAdmin({
+      existing: [{ youtube_video_id: "a" }],
+    });
+
+    const result = await syncChannelVideos("UC_abc");
+
+    expect(result).toEqual({
+      fetched: 1,
+      inserted: 0,
+      skipped: 1,
+      insertedVideoIds: [],
+    });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("既存動画の確認に失敗したら例外を投げる", async () => {
+    fetchChannelVideosMock.mockResolvedValue([buildVideo("a")]);
+    setupAdmin({ selectError: { message: "select boom" } });
+
+    await expect(syncChannelVideos("UC_abc")).rejects.toThrow(
+      "既存動画の確認に失敗しました: select boom"
+    );
+  });
+
+  it("保存に失敗したら例外を投げる", async () => {
+    fetchChannelVideosMock.mockResolvedValue([buildVideo("a")]);
+    setupAdmin({ insertError: { message: "insert boom" } });
+
+    await expect(syncChannelVideos("UC_abc")).rejects.toThrow(
+      "動画の保存に失敗しました: insert boom"
+    );
+  });
+});

--- a/src/lib/integrations/youtube/sync.ts
+++ b/src/lib/integrations/youtube/sync.ts
@@ -1,0 +1,88 @@
+import { adminClient } from "@/lib/supabase/admin";
+import { fetchChannelVideos } from "./client";
+import type { YoutubeVideo } from "./types";
+
+export type SyncChannelResult = {
+  fetched: number;
+  inserted: number;
+  skipped: number;
+  insertedVideoIds: string[];
+};
+
+function toVideoRow(video: YoutubeVideo) {
+  return {
+    title: video.title,
+    youtube_video_id: video.youtubeVideoId,
+    youtube_url: `https://www.youtube.com/watch?v=${video.youtubeVideoId}`,
+    youtube_channel_id: video.channelId,
+    thumbnail_url: video.thumbnailUrl,
+    published_at: video.publishedAt,
+    description: video.description,
+  };
+}
+
+// チャンネルの動画一覧を取得し、youtube_video_id で未登録のものだけ videos に保存する
+export async function syncChannelVideos(
+  channelId: string
+): Promise<SyncChannelResult> {
+  const fetched = await fetchChannelVideos(channelId);
+
+  // 取得結果内の重複を youtube_video_id で除外
+  const uniqueByVideoId = new Map<string, YoutubeVideo>();
+  for (const video of fetched) {
+    if (!uniqueByVideoId.has(video.youtubeVideoId)) {
+      uniqueByVideoId.set(video.youtubeVideoId, video);
+    }
+  }
+  const videos = [...uniqueByVideoId.values()];
+
+  if (videos.length === 0) {
+    return { fetched: 0, inserted: 0, skipped: 0, insertedVideoIds: [] };
+  }
+
+  const { data: existing, error: selectError } = await adminClient
+    .from("videos")
+    .select("youtube_video_id")
+    .in(
+      "youtube_video_id",
+      videos.map((v) => v.youtubeVideoId)
+    );
+
+  if (selectError) {
+    throw new Error(`既存動画の確認に失敗しました: ${selectError.message}`);
+  }
+
+  const existingIds = new Set(
+    (existing ?? [])
+      .map((row) => row.youtube_video_id)
+      .filter((id): id is string => Boolean(id))
+  );
+
+  const newVideos = videos.filter(
+    (video) => !existingIds.has(video.youtubeVideoId)
+  );
+
+  if (newVideos.length === 0) {
+    return {
+      fetched: videos.length,
+      inserted: 0,
+      skipped: videos.length,
+      insertedVideoIds: [],
+    };
+  }
+
+  const { error: insertError } = await adminClient
+    .from("videos")
+    .insert(newVideos.map(toVideoRow));
+
+  if (insertError) {
+    throw new Error(`動画の保存に失敗しました: ${insertError.message}`);
+  }
+
+  return {
+    fetched: videos.length,
+    inserted: newVideos.length,
+    skipped: videos.length - newVideos.length,
+    insertedVideoIds: newVideos.map((v) => v.youtubeVideoId),
+  };
+}

--- a/src/lib/integrations/youtube/sync.ts
+++ b/src/lib/integrations/youtube/sync.ts
@@ -40,49 +40,28 @@ export async function syncChannelVideos(
     return { fetched: 0, inserted: 0, skipped: 0, insertedVideoIds: [] };
   }
 
-  const { data: existing, error: selectError } = await adminClient
+  // upsert + ignoreDuplicates で「未登録のみ挿入」をアトミックに行う。
+  // SELECT→INSERT 方式だと並行実行時に unique 制約違反でバッチ全体が失敗しうる
+  const { data: insertedRows, error } = await adminClient
     .from("videos")
-    .select("youtube_video_id")
-    .in(
-      "youtube_video_id",
-      videos.map((v) => v.youtubeVideoId)
-    );
+    .upsert(videos.map(toVideoRow), {
+      onConflict: "youtube_video_id",
+      ignoreDuplicates: true,
+    })
+    .select("youtube_video_id");
 
-  if (selectError) {
-    throw new Error(`既存動画の確認に失敗しました: ${selectError.message}`);
+  if (error) {
+    throw new Error(`動画の保存に失敗しました: ${error.message}`);
   }
 
-  const existingIds = new Set(
-    (existing ?? [])
-      .map((row) => row.youtube_video_id)
-      .filter((id): id is string => Boolean(id))
-  );
-
-  const newVideos = videos.filter(
-    (video) => !existingIds.has(video.youtubeVideoId)
-  );
-
-  if (newVideos.length === 0) {
-    return {
-      fetched: videos.length,
-      inserted: 0,
-      skipped: videos.length,
-      insertedVideoIds: [],
-    };
-  }
-
-  const { error: insertError } = await adminClient
-    .from("videos")
-    .insert(newVideos.map(toVideoRow));
-
-  if (insertError) {
-    throw new Error(`動画の保存に失敗しました: ${insertError.message}`);
-  }
+  const insertedVideoIds = (insertedRows ?? [])
+    .map((row) => row.youtube_video_id)
+    .filter((id): id is string => Boolean(id));
 
   return {
     fetched: videos.length,
-    inserted: newVideos.length,
-    skipped: videos.length - newVideos.length,
-    insertedVideoIds: newVideos.map((v) => v.youtubeVideoId),
+    inserted: insertedVideoIds.length,
+    skipped: videos.length - insertedVideoIds.length,
+    insertedVideoIds,
   };
 }

--- a/src/lib/integrations/youtube/types.ts
+++ b/src/lib/integrations/youtube/types.ts
@@ -1,0 +1,8 @@
+export type YoutubeVideo = {
+  youtubeVideoId: string;
+  title: string;
+  description: string | null;
+  publishedAt: string | null;
+  thumbnailUrl: string | null;
+  channelId: string;
+};


### PR DESCRIPTION
## 概要

issue #38「YouTube動画自動取得」の対応です。YouTube 公式チャンネルから動画一覧を取得し、`youtube_video_id` で重複チェックして新着のみ `videos` テーブルに保存する処理を追加します。

Closes #38

## 変更内容

`src/lib/integrations/youtube/` を新設（`docs/issues.md` #97 の `src/lib/integrations/fany/` と同じ構成方針）。

### `client.ts` — YouTube Data API v3 クライアント

- `fetchUploadsPlaylistId(channelId)` — `channels.list` でチャンネルのアップロード再生リストIDを取得
- `fetchChannelVideos(channelId)` — `playlistItems.list` をページネーションで辿って動画一覧を取得
  - `search.list`（100ユニット）ではなく `playlistItems.list`（1ユニット）を使い、クォータ消費を抑える（#37 Step 9-5 の方針）
  - サムネイルは画質の高い順（maxres → standard → high → medium → default）で採用
  - `videoId` / `title` を欠く項目（削除・非公開動画など）はスキップ
- APIキーは `process.env.YOUTUBE_API_KEY` から取得（未設定なら例外）

### `sync.ts` — `syncChannelVideos(channelId)`

- `fetchChannelVideos` で取得 → 取得結果内の重複を除外
- `videos.youtube_video_id` と突き合わせ、未登録分のみ `adminClient`（service role）で insert
- 結果 `{ fetched, inserted, skipped, insertedVideoIds }` を返す

### テスト

- `client.test.ts` / `sync.test.ts` を追加（計12件）。`fetch` と `adminClient` をモック
- 既存テスト含め全件パス / 新規ファイルの lint・型チェックともクリーン

## 補足・依存

- 環境変数 `YOUTUBE_API_KEY` の `.env.example` 追加とセットアップ手順は #37（PR #107）で対応済み。実機での取得確認には Google Cloud でのAPIキー取得が必要です。
- 定期実行（Vercel Cron の `/api/cron/youtube`）は #39、取得動画の管理画面レビュー機能は #40 で対応予定。本PRは取得・保存のロジック層に限定しています。
- チャンネルIDは `comedy_groups.youtube_channel_id` を想定（`syncChannelVideos` の引数）。複数チャンネルの巡回は #39 で実装します。

## 完了条件

- [x] チャンネルIDで動画一覧取得
- [x] `youtube_video_id` で重複チェック
- [x] 新着のみDBに保存
- [ ] APIキー設定後、実チャンネルで取得を確認（#39 のCron整備後）


---
_Generated by [Claude Code](https://claude.ai/code/session_01RdqrCsNAF5Lyhz5CKUmYuo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * YouTube integration support added: retrieve videos from YouTube channels with automatic deduplication and intelligent storage of new videos to the database.

* **Tests**
  * Comprehensive test suites added for YouTube API client operations, including pagination, error handling, and video synchronization workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->