### PR TITLE
feat: cast関連 Server Action をRPCでアトミック化 (#64)

### DIFF
--- a/src/lib/actions/articles.test.ts
+++ b/src/lib/actions/articles.test.ts
@@ -103,6 +103,9 @@ describe("createArticle", () => {
       title: "テスト",
       url: "https://example.com/article",
       content: "短い要約",
+      cast_type: ["artist"],
+      cast_id: ["22222222-2222-4222-8222-222222222222"],
+      cast_name: ["出演者A"],
     });
     await expect(createArticle({}, fd)).rejects.toThrow(/__REDIRECT__/);
     expect(supabaseMock.rpc).toHaveBeenCalledWith(
@@ -115,8 +118,12 @@ describe("createArticle", () => {
           url: "https://example.com/article",
           content: "短い要約",
         }),
+        p_casts: [
+          { type: "artist", id: "22222222-2222-4222-8222-222222222222" },
+        ],
       })
     );
+    expect(supabaseMock.from).not.toHaveBeenCalled();
   });
 });
 
@@ -138,6 +145,24 @@ describe("updateArticle", () => {
       fd
     );
     expect(result.fieldErrors?.url).toBeDefined();
+  });
+
+  it("RPC が not found を返した場合は既存メッセージを返す", async () => {
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { code: "P0002", message: "not found" },
+    });
+
+    const fd = buildFormData({
+      title: "テスト",
+      url: "https://example.com",
+    });
+    const result = await updateArticle(
+      "11111111-1111-4111-8111-111111111111",
+      {},
+      fd
+    );
+    expect(result.error).toBe("指定された記事が見つかりません");
   });
 });
 

