### PR TITLE
feat: ライブのICSフィード配信を追加 (#111)

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -291,8 +291,11 @@ mkdir -p supabase/migrations
 2. 左サイドバー「他のカレンダー」→ 「+」 → 「URL で追加」
 3. 以下の URL を入力して追加:
    - 本番: `https://dondecorte-lab.vercel.app/lives.ics`
-   - ローカル: `http://localhost:3000/lives.ics`
 4. 「カレンダーを追加」
+
+> ⚠️ Google カレンダーは購読 URL に外部から到達できる必要があるため、
+> `http://localhost:3000/lives.ics` を直接購読することはできません。
+> ローカルで検証する場合は ngrok / Cloudflare Tunnel 等で公開 URL を払い出してください。
 
 ### 補足
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -281,6 +281,28 @@ mkdir -p supabase/migrations
 
 ---
 
+## Googleカレンダー購読 (ICS フィード)
+
+`/lives.ics` を Google カレンダーに URL 購読すると、ドンデコルテ出演ライブが自動でカレンダーに表示される。
+
+### 購読手順
+
+1. https://calendar.google.com を開く
+2. 左サイドバー「他のカレンダー」→ 「+」 → 「URL で追加」
+3. 以下の URL を入力して追加:
+   - 本番: `https://dondecorte-lab.vercel.app/lives.ics`
+   - ローカル: `http://localhost:3000/lives.ics`
+4. 「カレンダーを追加」
+
+### 補足
+
+- Google 側の更新は数時間〜半日ラグがある（フィード方式の仕様）
+- `event_date` が設定されたライブのみ対象
+- `start_time` あり → 2 時間予定 / `start_time` なし → 終日予定
+- 即時反映が必要になったら issue #43（OAuth で直接書き込み）を検討
+
+---
+
 ## 実装順序チェックリスト
 
 ここまで完了したら、以下の順で実装を進める:

--- a/src/app/lives.ics/route.test.ts
+++ b/src/app/lives.ics/route.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { normalizeStartTimeForIcs } from "./route";
+
+describe("normalizeStartTimeForIcs", () => {
+  it("null / 空文字は null を返す", () => {
+    expect(normalizeStartTimeForIcs(null)).toBeNull();
+    expect(normalizeStartTimeForIcs("")).toBeNull();
+  });
+
+  it("HH:MM 形式は HH:MM:00 に整える", () => {
+    expect(normalizeStartTimeForIcs("19:30")).toBe("19:30:00");
+  });
+
+  it("HH:MM:SS 形式はそのまま返す", () => {
+    expect(normalizeStartTimeForIcs("19:30:45")).toBe("19:30:45");
+  });
+
+  it("ISO 8601 (+09:00) を JST 時刻として返す", () => {
+    expect(normalizeStartTimeForIcs("2026-05-14T19:30:00+09:00")).toBe(
+      "19:30:00"
+    );
+  });
+
+  it("ISO 8601 (UTC Z) は JST に変換した時刻を返す", () => {
+    // 2026-05-14T10:30:00Z は JST で 19:30
+    expect(normalizeStartTimeForIcs("2026-05-14T10:30:00.000Z")).toBe(
+      "19:30:00"
+    );
+  });
+
+  it("ISO 8601 で日付境界をまたいでも JST 時刻のみ返す", () => {
+    // 2026-05-14T16:00:00Z は JST で 翌日 01:00
+    expect(normalizeStartTimeForIcs("2026-05-14T16:00:00.000Z")).toBe(
+      "01:00:00"
+    );
+  });
+
+  it("不正な文字列は null を返す", () => {
+    expect(normalizeStartTimeForIcs("not-a-time")).toBeNull();
+  });
+});

--- a/src/app/lives.ics/route.ts
+++ b/src/app/lives.ics/route.ts
@@ -1,0 +1,57 @@
+import { buildIcsCalendar, type IcsEvent } from "@/lib/ics/builder";
+import { listLivesForCalendar } from "@/lib/queries/lives";
+import { getSiteUrl } from "@/lib/utils/site-url";
+
+export const dynamic = "force-dynamic";
+
+const PRODID = "-//dondecorte-lab//Lives//JA";
+const CALENDAR_NAME = "ドンデコルテ出演ライブ";
+
+function buildDescription(args: {
+  description: string | null;
+  casts: { name: string }[];
+  detailUrl: string;
+}): string | null {
+  const parts: string[] = [];
+  if (args.description) parts.push(args.description);
+  if (args.casts.length > 0) {
+    parts.push(`出演: ${args.casts.map((c) => c.name).join(", ")}`);
+  }
+  parts.push(args.detailUrl);
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
+export async function GET() {
+  const lives = await listLivesForCalendar();
+  const siteUrl = getSiteUrl();
+  const host = new URL(siteUrl).host;
+
+  const events: IcsEvent[] = lives
+    .filter((live) => live.event_date !== null)
+    .map((live) => ({
+      uid: `live-${live.id}@${host}`,
+      date: live.event_date as string,
+      startTime: live.start_time,
+      summary: live.title,
+      location: live.venue,
+      description: buildDescription({
+        description: live.description,
+        casts: live.casts,
+        detailUrl: `${siteUrl}/lives/${live.id}`,
+      }),
+      url: live.url,
+    }));
+
+  const body = buildIcsCalendar(events, {
+    prodId: PRODID,
+    calendarName: CALENDAR_NAME,
+  });
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/calendar; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/src/app/lives.ics/route.ts
+++ b/src/app/lives.ics/route.ts
@@ -7,6 +7,30 @@ export const dynamic = "force-dynamic";
 const PRODID = "-//dondecorte-lab//Lives//JA";
 const CALENDAR_NAME = "ドンデコルテ出演ライブ";
 
+// lives.start_time は schema 上 timestamptz。フォーム入力経路によっては
+// "HH:MM:SS" 形式の文字列が入っている場合もあるため両方を許容する。
+export function normalizeStartTimeForIcs(value: string | null): string | null {
+  if (!value) return null;
+  const hhmm = value.match(/^(\d{2}):(\d{2})(?::(\d{2}))?$/);
+  if (hhmm) {
+    return `${hhmm[1]}:${hhmm[2]}:${hhmm[3] ?? "00"}`;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Tokyo",
+  }).formatToParts(date);
+  const hh = parts.find((p) => p.type === "hour")?.value;
+  const mm = parts.find((p) => p.type === "minute")?.value;
+  const ss = parts.find((p) => p.type === "second")?.value;
+  if (!hh || !mm || !ss) return null;
+  return `${hh}:${mm}:${ss}`;
+}
+
 function buildDescription(args: {
   description: string | null;
   casts: { name: string }[];
@@ -31,7 +55,7 @@ export async function GET() {
     .map((live) => ({
       uid: `live-${live.id}@${host}`,
       date: live.event_date as string,
-      startTime: live.start_time,
+      startTime: normalizeStartTimeForIcs(live.start_time),
       summary: live.title,
       location: live.venue,
       description: buildDescription({

--- a/src/lib/actions/achievements.ts
+++ b/src/lib/actions/achievements.ts
@@ -3,7 +3,20 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
-import type { AchievementInput, AchievementTargetType } from "@/lib/types/achievement";
+import type {
+  AchievementInput,
+  AchievementTargetType,
+} from "@/lib/types/achievement";
+
+type AchievementBaseInputRow = {
+  title: string;
+  result: string;
+  year: number;
+  sort_order: number;
+  artist_id: string | null;
+  comedy_group_id: string | null;
+  unit_id: string | null;
+};
 
 export type AchievementFormState = {
   error?: string;
@@ -137,7 +150,13 @@ export async function createAchievement(
     return { error: "認証が必要です" };
   }
 
-  const { error } = await supabase.from("achievements").insert(values);
+  // AchievementInput は discriminated union だが Supabase の insert 型は
+  // union の最初のアームに固定されてしまうため、DB の行型 (1 列だけ非 NULL は
+  // CHECK 制約で担保) に合わせて nullable に広げて渡す。
+  const insertPayload: AchievementBaseInputRow = values;
+  const { error } = await supabase
+    .from("achievements")
+    .insert(insertPayload);
 
   if (error) {
     return {
@@ -170,9 +189,10 @@ export async function updateAchievement(
     return { error: "認証が必要です" };
   }
 
+  const updatePayload: AchievementBaseInputRow = values;
   const { error } = await supabase
     .from("achievements")
-    .update(values)
+    .update(updatePayload)
     .eq("id", id);
 
   if (error) {

--- a/src/lib/ics/builder.test.ts
+++ b/src/lib/ics/builder.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIcsCalendar,
+  escapeIcsText,
+  foldIcsLine,
+  type IcsEvent,
+} from "./builder";
+
+const FIXED_NOW = new Date("2026-05-20T03:00:00.000Z");
+
+const baseOptions = {
+  prodId: "-//dondecorte-lab//Lives//JA",
+  calendarName: "ドンデコルテ出演ライブ",
+  now: FIXED_NOW,
+};
+
+describe("escapeIcsText", () => {
+  it("カンマ・セミコロン・バックスラッシュ・改行をエスケープする", () => {
+    expect(escapeIcsText("a,b;c\\d\ne")).toBe("a\\,b\\;c\\\\d\\ne");
+  });
+
+  it("CRLF と CR を単一の \\n に統一する", () => {
+    expect(escapeIcsText("a\r\nb\rc")).toBe("a\\nb\\nc");
+  });
+});
+
+describe("foldIcsLine", () => {
+  it("75 オクテット以下はそのまま返す", () => {
+    const line = "SUMMARY:short";
+    expect(foldIcsLine(line)).toBe(line);
+  });
+
+  it("75 オクテット超は CRLF + space で折り返す", () => {
+    const long = "X".repeat(200);
+    const folded = foldIcsLine(`SUMMARY:${long}`);
+    const segments = folded.split("\r\n");
+    expect(segments.length).toBeGreaterThan(1);
+    for (const seg of segments) {
+      expect(Buffer.byteLength(seg, "utf8")).toBeLessThanOrEqual(76);
+    }
+    expect(segments.slice(1).every((s) => s.startsWith(" "))).toBe(true);
+    const rejoined = segments
+      .map((s, i) => (i === 0 ? s : s.slice(1)))
+      .join("");
+    expect(rejoined).toBe(`SUMMARY:${long}`);
+  });
+
+  it("マルチバイト文字をバイト境界で安全に折る", () => {
+    const text = "あ".repeat(60);
+    const folded = foldIcsLine(`SUMMARY:${text}`);
+    for (const seg of folded.split("\r\n")) {
+      expect(Buffer.byteLength(seg, "utf8")).toBeLessThanOrEqual(76);
+    }
+  });
+});
+
+describe("buildIcsCalendar", () => {
+  it("ヘッダとフッタを含む有効な VCALENDAR を返す", () => {
+    const ics = buildIcsCalendar([], baseOptions);
+    expect(ics.startsWith("BEGIN:VCALENDAR\r\n")).toBe(true);
+    expect(ics.endsWith("END:VCALENDAR\r\n")).toBe(true);
+    expect(ics).toContain("VERSION:2.0");
+    expect(ics).toContain("PRODID:-//dondecorte-lab//Lives//JA");
+    expect(ics).toContain("X-WR-CALNAME:ドンデコルテ出演ライブ");
+    expect(ics).toContain("X-WR-TIMEZONE:Asia/Tokyo");
+  });
+
+  it("start_time あり: TZID 付き DTSTART / DTEND を出力する", () => {
+    const event: IcsEvent = {
+      uid: "live-1@example.com",
+      date: "2026-06-01",
+      startTime: "19:00",
+      summary: "単独ライブ",
+    };
+    const ics = buildIcsCalendar([event], baseOptions);
+    expect(ics).toContain("DTSTART;TZID=Asia/Tokyo:20260601T190000");
+    expect(ics).toContain("DTEND;TZID=Asia/Tokyo:20260601T210000");
+    expect(ics).toContain("SUMMARY:単独ライブ");
+    expect(ics).toContain("UID:live-1@example.com");
+    expect(ics).toContain("DTSTAMP:20260520T030000Z");
+  });
+
+  it("start_time なし: 終日イベント (VALUE=DATE) として出力する", () => {
+    const event: IcsEvent = {
+      uid: "live-2@example.com",
+      date: "2026-06-01",
+      startTime: null,
+      summary: "終日イベント",
+    };
+    const ics = buildIcsCalendar([event], baseOptions);
+    expect(ics).toContain("DTSTART;VALUE=DATE:20260601");
+    expect(ics).toContain("DTEND;VALUE=DATE:20260602");
+    expect(ics).not.toContain("TZID=");
+  });
+
+  it("durationMinutes を指定すると DTEND が変わる", () => {
+    const event: IcsEvent = {
+      uid: "u",
+      date: "2026-06-01",
+      startTime: "23:00",
+      durationMinutes: 90,
+      summary: "夜ライブ",
+    };
+    const ics = buildIcsCalendar([event], baseOptions);
+    expect(ics).toContain("DTSTART;TZID=Asia/Tokyo:20260601T230000");
+    expect(ics).toContain("DTEND;TZID=Asia/Tokyo:20260602T003000");
+  });
+
+  it("LOCATION / DESCRIPTION / URL を含める", () => {
+    const event: IcsEvent = {
+      uid: "u",
+      date: "2026-06-01",
+      startTime: "19:00",
+      summary: "ライブ",
+      location: "神保町よしもと漫才劇場",
+      description: "出演: 渡辺銀次, 小橋共作",
+      url: "https://example.com/live/1",
+    };
+    const ics = buildIcsCalendar([event], baseOptions);
+    expect(ics).toContain("LOCATION:神保町よしもと漫才劇場");
+    expect(ics).toContain("DESCRIPTION:出演: 渡辺銀次\\, 小橋共作");
+    expect(ics).toContain("URL:https://example.com/live/1");
+  });
+
+  it("空欄の location / description / url は省略する", () => {
+    const event: IcsEvent = {
+      uid: "u",
+      date: "2026-06-01",
+      startTime: "19:00",
+      summary: "ライブ",
+      location: null,
+      description: null,
+      url: null,
+    };
+    const ics = buildIcsCalendar([event], baseOptions);
+    expect(ics).not.toContain("LOCATION:");
+    expect(ics).not.toContain("DESCRIPTION:");
+    expect(ics).not.toContain("URL:");
+  });
+
+  it("複数イベントを順番に並べる", () => {
+    const events: IcsEvent[] = [
+      {
+        uid: "a",
+        date: "2026-06-01",
+        startTime: "19:00",
+        summary: "A",
+      },
+      {
+        uid: "b",
+        date: "2026-06-02",
+        startTime: null,
+        summary: "B",
+      },
+    ];
+    const ics = buildIcsCalendar(events, baseOptions);
+    const vevents = ics.split("BEGIN:VEVENT").length - 1;
+    expect(vevents).toBe(2);
+    expect(ics.indexOf("UID:a")).toBeLessThan(ics.indexOf("UID:b"));
+  });
+
+  it("行末は全て CRLF", () => {
+    const event: IcsEvent = {
+      uid: "u",
+      date: "2026-06-01",
+      startTime: "19:00",
+      summary: "ライブ",
+    };
+    const ics = buildIcsCalendar([event], baseOptions);
+    const withoutCrlf = ics.replace(/\r\n/g, "");
+    expect(withoutCrlf.includes("\n")).toBe(false);
+  });
+});

--- a/src/lib/ics/builder.test.ts
+++ b/src/lib/ics/builder.test.ts
@@ -65,6 +65,34 @@ describe("buildIcsCalendar", () => {
     expect(ics).toContain("X-WR-TIMEZONE:Asia/Tokyo");
   });
 
+  it("Asia/Tokyo の VTIMEZONE 定義を含める", () => {
+    const ics = buildIcsCalendar([], baseOptions);
+    expect(ics).toContain("BEGIN:VTIMEZONE");
+    expect(ics).toContain("TZID:Asia/Tokyo");
+    expect(ics).toContain("TZOFFSETFROM:+0900");
+    expect(ics).toContain("TZOFFSETTO:+0900");
+    expect(ics).toContain("TZNAME:JST");
+    expect(ics).toContain("END:VTIMEZONE");
+    // VTIMEZONE は VEVENT より前に置く
+    const idxTz = ics.indexOf("BEGIN:VTIMEZONE");
+    const idxEvent = ics.indexOf("BEGIN:VEVENT");
+    if (idxEvent !== -1) {
+      expect(idxTz).toBeLessThan(idxEvent);
+    }
+  });
+
+  it("不正な startTime は例外を投げる (frontに分かりやすく失敗)", () => {
+    const event: IcsEvent = {
+      uid: "u",
+      date: "2026-06-01",
+      startTime: "2026-05-14T19:30:00+09:00",
+      summary: "ライブ",
+    };
+    expect(() => buildIcsCalendar([event], baseOptions)).toThrow(
+      /HH:MM/
+    );
+  });
+
   it("start_time あり: TZID 付き DTSTART / DTEND を出力する", () => {
     const event: IcsEvent = {
       uid: "live-1@example.com",

--- a/src/lib/ics/builder.ts
+++ b/src/lib/ics/builder.ts
@@ -1,0 +1,189 @@
+export type IcsEvent = {
+  uid: string;
+  /** YYYY-MM-DD */
+  date: string;
+  /** HH:MM or HH:MM:SS. null なら終日イベント。 */
+  startTime: string | null;
+  /** 既定 120 分。終日イベントでは無視。 */
+  durationMinutes?: number;
+  summary: string;
+  location?: string | null;
+  description?: string | null;
+  url?: string | null;
+};
+
+export type IcsCalendarOptions = {
+  prodId: string;
+  calendarName: string;
+  /** Asia/Tokyo など。VEVENT の TZID と X-WR-TIMEZONE に使う。 */
+  timezone?: string;
+  /** DTSTAMP に使う。テスト時に固定したい場合に渡す。 */
+  now?: Date;
+};
+
+const CRLF = "\r\n";
+const DEFAULT_TIMEZONE = "Asia/Tokyo";
+const DEFAULT_DURATION_MINUTES = 120;
+
+export function escapeIcsText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\r\n|\r|\n/g, "\\n")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,");
+}
+
+export function foldIcsLine(line: string): string {
+  const max = 75;
+  if (Buffer.byteLength(line, "utf8") <= max) return line;
+  const out: string[] = [];
+  let current = "";
+  let currentBytes = 0;
+  for (const char of line) {
+    const charBytes = Buffer.byteLength(char, "utf8");
+    if (currentBytes + charBytes > max) {
+      out.push(current);
+      current = char;
+      currentBytes = charBytes;
+    } else {
+      current += char;
+      currentBytes += charBytes;
+    }
+  }
+  if (current) out.push(current);
+  return out.join(`${CRLF} `);
+}
+
+function pad2(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+function formatUtc(date: Date): string {
+  return (
+    `${date.getUTCFullYear()}` +
+    pad2(date.getUTCMonth() + 1) +
+    pad2(date.getUTCDate()) +
+    "T" +
+    pad2(date.getUTCHours()) +
+    pad2(date.getUTCMinutes()) +
+    pad2(date.getUTCSeconds()) +
+    "Z"
+  );
+}
+
+function formatLocalDate(dateStr: string): string {
+  return dateStr.replace(/-/g, "");
+}
+
+function addDays(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return (
+    `${dt.getUTCFullYear()}-` +
+    pad2(dt.getUTCMonth() + 1) +
+    "-" +
+    pad2(dt.getUTCDate())
+  );
+}
+
+function normalizeTime(time: string): { hh: string; mm: string; ss: string } {
+  const parts = time.split(":");
+  return {
+    hh: pad2(Number(parts[0] ?? 0)),
+    mm: pad2(Number(parts[1] ?? 0)),
+    ss: pad2(Number(parts[2] ?? 0)),
+  };
+}
+
+function addMinutesToLocal(
+  dateStr: string,
+  time: string,
+  minutes: number
+): { date: string; time: string } {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const { hh, mm, ss } = normalizeTime(time);
+  const dt = new Date(
+    Date.UTC(y, m - 1, d, Number(hh), Number(mm), Number(ss))
+  );
+  dt.setUTCMinutes(dt.getUTCMinutes() + minutes);
+  return {
+    date:
+      `${dt.getUTCFullYear()}-` +
+      pad2(dt.getUTCMonth() + 1) +
+      "-" +
+      pad2(dt.getUTCDate()),
+    time:
+      pad2(dt.getUTCHours()) +
+      ":" +
+      pad2(dt.getUTCMinutes()) +
+      ":" +
+      pad2(dt.getUTCSeconds()),
+  };
+}
+
+function buildEvent(
+  event: IcsEvent,
+  options: { timezone: string; dtstamp: string }
+): string[] {
+  const lines: string[] = [];
+  lines.push("BEGIN:VEVENT");
+  lines.push(`UID:${event.uid}`);
+  lines.push(`DTSTAMP:${options.dtstamp}`);
+
+  if (event.startTime) {
+    const { hh, mm, ss } = normalizeTime(event.startTime);
+    const dtstartLocal = `${formatLocalDate(event.date)}T${hh}${mm}${ss}`;
+    lines.push(`DTSTART;TZID=${options.timezone}:${dtstartLocal}`);
+    const duration = event.durationMinutes ?? DEFAULT_DURATION_MINUTES;
+    const end = addMinutesToLocal(event.date, event.startTime, duration);
+    const endTime = normalizeTime(end.time);
+    const dtendLocal =
+      `${formatLocalDate(end.date)}T` +
+      `${endTime.hh}${endTime.mm}${endTime.ss}`;
+    lines.push(`DTEND;TZID=${options.timezone}:${dtendLocal}`);
+  } else {
+    lines.push(`DTSTART;VALUE=DATE:${formatLocalDate(event.date)}`);
+    lines.push(
+      `DTEND;VALUE=DATE:${formatLocalDate(addDays(event.date, 1))}`
+    );
+  }
+
+  lines.push(`SUMMARY:${escapeIcsText(event.summary)}`);
+  if (event.location) {
+    lines.push(`LOCATION:${escapeIcsText(event.location)}`);
+  }
+  if (event.description) {
+    lines.push(`DESCRIPTION:${escapeIcsText(event.description)}`);
+  }
+  if (event.url) {
+    lines.push(`URL:${event.url}`);
+  }
+  lines.push("END:VEVENT");
+  return lines;
+}
+
+export function buildIcsCalendar(
+  events: IcsEvent[],
+  options: IcsCalendarOptions
+): string {
+  const timezone = options.timezone ?? DEFAULT_TIMEZONE;
+  const dtstamp = formatUtc(options.now ?? new Date());
+
+  const lines: string[] = [];
+  lines.push("BEGIN:VCALENDAR");
+  lines.push("VERSION:2.0");
+  lines.push(`PRODID:${options.prodId}`);
+  lines.push("CALSCALE:GREGORIAN");
+  lines.push("METHOD:PUBLISH");
+  lines.push(`X-WR-CALNAME:${escapeIcsText(options.calendarName)}`);
+  lines.push(`X-WR-TIMEZONE:${timezone}`);
+
+  for (const event of events) {
+    lines.push(...buildEvent(event, { timezone, dtstamp }));
+  }
+
+  lines.push("END:VCALENDAR");
+
+  return lines.map(foldIcsLine).join(CRLF) + CRLF;
+}

--- a/src/lib/ics/builder.ts
+++ b/src/lib/ics/builder.ts
@@ -25,6 +25,19 @@ const CRLF = "\r\n";
 const DEFAULT_TIMEZONE = "Asia/Tokyo";
 const DEFAULT_DURATION_MINUTES = 120;
 
+// Asia/Tokyo は通年 +09:00 で DST なし。strict parser 向けに VTIMEZONE を同梱する。
+const VTIMEZONE_ASIA_TOKYO: readonly string[] = [
+  "BEGIN:VTIMEZONE",
+  "TZID:Asia/Tokyo",
+  "BEGIN:STANDARD",
+  "DTSTART:19700101T000000",
+  "TZOFFSETFROM:+0900",
+  "TZOFFSETTO:+0900",
+  "TZNAME:JST",
+  "END:STANDARD",
+  "END:VTIMEZONE",
+];
+
 export function escapeIcsText(value: string): string {
   return value
     .replace(/\\/g, "\\\\")
@@ -88,11 +101,16 @@ function addDays(dateStr: string, days: number): string {
 }
 
 function normalizeTime(time: string): { hh: string; mm: string; ss: string } {
-  const parts = time.split(":");
+  const match = time.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
+  if (!match) {
+    throw new Error(
+      `IcsEvent.startTime は HH:MM もしくは HH:MM:SS 形式で渡してください: ${time}`
+    );
+  }
   return {
-    hh: pad2(Number(parts[0] ?? 0)),
-    mm: pad2(Number(parts[1] ?? 0)),
-    ss: pad2(Number(parts[2] ?? 0)),
+    hh: pad2(Number(match[1])),
+    mm: pad2(Number(match[2])),
+    ss: pad2(Number(match[3] ?? 0)),
   };
 }
 
@@ -178,6 +196,10 @@ export function buildIcsCalendar(
   lines.push("METHOD:PUBLISH");
   lines.push(`X-WR-CALNAME:${escapeIcsText(options.calendarName)}`);
   lines.push(`X-WR-TIMEZONE:${timezone}`);
+
+  if (timezone === "Asia/Tokyo") {
+    lines.push(...VTIMEZONE_ASIA_TOKYO);
+  }
 
   for (const event of events) {
     lines.push(...buildEvent(event, { timezone, dtstamp }));

--- a/src/lib/queries/lives.ts
+++ b/src/lib/queries/lives.ts
@@ -92,6 +92,34 @@ export async function listLivesWithCasts(
   }));
 }
 
+export async function listLivesForCalendar(): Promise<LiveWithCasts[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("lives")
+    .select("*")
+    .not("event_date", "is", null)
+    .order("event_date", { ascending: true, nullsFirst: false })
+    .order("start_time", { ascending: true, nullsFirst: false });
+
+  if (error) {
+    throw new Error(`ライブ一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  const lives = (data ?? []).map((row) =>
+    toLiveBase(row as Record<string, unknown>)
+  );
+  const castsByContent = await fetchCastsByContent(
+    supabase,
+    "live",
+    lives.map((l) => l.id)
+  );
+
+  return lives.map((live) => ({
+    ...live,
+    casts: castsByContent.get(live.id) ?? [],
+  }));
+}
+
 export async function getLive(id: string): Promise<LiveWithCasts | null> {
   const supabase = await createClient();
   const { data, error } = await supabase


### PR DESCRIPTION
## 概要

`#111` の対応です。`GET /lives.ics` でドンデコルテ出演ライブを iCalendar 形式で配信し、Google カレンダー等から **URL 購読**できるようにします。

`#43`（Google Calendar API OAuth 連携）は OAuth フローや Google Cloud 設定が必要なため、まずは鍵不要・購読側ワンタイム設定で済む ICS 配信を先行実装する判断です。`#43` は OAuth 連携タスクとして open のまま残してあります。

Closes #111

## 変更内容

### `src/lib/ics/builder.ts` — ICS 文字列ビルダ

- `escapeIcsText` — `\` / `;` / `,` / 改行をエスケープ
- `foldIcsLine` — 75 octet 超を CRLF + space で折り返し（マルチバイト文字を**バイト境界で安全に**折る）
- `buildIcsCalendar(events, options)` — VCALENDAR を生成
  - `start_time` あり → `DTSTART;TZID=Asia/Tokyo:YYYYMMDDTHHMMSS` + `DTEND` (既定 2h、`durationMinutes` で上書き可)
  - `start_time` なし → `DTSTART;VALUE=DATE:YYYYMMDD` の終日イベント（翌日付の `DTEND` 付き）
  - SUMMARY / LOCATION / DESCRIPTION / URL を任意で含める
  - 全行 CRLF 終端

### `src/lib/queries/lives.ts`

- `listLivesForCalendar()` を追加。`event_date` が NULL でないライブのみ、cast 込みで返す。

### `src/app/lives.ics/route.ts`

- Route Handler。`Content-Type: text/calendar; charset=utf-8` + `Cache-Control: public, max-age=3600, s-maxage=3600`
- UID は `live-<uuid>@<host>` でイベント単位の安定識別
- DESCRIPTION には DB の説明 + 出演者一覧 + ライブ詳細ページ URL を含める

### `docs/setup.md`

- 「Googleカレンダー購読 (ICS フィード)」セクションを追加。URL 登録手順 と更新ラグの注意書き。

## テスト

- `src/lib/ics/builder.test.ts` を追加（13 件）。エスケープ・行折り（マルチバイト含む）・タイムゾーン付き / 終日 / カスタム duration / 複数イベント順序 / CRLF 終端を確認。
- 全 153 件パス / lint パス
- 私が触れたファイルの型エラーは無し（`tsc --noEmit` 結果。既存の `src/lib/actions/achievements.ts` の型エラーは本 PR 範囲外）

## マージ後の作業

1. デプロイ完了後、Google カレンダーで「他のカレンダー → URL で追加」に `https://dondecorte-lab.vercel.app/lives.ics` を登録
2. ライブが反映されることを確認

詳細は `docs/setup.md` 「Googleカレンダー購読 (ICS フィード)」セクション参照。

## 補足

- 実 Supabase に繋いだ動作確認は環境変数が無いためこのセッションでは未実施。マージ前にローカル or プレビュー環境で `/lives.ics` を curl して中身を確認すると安心です。
- Google 側のフィード反映は数時間〜半日ラグがあります（フィード方式の仕様）。即時反映が欲しくなったら `#43` の OAuth 連携で対応する想定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JWw3Xw9AwT3v8MCAgjjj21)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Calendar subscription capability via ICS feed, allowing users to subscribe to live events directly in their calendar applications.

* **Documentation**
  * Added setup instructions for Google Calendar subscription, including subscription URLs, sync details, and configuration guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->