--- a/src/lib/actions/articles.test.ts
+++ b/src/lib/actions/articles.test.ts
@@ -13,6 +13,7 @@ vi.mock("next/navigation", () => ({
 const supabaseMock = vi.hoisted(() => ({
   auth: { getUser: vi.fn() },
   from: vi.fn(),
+  rpc: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -37,6 +38,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } } });
   supabaseMock.from.mockReset();
+  supabaseMock.rpc.mockReset();
 });
 
 describe("createArticle", () => {
@@ -91,21 +93,10 @@ describe("createArticle", () => {
     expect(result.error).toBe("認証が必要です");
   });
 
-  it("バリデーション通過時は records を挿入して redirect する", async () => {
-    const insertSelectSingle = vi.fn().mockResolvedValue({
-      data: { id: "11111111-1111-4111-8111-111111111111" },
+  it("バリデーション通過時は RPC を呼び出して redirect する", async () => {
+    supabaseMock.rpc.mockResolvedValue({
+      data: "11111111-1111-4111-8111-111111111111",
       error: null,
-    });
-    const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
-    const insertChain = vi.fn(() => ({ select: insertSelect }));
-    const deleteEqContent = vi.fn().mockResolvedValue({ error: null });
-    const deleteEqType = vi.fn(() => ({ eq: deleteEqContent }));
-    const deleteChain = vi.fn(() => ({ eq: deleteEqType }));
-
-    supabaseMock.from.mockImplementation((table: string) => {
-      if (table === "articles") return { insert: insertChain };
-      if (table === "casts") return { delete: deleteChain };
-      throw new Error(`unexpected table: ${table}`);
     });
 
     const fd = buildFormData({
@@ -114,11 +105,16 @@ describe("createArticle", () => {
       content: "短い要約",
     });
     await expect(createArticle({}, fd)).rejects.toThrow(/__REDIRECT__/);
-    expect(insertChain).toHaveBeenCalledWith(
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "upsert_content_with_casts",
       expect.objectContaining({
-        title: "テスト",
-        url: "https://example.com/article",
-        content: "短い要約",
+        p_content_type: "article",
+        p_content_id: null,
+        p_content: expect.objectContaining({
+          title: "テスト",
+          url: "https://example.com/article",
+          content: "短い要約",
+        }),
       })
     );
   });

--- a/src/lib/actions/articles.ts
+++ b/src/lib/actions/articles.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { ArticleFormState, ArticleInput } from "@/lib/types/article";
+import { upsertContentWithCasts } from "./casts";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -101,40 +102,6 @@ function parseFormData(formData: FormData): {
   return { values, casts, fieldErrors };
 }
 
-async function replaceCasts(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  articleId: string,
-  casts: CastEntry[]
-): Promise<{ error?: string }> {
-  const { error: deleteError } = await supabase
-    .from("casts")
-    .delete()
-    .eq("content_type", "article")
-    .eq("content_id", articleId);
-
-  if (deleteError) {
-    return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
-  }
-
-  if (casts.length === 0) return {};
-
-  const rows = casts.map((c) => ({
-    content_type: "article",
-    content_id: articleId,
-    artist_id: c.type === "artist" ? c.id : null,
-    comedy_group_id: c.type === "comedy_group" ? c.id : null,
-    unit_id: c.type === "unit" ? c.id : null,
-  }));
-
-  const { error: insertError } = await supabase.from("casts").insert(rows);
-
-  if (insertError) {
-    return { error: `出演者の追加に失敗しました: ${insertError.message}` };
-  }
-
-  return {};
-}
-
 export async function createArticle(
   _prev: ArticleFormState,
   formData: FormData
@@ -151,21 +118,14 @@ export async function createArticle(
     return { error: "認証が必要です" };
   }
 
-  const { data, error } = await supabase
-    .from("articles")
-    .insert(values)
-    .select("id")
-    .single();
-
-  if (error || !data) {
-    return {
-      error: `記事の登録に失敗しました: ${error?.message ?? "unknown"}`,
-    };
-  }
-
-  const castsResult = await replaceCasts(supabase, data.id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "article",
+    contentId: null,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return { error: `記事の登録に失敗しました: ${result.error}` };
   }
 
   revalidatePath("/admin/articles");
@@ -193,24 +153,18 @@ export async function updateArticle(
     return { error: "認証が必要です" };
   }
 
-  const { error, count } = await supabase
-    .from("articles")
-    .update(
-      { ...values, updated_at: new Date().toISOString() },
-      { count: "exact" }
-    )
-    .eq("id", id);
-
-  if (error) {
-    return { error: `記事の更新に失敗しました: ${error.message}` };
-  }
-  if (count !== 1) {
-    return { error: "指定された記事が見つかりません" };
-  }
-
-  const castsResult = await replaceCasts(supabase, id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "article",
+    contentId: id,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return {
+      error: result.notFound
+        ? "指定された記事が見つかりません"
+        : `記事の更新に失敗しました: ${result.error}`,
+    };
   }
 
   revalidatePath("/admin/articles");

--- a/src/lib/actions/casts.ts
+++ b/src/lib/actions/casts.ts
@@ -1,0 +1,32 @@
+import type { createClient } from "@/lib/supabase/server";
+import type { CastEntry, ContentType } from "@/lib/types";
+
+type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
+
+/**
+ * メインレコードの upsert と casts の置き換えを RPC 経由で
+ * 1 トランザクション(アトミック)で実行する。
+ */
+export async function upsertContentWithCasts(
+  supabase: SupabaseServerClient,
+  params: {
+    contentType: ContentType;
+    contentId: string | null;
+    content: Record<string, unknown>;
+    casts: CastEntry[];
+  }
+): Promise<{ error?: string; notFound?: boolean }> {
+  const { error } = await supabase.rpc("upsert_content_with_casts", {
+    p_content_type: params.contentType,
+    p_content_id: params.contentId,
+    p_content: params.content,
+    p_casts: params.casts.map((c) => ({ type: c.type, id: c.id })),
+  });
+
+  if (error) {
+    // PL/pgSQL の no_data_found(SQLSTATE P0002)= 更新対象が見つからない
+    return { error: error.message, notFound: error.code === "P0002" };
+  }
+
+  return {};
+}

--- a/src/lib/actions/lives.test.ts
+++ b/src/lib/actions/lives.test.ts
@@ -13,6 +13,7 @@ vi.mock("next/navigation", () => ({
 const supabaseMock = vi.hoisted(() => ({
   auth: { getUser: vi.fn() },
   from: vi.fn(),
+  rpc: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -37,6 +38,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } } });
   supabaseMock.from.mockReset();
+  supabaseMock.rpc.mockReset();
 });
 
 describe("createLive", () => {
@@ -84,44 +86,29 @@ describe("createLive", () => {
   });
 
   it("event_date が空でも作成は進む（必須ではない）", async () => {
-    const insertSelectSingle = vi.fn().mockResolvedValue({
-      data: { id: "11111111-1111-4111-8111-111111111111" },
+    supabaseMock.rpc.mockResolvedValue({
+      data: "11111111-1111-4111-8111-111111111111",
       error: null,
-    });
-    const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
-    const insertChain = vi.fn(() => ({ select: insertSelect }));
-    const deleteEqContent = vi.fn().mockResolvedValue({ error: null });
-    const deleteEqType = vi.fn(() => ({ eq: deleteEqContent }));
-    const deleteChain = vi.fn(() => ({ eq: deleteEqType }));
-
-    supabaseMock.from.mockImplementation((table: string) => {
-      if (table === "lives") return { insert: insertChain };
-      if (table === "casts") return { delete: deleteChain };
-      throw new Error(`unexpected table: ${table}`);
     });
 
     const fd = buildFormData({ title: "テスト" });
     await expect(createLive({}, fd)).rejects.toThrow(/__REDIRECT__/);
-    expect(insertChain).toHaveBeenCalledWith(
-      expect.objectContaining({ event_date: null, start_time: null })
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "upsert_content_with_casts",
+      expect.objectContaining({
+        p_content_type: "live",
+        p_content: expect.objectContaining({
+          event_date: null,
+          start_time: null,
+        }),
+      })
     );
   });
 
   it("event_date と start_time から ISO 形式の開始時刻を組み立てる", async () => {
-    const insertSelectSingle = vi.fn().mockResolvedValue({
-      data: { id: "11111111-1111-4111-8111-111111111111" },
+    supabaseMock.rpc.mockResolvedValue({
+      data: "11111111-1111-4111-8111-111111111111",
       error: null,
-    });
-    const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
-    const insertChain = vi.fn(() => ({ select: insertSelect }));
-    const deleteEqContent = vi.fn().mockResolvedValue({ error: null });
-    const deleteEqType = vi.fn(() => ({ eq: deleteEqContent }));
-    const deleteChain = vi.fn(() => ({ eq: deleteEqType }));
-
-    supabaseMock.from.mockImplementation((table: string) => {
-      if (table === "lives") return { insert: insertChain };
-      if (table === "casts") return { delete: deleteChain };
-      throw new Error(`unexpected table: ${table}`);
     });
 
     const fd = buildFormData({
@@ -130,10 +117,14 @@ describe("createLive", () => {
       start_time: "19:30",
     });
     await expect(createLive({}, fd)).rejects.toThrow(/__REDIRECT__/);
-    expect(insertChain).toHaveBeenCalledWith(
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "upsert_content_with_casts",
       expect.objectContaining({
-        event_date: "2026-05-14",
-        start_time: "2026-05-14T19:30:00",
+        p_content_type: "live",
+        p_content: expect.objectContaining({
+          event_date: "2026-05-14",
+          start_time: "2026-05-14T19:30:00",
+        }),
       })
     );
   });

--- a/src/lib/actions/lives.test.ts
+++ b/src/lib/actions/lives.test.ts
@@ -153,6 +153,56 @@ describe("updateLive", () => {
     );
     expect(result.fieldErrors?.event_date).toBeDefined();
   });
+
+  it("RPC を呼び出して更新する（redirectまで進む）", async () => {
+    supabaseMock.rpc.mockResolvedValue({
+      data: "11111111-1111-4111-8111-111111111111",
+      error: null,
+    });
+
+    const fd = buildFormData({ title: "更新後ライブ" });
+    await expect(
+      updateLive("11111111-1111-4111-8111-111111111111", {}, fd)
+    ).rejects.toThrow(/__REDIRECT__/);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "upsert_content_with_casts",
+      expect.objectContaining({
+        p_content_type: "live",
+        p_content_id: "11111111-1111-4111-8111-111111111111",
+      })
+    );
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("RPC が not found を返した場合は既存メッセージを返す", async () => {
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { code: "P0002", message: "not found" },
+    });
+
+    const fd = buildFormData({ title: "テスト" });
+    const result = await updateLive(
+      "11111111-1111-4111-8111-111111111111",
+      {},
+      fd
+    );
+    expect(result.error).toBe("指定されたライブが見つかりません");
+  });
+
+  it("RPC が汎用エラーを返した場合は整形したメッセージを返す", async () => {
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { code: "23505", message: "duplicate key" },
+    });
+
+    const fd = buildFormData({ title: "テスト" });
+    const result = await updateLive(
+      "11111111-1111-4111-8111-111111111111",
+      {},
+      fd
+    );
+    expect(result.error).toBe("ライブの更新に失敗しました: duplicate key");
+  });
 });
 
 describe("deleteLive", () => {

--- a/src/lib/actions/lives.ts
+++ b/src/lib/actions/lives.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { LiveFormState, LiveInput } from "@/lib/types/live";
+import { upsertContentWithCasts } from "./casts";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -106,40 +107,6 @@ function parseFormData(formData: FormData): {
   return { values, casts, fieldErrors };
 }
 
-async function replaceCasts(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  liveId: string,
-  casts: CastEntry[]
-): Promise<{ error?: string }> {
-  const { error: deleteError } = await supabase
-    .from("casts")
-    .delete()
-    .eq("content_type", "live")
-    .eq("content_id", liveId);
-
-  if (deleteError) {
-    return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
-  }
-
-  if (casts.length === 0) return {};
-
-  const rows = casts.map((c) => ({
-    content_type: "live",
-    content_id: liveId,
-    artist_id: c.type === "artist" ? c.id : null,
-    comedy_group_id: c.type === "comedy_group" ? c.id : null,
-    unit_id: c.type === "unit" ? c.id : null,
-  }));
-
-  const { error: insertError } = await supabase.from("casts").insert(rows);
-
-  if (insertError) {
-    return { error: `出演者の追加に失敗しました: ${insertError.message}` };
-  }
-
-  return {};
-}
-
 export async function createLive(
   _prev: LiveFormState,
   formData: FormData
@@ -156,21 +123,14 @@ export async function createLive(
     return { error: "認証が必要です" };
   }
 
-  const { data, error } = await supabase
-    .from("lives")
-    .insert(values)
-    .select("id")
-    .single();
-
-  if (error || !data) {
-    return {
-      error: `ライブの登録に失敗しました: ${error?.message ?? "unknown"}`,
-    };
-  }
-
-  const castsResult = await replaceCasts(supabase, data.id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "live",
+    contentId: null,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return { error: `ライブの登録に失敗しました: ${result.error}` };
   }
 
   revalidatePath("/admin/lives");
@@ -198,24 +158,18 @@ export async function updateLive(
     return { error: "認証が必要です" };
   }
 
-  const { error, count } = await supabase
-    .from("lives")
-    .update(
-      { ...values, updated_at: new Date().toISOString() },
-      { count: "exact" }
-    )
-    .eq("id", id);
-
-  if (error) {
-    return { error: `ライブの更新に失敗しました: ${error.message}` };
-  }
-  if (count !== 1) {
-    return { error: "指定されたライブが見つかりません" };
-  }
-
-  const castsResult = await replaceCasts(supabase, id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "live",
+    contentId: id,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return {
+      error: result.notFound
+        ? "指定されたライブが見つかりません"
+        : `ライブの更新に失敗しました: ${result.error}`,
+    };
   }
 
   revalidatePath("/admin/lives");

--- a/src/lib/actions/radios.ts
+++ b/src/lib/actions/radios.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { RadioFormState, RadioInput } from "@/lib/types/radio";
+import { upsertContentWithCasts } from "./casts";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -78,40 +79,6 @@ function parseFormData(formData: FormData): {
   return { values, casts, fieldErrors };
 }
 
-async function replaceCasts(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  radioId: string,
-  casts: CastEntry[]
-): Promise<{ error?: string }> {
-  const { error: deleteError } = await supabase
-    .from("casts")
-    .delete()
-    .eq("content_type", "radio")
-    .eq("content_id", radioId);
-
-  if (deleteError) {
-    return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
-  }
-
-  if (casts.length === 0) return {};
-
-  const rows = casts.map((c) => ({
-    content_type: "radio",
-    content_id: radioId,
-    artist_id: c.type === "artist" ? c.id : null,
-    comedy_group_id: c.type === "comedy_group" ? c.id : null,
-    unit_id: c.type === "unit" ? c.id : null,
-  }));
-
-  const { error: insertError } = await supabase.from("casts").insert(rows);
-
-  if (insertError) {
-    return { error: `出演者の追加に失敗しました: ${insertError.message}` };
-  }
-
-  return {};
-}
-
 export async function createRadio(
   _prev: RadioFormState,
   formData: FormData
@@ -128,21 +95,14 @@ export async function createRadio(
     return { error: "認証が必要です" };
   }
 
-  const { data, error } = await supabase
-    .from("radios")
-    .insert(values)
-    .select("id")
-    .single();
-
-  if (error || !data) {
-    return {
-      error: `ラジオの登録に失敗しました: ${error?.message ?? "unknown"}`,
-    };
-  }
-
-  const castsResult = await replaceCasts(supabase, data.id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "radio",
+    contentId: null,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return { error: `ラジオの登録に失敗しました: ${result.error}` };
   }
 
   revalidatePath("/admin/radios");
@@ -170,24 +130,18 @@ export async function updateRadio(
     return { error: "認証が必要です" };
   }
 
-  const { error, count } = await supabase
-    .from("radios")
-    .update(
-      { ...values, updated_at: new Date().toISOString() },
-      { count: "exact" }
-    )
-    .eq("id", id);
-
-  if (error) {
-    return { error: `ラジオの更新に失敗しました: ${error.message}` };
-  }
-  if (count !== 1) {
-    return { error: "指定されたラジオが見つかりません" };
-  }
-
-  const castsResult = await replaceCasts(supabase, id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "radio",
+    contentId: id,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return {
+      error: result.notFound
+        ? "指定されたラジオが見つかりません"
+        : `ラジオの更新に失敗しました: ${result.error}`,
+    };
   }
 
   revalidatePath("/admin/radios");

--- a/src/lib/actions/topics.ts
+++ b/src/lib/actions/topics.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { TopicFormState, TopicInput } from "@/lib/types/topic";
+import { upsertContentWithCasts } from "./casts";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -78,40 +79,6 @@ function parseFormData(formData: FormData): {
   return { values, casts, fieldErrors };
 }
 
-async function replaceCasts(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  topicId: string,
-  casts: CastEntry[]
-): Promise<{ error?: string }> {
-  const { error: deleteError } = await supabase
-    .from("casts")
-    .delete()
-    .eq("content_type", "topic")
-    .eq("content_id", topicId);
-
-  if (deleteError) {
-    return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
-  }
-
-  if (casts.length === 0) return {};
-
-  const rows = casts.map((c) => ({
-    content_type: "topic",
-    content_id: topicId,
-    artist_id: c.type === "artist" ? c.id : null,
-    comedy_group_id: c.type === "comedy_group" ? c.id : null,
-    unit_id: c.type === "unit" ? c.id : null,
-  }));
-
-  const { error: insertError } = await supabase.from("casts").insert(rows);
-
-  if (insertError) {
-    return { error: `出演者の追加に失敗しました: ${insertError.message}` };
-  }
-
-  return {};
-}
-
 export async function createTopic(
   _prev: TopicFormState,
   formData: FormData
@@ -128,21 +95,14 @@ export async function createTopic(
     return { error: "認証が必要です" };
   }
 
-  const { data, error } = await supabase
-    .from("topics")
-    .insert(values)
-    .select("id")
-    .single();
-
-  if (error || !data) {
-    return {
-      error: `トピックの登録に失敗しました: ${error?.message ?? "unknown"}`,
-    };
-  }
-
-  const castsResult = await replaceCasts(supabase, data.id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "topic",
+    contentId: null,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return { error: `トピックの登録に失敗しました: ${result.error}` };
   }
 
   revalidatePath("/admin/topics");
@@ -170,24 +130,18 @@ export async function updateTopic(
     return { error: "認証が必要です" };
   }
 
-  const { error, count } = await supabase
-    .from("topics")
-    .update(
-      { ...values, updated_at: new Date().toISOString() },
-      { count: "exact" }
-    )
-    .eq("id", id);
-
-  if (error) {
-    return { error: `トピックの更新に失敗しました: ${error.message}` };
-  }
-  if (count !== 1) {
-    return { error: "指定されたトピックが見つかりません" };
-  }
-
-  const castsResult = await replaceCasts(supabase, id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "topic",
+    contentId: id,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return {
+      error: result.notFound
+        ? "指定されたトピックが見つかりません"
+        : `トピックの更新に失敗しました: ${result.error}`,
+    };
   }
 
   revalidatePath("/admin/topics");

--- a/src/lib/actions/tv-shows.ts
+++ b/src/lib/actions/tv-shows.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { TvShowFormState, TvShowInput } from "@/lib/types/tv-show";
+import { upsertContentWithCasts } from "./casts";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -79,40 +80,6 @@ function parseFormData(formData: FormData): {
   return { values, casts, fieldErrors };
 }
 
-async function replaceCasts(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  tvShowId: string,
-  casts: CastEntry[]
-): Promise<{ error?: string }> {
-  const { error: deleteError } = await supabase
-    .from("casts")
-    .delete()
-    .eq("content_type", "tv_show")
-    .eq("content_id", tvShowId);
-
-  if (deleteError) {
-    return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
-  }
-
-  if (casts.length === 0) return {};
-
-  const rows = casts.map((c) => ({
-    content_type: "tv_show",
-    content_id: tvShowId,
-    artist_id: c.type === "artist" ? c.id : null,
-    comedy_group_id: c.type === "comedy_group" ? c.id : null,
-    unit_id: c.type === "unit" ? c.id : null,
-  }));
-
-  const { error: insertError } = await supabase.from("casts").insert(rows);
-
-  if (insertError) {
-    return { error: `出演者の追加に失敗しました: ${insertError.message}` };
-  }
-
-  return {};
-}
-
 export async function createTvShow(
   _prev: TvShowFormState,
   formData: FormData
@@ -129,21 +96,14 @@ export async function createTvShow(
     return { error: "認証が必要です" };
   }
 
-  const { data, error } = await supabase
-    .from("tv_shows")
-    .insert(values)
-    .select("id")
-    .single();
-
-  if (error || !data) {
-    return {
-      error: `TV番組の登録に失敗しました: ${error?.message ?? "unknown"}`,
-    };
-  }
-
-  const castsResult = await replaceCasts(supabase, data.id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "tv_show",
+    contentId: null,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return { error: `TV番組の登録に失敗しました: ${result.error}` };
   }
 
   revalidatePath("/admin/tv");
@@ -171,24 +131,18 @@ export async function updateTvShow(
     return { error: "認証が必要です" };
   }
 
-  const { error, count } = await supabase
-    .from("tv_shows")
-    .update(
-      { ...values, updated_at: new Date().toISOString() },
-      { count: "exact" }
-    )
-    .eq("id", id);
-
-  if (error) {
-    return { error: `TV番組の更新に失敗しました: ${error.message}` };
-  }
-  if (count !== 1) {
-    return { error: "指定されたTV番組が見つかりません" };
-  }
-
-  const castsResult = await replaceCasts(supabase, id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "tv_show",
+    contentId: id,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return {
+      error: result.notFound
+        ? "指定されたTV番組が見つかりません"
+        : `TV番組の更新に失敗しました: ${result.error}`,
+    };
   }
 
   revalidatePath("/admin/tv");

--- a/src/lib/actions/videos.test.ts
+++ b/src/lib/actions/videos.test.ts
@@ -13,6 +13,7 @@ vi.mock("next/navigation", () => ({
 const supabaseMock = vi.hoisted(() => ({
   auth: { getUser: vi.fn() },
   from: vi.fn(),
+  rpc: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -37,6 +38,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } } });
   supabaseMock.from.mockReset();
+  supabaseMock.rpc.mockReset();
 });
 
 describe("createVideo", () => {
@@ -65,24 +67,9 @@ describe("createVideo", () => {
   });
 
   it("youtube_video_id が11文字の英数字なら受理する（redirectまで進む）", async () => {
-    const insertSelectSingle = vi.fn().mockResolvedValue({
-      data: { id: "11111111-1111-4111-8111-111111111111" },
+    supabaseMock.rpc.mockResolvedValue({
+      data: "11111111-1111-4111-8111-111111111111",
       error: null,
-    });
-    const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
-    const insertChain = vi.fn(() => ({ select: insertSelect }));
-    const deleteEqContent = vi.fn().mockResolvedValue({ error: null });
-    const deleteEqType = vi.fn(() => ({ eq: deleteEqContent }));
-    const deleteChain = vi.fn(() => ({ eq: deleteEqType }));
-
-    supabaseMock.from.mockImplementation((table: string) => {
-      if (table === "videos") {
-        return { insert: insertChain };
-      }
-      if (table === "casts") {
-        return { delete: deleteChain };
-      }
-      throw new Error(`unexpected table: ${table}`);
     });
 
     const fd = buildFormData({
@@ -91,32 +78,20 @@ describe("createVideo", () => {
     });
 
     await expect(createVideo({}, fd)).rejects.toThrow(/__REDIRECT__/);
-    expect(insertChain).toHaveBeenCalledWith(
-      expect.objectContaining({ youtube_video_id: "abcDEF12345" })
-    );
-    expect(supabaseMock.from).toHaveBeenCalledWith("casts");
-    expect(deleteEqType).toHaveBeenCalledWith("content_type", "video");
-    expect(deleteEqContent).toHaveBeenCalledWith(
-      "content_id",
-      "11111111-1111-4111-8111-111111111111"
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "upsert_content_with_casts",
+      expect.objectContaining({
+        p_content_type: "video",
+        p_content_id: null,
+        p_content: expect.objectContaining({ youtube_video_id: "abcDEF12345" }),
+      })
     );
   });
 
   it("youtube_url から動画IDを抽出する", async () => {
-    const insertSelectSingle = vi.fn().mockResolvedValue({
-      data: { id: "11111111-1111-4111-8111-111111111111" },
+    supabaseMock.rpc.mockResolvedValue({
+      data: "11111111-1111-4111-8111-111111111111",
       error: null,
-    });
-    const insertSelect = vi.fn(() => ({ single: insertSelectSingle }));
-    const insertChain = vi.fn(() => ({ select: insertSelect }));
-    const deleteEqContent = vi.fn().mockResolvedValue({ error: null });
-    const deleteEqType = vi.fn(() => ({ eq: deleteEqContent }));
-    const deleteChain = vi.fn(() => ({ eq: deleteEqType }));
-
-    supabaseMock.from.mockImplementation((table: string) => {
-      if (table === "videos") return { insert: insertChain };
-      if (table === "casts") return { delete: deleteChain };
-      throw new Error(`unexpected table: ${table}`);
     });
 
     const fd = buildFormData({
@@ -125,14 +100,13 @@ describe("createVideo", () => {
     });
 
     await expect(createVideo({}, fd)).rejects.toThrow(/__REDIRECT__/);
-    expect(insertChain).toHaveBeenCalledWith(
-      expect.objectContaining({ youtube_video_id: "abcDEF12345" })
-    );
-    expect(supabaseMock.from).toHaveBeenCalledWith("casts");
-    expect(deleteEqType).toHaveBeenCalledWith("content_type", "video");
-    expect(deleteEqContent).toHaveBeenCalledWith(
-      "content_id",
-      "11111111-1111-4111-8111-111111111111"
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "upsert_content_with_casts",
+      expect.objectContaining({
+        p_content_type: "video",
+        p_content_id: null,
+        p_content: expect.objectContaining({ youtube_video_id: "abcDEF12345" }),
+      })
     );
   });
 

--- a/src/lib/actions/videos.test.ts
+++ b/src/lib/actions/videos.test.ts
@@ -157,6 +157,41 @@ describe("updateVideo", () => {
     );
     expect(result.fieldErrors?.title).toBeDefined();
   });
+
+  it("RPC を呼び出して更新する（redirectまで進む）", async () => {
+    supabaseMock.rpc.mockResolvedValue({
+      data: "11111111-1111-4111-8111-111111111111",
+      error: null,
+    });
+
+    const fd = buildFormData({ title: "更新後タイトル" });
+    await expect(
+      updateVideo("11111111-1111-4111-8111-111111111111", {}, fd)
+    ).rejects.toThrow(/__REDIRECT__/);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "upsert_content_with_casts",
+      expect.objectContaining({
+        p_content_type: "video",
+        p_content_id: "11111111-1111-4111-8111-111111111111",
+      })
+    );
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("RPC が not found を返した場合は既存メッセージを返す", async () => {
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { code: "P0002", message: "not found" },
+    });
+
+    const fd = buildFormData({ title: "テスト" });
+    const result = await updateVideo(
+      "11111111-1111-4111-8111-111111111111",
+      {},
+      fd
+    );
+    expect(result.error).toBe("指定された動画が見つかりません");
+  });
 });
 
 describe("deleteVideo", () => {

--- a/src/lib/actions/videos.ts
+++ b/src/lib/actions/videos.ts
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { CastEntry } from "@/lib/types";
 import type { VideoFormState, VideoInput } from "@/lib/types/video";
 import { extractYoutubeVideoId, YOUTUBE_ID_PATTERN } from "@/lib/utils/youtube";
+import { upsertContentWithCasts } from "./casts";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -93,40 +94,6 @@ function parseFormData(formData: FormData): {
   return { values, casts, fieldErrors };
 }
 
-async function replaceCasts(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  videoId: string,
-  casts: CastEntry[]
-): Promise<{ error?: string }> {
-  const { error: deleteError } = await supabase
-    .from("casts")
-    .delete()
-    .eq("content_type", "video")
-    .eq("content_id", videoId);
-
-  if (deleteError) {
-    return { error: `出演者の削除に失敗しました: ${deleteError.message}` };
-  }
-
-  if (casts.length === 0) return {};
-
-  const rows = casts.map((c) => ({
-    content_type: "video",
-    content_id: videoId,
-    artist_id: c.type === "artist" ? c.id : null,
-    comedy_group_id: c.type === "comedy_group" ? c.id : null,
-    unit_id: c.type === "unit" ? c.id : null,
-  }));
-
-  const { error: insertError } = await supabase.from("casts").insert(rows);
-
-  if (insertError) {
-    return { error: `出演者の追加に失敗しました: ${insertError.message}` };
-  }
-
-  return {};
-}
-
 export async function createVideo(
   _prev: VideoFormState,
   formData: FormData
@@ -143,21 +110,14 @@ export async function createVideo(
     return { error: "認証が必要です" };
   }
 
-  const { data, error } = await supabase
-    .from("videos")
-    .insert(values)
-    .select("id")
-    .single();
-
-  if (error || !data) {
-    return {
-      error: `動画の登録に失敗しました: ${error?.message ?? "unknown"}`,
-    };
-  }
-
-  const castsResult = await replaceCasts(supabase, data.id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "video",
+    contentId: null,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return { error: `動画の登録に失敗しました: ${result.error}` };
   }
 
   revalidatePath("/admin/videos");
@@ -185,24 +145,18 @@ export async function updateVideo(
     return { error: "認証が必要です" };
   }
 
-  const { error, count } = await supabase
-    .from("videos")
-    .update(
-      { ...values, updated_at: new Date().toISOString() },
-      { count: "exact" }
-    )
-    .eq("id", id);
-
-  if (error) {
-    return { error: `動画の更新に失敗しました: ${error.message}` };
-  }
-  if (count !== 1) {
-    return { error: "指定された動画が見つかりません" };
-  }
-
-  const castsResult = await replaceCasts(supabase, id, casts);
-  if (castsResult.error) {
-    return { error: castsResult.error };
+  const result = await upsertContentWithCasts(supabase, {
+    contentType: "video",
+    contentId: id,
+    content: values,
+    casts,
+  });
+  if (result.error) {
+    return {
+      error: result.notFound
+        ? "指定された動画が見つかりません"
+        : `動画の更新に失敗しました: ${result.error}`,
+    };
   }
 
   revalidatePath("/admin/videos");

--- a/supabase/migrations/006_upsert_content_with_casts.sql
+++ b/supabase/migrations/006_upsert_content_with_casts.sql
@@ -1,0 +1,101 @@
+-- ============================================
+-- コンテンツ + 出演者(casts) のアトミックな upsert
+-- ============================================
+-- 各コンテンツ(video / live / radio / article / tv_show / topic)の
+-- Server Action は、メインレコードの insert/update と casts の置き換え
+-- (delete → insert)を別クエリで実行しており非アトミックだった。
+-- 片方が失敗するとデータ不整合(出演者なしレコード / 出演者全消去)が
+-- 起こりうるため、両者を 1 つの関数 = 1 トランザクションにまとめる。
+--
+-- casts は #47 で単一テーブルに統合済みのため、6 コンテンツを
+-- 1 つの汎用関数で扱える。
+
+create or replace function upsert_content_with_casts(
+  p_content_type text,
+  p_content_id   uuid,   -- null の場合は INSERT、指定時は UPDATE
+  p_content      jsonb,  -- メインレコードのカラム(キー名 = カラム名)
+  p_casts        jsonb   -- [{ "type": "artist|comedy_group|unit", "id": "<uuid>" }, ...]
+)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_table text;
+  v_id    uuid;
+  v_cols  text;
+  v_set   text;
+  v_count int;
+begin
+  -- content_type をホワイトリスト検証してテーブル名に解決する
+  v_table := case p_content_type
+    when 'video'   then 'videos'
+    when 'live'    then 'lives'
+    when 'radio'   then 'radios'
+    when 'article' then 'articles'
+    when 'tv_show' then 'tv_shows'
+    when 'topic'   then 'topics'
+  end;
+  if v_table is null then
+    raise exception 'content_type が不正です: %', p_content_type;
+  end if;
+
+  -- 対象カラム一覧(jsonb のキー = カラム名)
+  select string_agg(quote_ident(key), ', ')
+    into v_cols
+    from jsonb_object_keys(p_content) as key;
+  if v_cols is null then
+    raise exception 'content が空です';
+  end if;
+
+  if p_content_id is null then
+    -- INSERT: p_content に含まれるカラムのみ指定し、残りは既定値に任せる
+    execute format(
+      'insert into %I (%s) select %s from jsonb_populate_record(null::%I, $1) returning id',
+      v_table, v_cols, v_cols, v_table
+    )
+    using p_content
+    into v_id;
+  else
+    -- UPDATE: updated_at は常に現在時刻で更新する
+    v_id := p_content_id;
+    select string_agg(format('%I = r.%I', key, key), ', ')
+      into v_set
+      from jsonb_object_keys(p_content) as key;
+    execute format(
+      'update %I as t set %s, updated_at = now() '
+      'from jsonb_populate_record(null::%I, $1) as r where t.id = $2',
+      v_table, v_set, v_table
+    )
+    using p_content, v_id;
+
+    get diagnostics v_count = row_count;
+    if v_count <> 1 then
+      raise exception '指定されたコンテンツが見つかりません'
+        using errcode = 'no_data_found';
+    end if;
+  end if;
+
+  -- casts の置き換え(delete → insert)を同一トランザクション内で実行する
+  delete from casts
+   where content_type = p_content_type
+     and content_id = v_id;
+
+  insert into casts (content_type, content_id, artist_id, comedy_group_id, unit_id)
+  select
+    p_content_type,
+    v_id,
+    case when c->>'type' = 'artist'       then (c->>'id')::uuid end,
+    case when c->>'type' = 'comedy_group' then (c->>'id')::uuid end,
+    case when c->>'type' = 'unit'         then (c->>'id')::uuid end
+  from jsonb_array_elements(coalesce(p_casts, '[]'::jsonb)) as c;
+
+  return v_id;
+end;
+$$;
+
+comment on function upsert_content_with_casts(text, uuid, jsonb, jsonb) is
+  'コンテンツのメインレコード upsert と casts の置き換えを 1 トランザクションで実行する(#64)';
+
+-- 書き込みは認証ユーザーのみ。anon からの実行は禁止する。
+revoke execute on function upsert_content_with_casts(text, uuid, jsonb, jsonb) from public;
+grant execute on function upsert_content_with_casts(text, uuid, jsonb, jsonb) to authenticated;


### PR DESCRIPTION
## 概要

各コンテンツ（video / live / radio / article / tv_show / topic）の Server Action は、メインレコードの insert/update と `casts` の置き換え（delete → insert）を**別クエリ**で実行しており非アトミックでした。片方が失敗すると以下のデータ不整合が発生しうる状態でした。

- メインレコード insert 成功 → casts 置き換え失敗 → **出演者なしレコードが残る**
- 既存 casts の delete 成功 → 新 casts の insert 失敗 → **出演者が全消去された状態で残る**

`casts` は #47 で単一テーブルに統合済みのため、issue 補足の **B案（統合後に1つのRPCにまとめる）** に沿って、6コンテンツ共通の汎用RPC 1本にまとめました。

## 変更内容

### DB（migration 006）

- 汎用RPC `upsert_content_with_casts(content_type, content_id, content, casts)` を追加
  - メインレコードの upsert と `casts` の置き換えを**1トランザクション**で実行（途中失敗時は全ロールバック）
  - `content_type` はホワイトリストでテーブル名に解決、`jsonb_populate_record` で6コンテンツを単一関数で処理
  - `SECURITY INVOKER`（RLS 有効のまま）+ 実行権限は `authenticated` のみに制限

### アプリ側

- `src/lib/actions/casts.ts` — RPCラッパー `upsertContentWithCasts` を追加（6ファイルに重複していた `replaceCasts` を集約）
- video / live / radio / article / tv_show / topic の各 Server Action の create / update を RPC 呼び出しに置き換え、`replaceCasts` を削除
- 更新対象が存在しない場合は `no_data_found`（SQLSTATE P0002）で検知し、従来の「指定された〇〇が見つかりません」メッセージを維持

### テスト

- videos / lives / articles のテストを RPC 呼び出し前提に更新（全112テスト pass）

## 確認事項

- `pnpm test` 全112テスト pass / `pnpm lint` clean
- 変更ファイルは型エラーなし（`tsc` で出る既存の型エラー3件は今回未変更のファイルで本PRのスコープ外）

Closes #64


---
_Generated by [Claude Code](https://claude.ai/code/session_012b4Duhp8b7yRNbzPXmZQZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal persistence and data-handling logic across multiple content types (articles, lives, radios, topics, TV shows, and videos) through a shared utility, reducing code duplication and improving overall system maintainability and reliability. These changes are internal architectural improvements with no visible impact on user-facing functionality or end-user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->