### PR TITLE
feat: Web Push 通知基盤を追加 (#96)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,11 @@ SUPABASE_SERVICE_ROLE_KEY=
 # 公開サイトのURL（sitemap / canonical / OGP の絶対URL生成に使用）
 # 例: https://dondecorte-lab.vercel.app
 NEXT_PUBLIC_SITE_URL=
+
+# Web Push（VAPID）。`npx web-push generate-vapid-keys` で一度だけ生成し使い回す。
+# 変更すると既存の購読が全て無効になるので注意。
+# VAPID_PUBLIC_KEY は公開フッターの購読ボタンにも使われる（クライアントへ露出してよい値）。
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+# 連絡先（mailto: 形式 or サイトURL）
+VAPID_SUBJECT=mailto:hiiragi.en22@gmail.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "next": "16.2.5",
         "react": "19.2.6",
         "react-dom": "19.2.6",
-        "react-hook-form": "^7.72.1"
+        "react-hook-form": "^7.72.1",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -27,6 +28,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/web-push": "^3.6.4",
         "@vitejs/plugin-react": "^6.0.1",
         "dotenv": "^17.4.2",
         "eslint": "^9",
@@ -2330,6 +2332,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -2852,6 +2920,16 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.3",
@@ -3579,6 +3657,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -3800,6 +3887,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3892,6 +3991,12 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -3948,6 +4053,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
@@ -4650,7 +4761,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4790,6 +4900,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6001,6 +6120,28 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -6074,6 +6215,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -6697,6 +6844,27 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7132,6 +7300,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -7149,7 +7323,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7168,7 +7341,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -8053,6 +8225,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -9330,6 +9522,25 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "next": "16.2.5",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "react-hook-form": "^7.72.1"
+    "react-hook-form": "^7.72.1",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
@@ -33,6 +34,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "@vitejs/plugin-react": "^6.0.1",
     "dotenv": "^17.4.2",
     "eslint": "^9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-hook-form:
         specifier: ^7.72.1
         version: 7.72.1(react@19.2.6)
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
@@ -60,6 +63,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.12(@types/node@20.19.39)(jiti@2.6.1))
@@ -1006,6 +1012,9 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1223,6 +1232,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -1280,6 +1293,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1318,6 +1334,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -1333,6 +1352,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1608,6 +1630,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.338:
     resolution: {integrity: sha512-KVQQ3xko9/coDX3qXLUEEbqkKT8L+1DyAovrtu0Khtrt9wjSZ+7CZV4GVzxFy9Oe1NbrIU1oVXCwHJruIA1PNg==}
@@ -1952,6 +1977,14 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
@@ -1982,6 +2015,9 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -2154,6 +2190,12 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2291,6 +2333,9 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2555,6 +2600,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -2921,6 +2969,11 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
@@ -3843,6 +3896,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 20.19.39
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.39
@@ -4049,6 +4106,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4139,6 +4198,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -4163,6 +4229,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bn.js@4.12.3: {}
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -4183,6 +4251,8 @@ snapshots:
       electron-to-chromium: 1.5.338
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4471,6 +4541,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.338: {}
 
@@ -4959,6 +5033,15 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  http_ece@1.2.0: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   iceberg-js@0.8.1: {}
 
   iconv-lite@0.6.3:
@@ -4979,6 +5062,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -5170,6 +5255,17 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -5272,6 +5368,8 @@ snapshots:
       picomatch: 2.3.2
 
   min-indent@1.0.1: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -5562,6 +5660,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -5968,6 +6068,16 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webidl-conversions@4.0.2: {}
 

--- a/src/app/admin/notifications/page.tsx
+++ b/src/app/admin/notifications/page.tsx
@@ -1,0 +1,76 @@
+import { TestPushButton } from "@/components/features/push/test-push-button";
+import { adminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString("ja-JP");
+}
+
+export default async function AdminNotificationsPage() {
+  const { data } = await adminClient
+    .from("push_subscriptions")
+    .select("id, user_agent, created_at, last_seen_at")
+    .order("last_seen_at", { ascending: false });
+  const subscriptions = data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-bold text-brand-brown-dark">通知</h1>
+        <p className="mt-1 text-sm text-brand-brown-light">
+          Web Push の購読端末を確認し、テスト通知を送信します。
+        </p>
+      </div>
+
+      <section className="space-y-3 rounded-lg border border-brand-border-light bg-brand-card-light p-4">
+        <h2 className="text-sm font-medium text-brand-brown-dark">
+          テスト送信
+        </h2>
+        <p className="text-xs text-brand-brown-light">
+          登録済みの全端末にテスト通知を送ります。
+        </p>
+        <TestPushButton />
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-medium text-brand-brown-dark">
+          購読端末（{subscriptions.length}）
+        </h2>
+        <div className="overflow-x-auto rounded-lg border border-brand-border-light bg-brand-card-light">
+          {subscriptions.length === 0 ? (
+            <p className="px-4 py-8 text-center text-sm text-brand-brown-light">
+              まだ購読端末がありません。公開サイトのフッターから通知をオンにしてください。
+            </p>
+          ) : (
+            <table className="min-w-full divide-y divide-brand-border-light text-sm">
+              <thead className="bg-brand-bg-light text-xs text-brand-brown-light">
+                <tr>
+                  <th className="px-4 py-2 text-left font-medium">端末</th>
+                  <th className="px-4 py-2 text-left font-medium">登録日時</th>
+                  <th className="px-4 py-2 text-left font-medium">最終確認</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-brand-border-light">
+                {subscriptions.map((sub) => (
+                  <tr key={sub.id} className="hover:bg-brand-bg-light">
+                    <td className="max-w-md truncate px-4 py-2 text-brand-brown-dark">
+                      {sub.user_agent ?? "—"}
+                    </td>
+                    <td className="px-4 py-2 text-brand-brown-light">
+                      {formatDateTime(sub.created_at)}
+                    </td>
+                    <td className="px-4 py-2 text-brand-brown-light">
+                      {formatDateTime(sub.last_seen_at)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/notifications/page.tsx
+++ b/src/app/admin/notifications/page.tsx
@@ -9,10 +9,13 @@ function formatDateTime(iso: string | null): string {
 }
 
 export default async function AdminNotificationsPage() {
-  const { data } = await adminClient
+  const { data, error } = await adminClient
     .from("push_subscriptions")
     .select("id, user_agent, created_at, last_seen_at")
     .order("last_seen_at", { ascending: false });
+  if (error) {
+    throw new Error(`購読端末の取得に失敗しました: ${error.message}`);
+  }
   const subscriptions = data ?? [];
 
   return (

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -4,13 +4,39 @@ import type { PushSubscriptionJSON } from "@/lib/types/push";
 
 export const runtime = "nodejs";
 
+const MAX_ENDPOINT_LENGTH = 2048;
+const MAX_P256DH_LENGTH = 512;
+const MAX_AUTH_LENGTH = 256;
+
+// 未認証で叩ける書き込み口なので、保存できない / 送信不能なレコードが
+// 永続化されないよう厳しめに検証する（空キーや非 HTTPS endpoint を弾く）。
 function isValidSubscription(value: unknown): value is PushSubscriptionJSON {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
-  if (typeof v.endpoint !== "string" || v.endpoint.length === 0) return false;
+
+  if (
+    typeof v.endpoint !== "string" ||
+    v.endpoint.length === 0 ||
+    v.endpoint.length > MAX_ENDPOINT_LENGTH
+  ) {
+    return false;
+  }
+  try {
+    if (new URL(v.endpoint).protocol !== "https:") return false;
+  } catch {
+    return false;
+  }
+
   if (typeof v.keys !== "object" || v.keys === null) return false;
   const keys = v.keys as Record<string, unknown>;
-  return typeof keys.p256dh === "string" && typeof keys.auth === "string";
+  return (
+    typeof keys.p256dh === "string" &&
+    keys.p256dh.length > 0 &&
+    keys.p256dh.length <= MAX_P256DH_LENGTH &&
+    typeof keys.auth === "string" &&
+    keys.auth.length > 0 &&
+    keys.auth.length <= MAX_AUTH_LENGTH
+  );
 }
 
 export async function POST(request: Request) {

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { adminClient } from "@/lib/supabase/admin";
+import type { PushSubscriptionJSON } from "@/lib/types/push";
+
+export const runtime = "nodejs";
+
+function isValidSubscription(value: unknown): value is PushSubscriptionJSON {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.endpoint !== "string" || v.endpoint.length === 0) return false;
+  if (typeof v.keys !== "object" || v.keys === null) return false;
+  const keys = v.keys as Record<string, unknown>;
+  return typeof keys.p256dh === "string" && typeof keys.auth === "string";
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "不正なリクエストです" }, { status: 400 });
+  }
+
+  if (!isValidSubscription(body)) {
+    return NextResponse.json({ error: "購読情報が不正です" }, { status: 400 });
+  }
+
+  const { error } = await adminClient.from("push_subscriptions").upsert(
+    {
+      endpoint: body.endpoint,
+      p256dh: body.keys.p256dh,
+      auth: body.keys.auth,
+      user_agent: request.headers.get("user-agent"),
+      last_seen_at: new Date().toISOString(),
+    },
+    { onConflict: "endpoint" }
+  );
+
+  if (error) {
+    return NextResponse.json(
+      { error: "購読の登録に失敗しました" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/push/unsubscribe/route.ts
+++ b/src/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { adminClient } from "@/lib/supabase/admin";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "不正なリクエストです" }, { status: 400 });
+  }
+
+  const endpoint =
+    typeof body === "object" && body !== null
+      ? (body as Record<string, unknown>).endpoint
+      : null;
+  if (typeof endpoint !== "string" || endpoint.length === 0) {
+    return NextResponse.json({ error: "endpoint が不正です" }, { status: 400 });
+  }
+
+  const { error } = await adminClient
+    .from("push_subscriptions")
+    .delete()
+    .eq("endpoint", endpoint);
+
+  if (error) {
+    return NextResponse.json(
+      { error: "購読の解除に失敗しました" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/lives.ics/route.ts
+++ b/src/app/lives.ics/route.ts
@@ -1,4 +1,5 @@
 import { buildIcsCalendar, type IcsEvent } from "@/lib/ics/builder";
+import { normalizeStartTimeForIcs } from "@/lib/ics/start-time";
 import { listLivesForCalendar } from "@/lib/queries/lives";
 import { getSiteUrl } from "@/lib/utils/site-url";
 
@@ -6,30 +7,6 @@ export const dynamic = "force-dynamic";
 
 const PRODID = "-//dondecorte-lab//Lives//JA";
 const CALENDAR_NAME = "ドンデコルテ出演ライブ";
-
-// lives.start_time は schema 上 timestamptz。フォーム入力経路によっては
-// "HH:MM:SS" 形式の文字列が入っている場合もあるため両方を許容する。
-export function normalizeStartTimeForIcs(value: string | null): string | null {
-  if (!value) return null;
-  const hhmm = value.match(/^(\d{2}):(\d{2})(?::(\d{2}))?$/);
-  if (hhmm) {
-    return `${hhmm[1]}:${hhmm[2]}:${hhmm[3] ?? "00"}`;
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  const parts = new Intl.DateTimeFormat("en-GB", {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-    timeZone: "Asia/Tokyo",
-  }).formatToParts(date);
-  const hh = parts.find((p) => p.type === "hour")?.value;
-  const mm = parts.find((p) => p.type === "minute")?.value;
-  const ss = parts.find((p) => p.type === "second")?.value;
-  if (!hh || !mm || !ss) return null;
-  return `${hh}:${mm}:${ss}`;
-}
 
 function buildDescription(args: {
   description: string | null;

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -20,3 +20,59 @@ const serwist = new Serwist({
 });
 
 serwist.addEventListeners();
+
+type PushPayload = {
+  title?: string;
+  body?: string;
+  url?: string;
+  tag?: string;
+};
+
+self.addEventListener("push", (event) => {
+  let payload: PushPayload = {};
+  try {
+    payload = event.data?.json() ?? {};
+  } catch {
+    payload = { body: event.data?.text() };
+  }
+
+  const title = payload.title ?? "DonDecorte Lab";
+  const url = payload.url ?? "/";
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: payload.body ?? "",
+      tag: payload.tag,
+      icon: "/icon-192.png",
+      badge: "/icon-192.png",
+      data: { url },
+    })
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const data = event.notification.data as { url?: string } | undefined;
+  const url = data?.url ?? "/";
+
+  event.waitUntil(
+    (async () => {
+      const allClients = await self.clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      });
+      for (const client of allClients) {
+        if ("focus" in client) {
+          await client.focus();
+          try {
+            await client.navigate(url);
+          } catch {
+            // navigate 非対応 / クロスオリジン時はフォーカスのみ
+          }
+          return;
+        }
+      }
+      await self.clients.openWindow(url);
+    })()
+  );
+});

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -2,6 +2,7 @@
 import { defaultCache } from "@serwist/next/worker";
 import type { PrecacheEntry, SerwistGlobalConfig } from "serwist";
 import { Serwist } from "serwist";
+import type { PushPayload } from "@/lib/types/push";
 
 declare global {
   interface WorkerGlobalScope extends SerwistGlobalConfig {
@@ -21,30 +22,29 @@ const serwist = new Serwist({
 
 serwist.addEventListeners();
 
-type PushPayload = {
-  title?: string;
-  body?: string;
-  url?: string;
-  tag?: string;
-};
+const DEFAULT_NOTIFICATION_TITLE = "DonDecorte Lab";
+const DEFAULT_NOTIFICATION_URL = "/";
+const NOTIFICATION_ICON = "/icon-192.png";
+const NOTIFICATION_BADGE = "/icon-192.png";
 
 self.addEventListener("push", (event) => {
-  let payload: PushPayload = {};
+  // 受信ペイロードは信頼できないため全フィールドを optional 扱いにする。
+  let payload: Partial<PushPayload> = {};
   try {
     payload = event.data?.json() ?? {};
   } catch {
     payload = { body: event.data?.text() };
   }
 
-  const title = payload.title ?? "DonDecorte Lab";
-  const url = payload.url ?? "/";
+  const title = payload.title ?? DEFAULT_NOTIFICATION_TITLE;
+  const url = payload.url ?? DEFAULT_NOTIFICATION_URL;
 
   event.waitUntil(
     self.registration.showNotification(title, {
       body: payload.body ?? "",
       tag: payload.tag,
-      icon: "/icon-192.png",
-      badge: "/icon-192.png",
+      icon: NOTIFICATION_ICON,
+      badge: NOTIFICATION_BADGE,
       data: { url },
     })
   );

--- a/src/components/features/push/push-toggle.tsx
+++ b/src/components/features/push/push-toggle.tsx
@@ -79,11 +79,14 @@ export function PushToggle({ vapidPublicKey }: Props) {
       const reg = await navigator.serviceWorker.ready;
       const sub = await reg.pushManager.getSubscription();
       if (sub) {
-        await fetch("/api/push/unsubscribe", {
+        const res = await fetch("/api/push/unsubscribe", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ endpoint: sub.endpoint }),
         });
+        if (!res.ok) {
+          throw new Error("購読の解除に失敗しました");
+        }
         await sub.unsubscribe();
       }
       setSubscribed(false);

--- a/src/components/features/push/push-toggle.tsx
+++ b/src/components/features/push/push-toggle.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+type Props = {
+  vapidPublicKey: string;
+};
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const output = new Uint8Array(new ArrayBuffer(raw.length));
+  for (let i = 0; i < raw.length; i += 1) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+export function PushToggle({ vapidPublicKey }: Props) {
+  const [supported, setSupported] = useState(false);
+  const [subscribed, setSubscribed] = useState<boolean | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const ok =
+      typeof window !== "undefined" &&
+      "serviceWorker" in navigator &&
+      "PushManager" in window &&
+      "Notification" in window;
+    setSupported(ok);
+    if (!ok) {
+      setSubscribed(false);
+      return;
+    }
+    navigator.serviceWorker.ready
+      .then((reg) => reg.pushManager.getSubscription())
+      .then((sub) => setSubscribed(Boolean(sub)))
+      .catch(() => setSubscribed(false));
+  }, []);
+
+  const subscribe = useCallback(async () => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") {
+        setMessage("通知が許可されませんでした。");
+        return;
+      }
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+      });
+      const res = await fetch("/api/push/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(sub.toJSON()),
+      });
+      if (!res.ok) {
+        await sub.unsubscribe();
+        throw new Error("購読の登録に失敗しました");
+      }
+      setSubscribed(true);
+      setMessage("通知をオンにしました。");
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "通知の設定に失敗しました。");
+    } finally {
+      setBusy(false);
+    }
+  }, [vapidPublicKey]);
+
+  const unsubscribe = useCallback(async () => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) {
+        await fetch("/api/push/unsubscribe", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ endpoint: sub.endpoint }),
+        });
+        await sub.unsubscribe();
+      }
+      setSubscribed(false);
+      setMessage("通知をオフにしました。");
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "通知の解除に失敗しました。");
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  if (!supported) {
+    return (
+      <p className="text-xs text-brand-muted">
+        この端末では通知に対応していません。iPhone の場合はホーム画面に追加すると通知を受け取れます。
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <button
+        type="button"
+        onClick={subscribed ? unsubscribe : subscribe}
+        disabled={busy || subscribed === null}
+        className="inline-flex items-center gap-2 rounded-md border border-brand-border-dark bg-brand-card-dark px-3 py-1.5 text-xs font-medium text-brand-cream transition hover:border-brand-sky disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {subscribed === null
+          ? "確認中..."
+          : busy
+            ? "処理中..."
+            : subscribed
+              ? "🔔 通知をオフにする"
+              : "🔔 ライブ・先行抽選の通知を受け取る"}
+      </button>
+      {message ? <p className="text-xs text-brand-muted">{message}</p> : null}
+    </div>
+  );
+}

--- a/src/components/features/push/test-push-button.tsx
+++ b/src/components/features/push/test-push-button.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { sendTestPush } from "@/lib/actions/push";
+
+export function TestPushButton() {
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleClick = () => {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await sendTestPush();
+      if (result.ok) {
+        const { sent, removed, failed } = result.summary;
+        setMessage(
+          `送信 ${sent}件 / 失効削除 ${removed}件 / 失敗 ${failed}件`
+        );
+      } else {
+        setMessage(result.error);
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={pending}
+        className="rounded-md bg-brand-sky px-4 py-2 text-sm font-medium text-white transition hover:bg-brand-sky-dark disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {pending ? "送信中..." : "テスト通知を送信"}
+      </button>
+      {message ? (
+        <p className="text-sm text-brand-brown-light">{message}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/features/push/test-push-button.tsx
+++ b/src/components/features/push/test-push-button.tsx
@@ -10,14 +10,18 @@ export function TestPushButton() {
   const handleClick = () => {
     setMessage(null);
     startTransition(async () => {
-      const result = await sendTestPush();
-      if (result.ok) {
-        const { sent, removed, failed } = result.summary;
-        setMessage(
-          `送信 ${sent}件 / 失効削除 ${removed}件 / 失敗 ${failed}件`
-        );
-      } else {
-        setMessage(result.error);
+      try {
+        const result = await sendTestPush();
+        if (result.ok) {
+          const { sent, removed, failed } = result.summary;
+          setMessage(
+            `送信 ${sent}件 / 失効削除 ${removed}件 / 失敗 ${failed}件`
+          );
+        } else {
+          setMessage(result.error);
+        }
+      } catch {
+        setMessage("テスト通知の送信に失敗しました");
       }
     });
   };

--- a/src/components/layout/admin-sidebar.tsx
+++ b/src/components/layout/admin-sidebar.tsx
@@ -22,6 +22,7 @@ const NAV_ITEMS: AdminNavItem[] = [
   { href: "/admin/tv", label: "テレビ（TV）" },
   { href: "/admin/topics", label: "トピック（Topics）" },
   { href: "/admin/tags", label: "タグ（Tags）" },
+  { href: "/admin/notifications", label: "通知（Notifications）" },
 ];
 
 function isActive(pathname: string, href: string) {

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,7 +1,16 @@
+import { PushToggle } from "@/components/features/push/push-toggle";
+
 export function PublicFooter() {
+  const vapidPublicKey = process.env.VAPID_PUBLIC_KEY;
+
   return (
     <footer className="border-t border-brand-border-dark bg-brand-card-dark px-4 py-6 text-xs leading-relaxed text-brand-muted">
       <div className="mx-auto max-w-6xl space-y-2">
+        {vapidPublicKey ? (
+          <div className="border-b border-brand-border-dark pb-3">
+            <PushToggle vapidPublicKey={vapidPublicKey} />
+          </div>
+        ) : null}
         <p>
           本サイトはドンデコルテおよび吉本興業とは無関係の非公式ファンサイトです。
         </p>

--- a/src/lib/actions/push.ts
+++ b/src/lib/actions/push.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { sendPushToAll, type SendPushSummary } from "@/lib/push/sender";
+import { createClient } from "@/lib/supabase/server";
+import { getSiteUrl } from "@/lib/utils/site-url";
+
+export type TestPushResult =
+  | { ok: true; summary: SendPushSummary }
+  | { ok: false; error: string };
+
+export async function sendTestPush(): Promise<TestPushResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: "認証が必要です" };
+
+  try {
+    const summary = await sendPushToAll({
+      title: "DonDecorte Lab",
+      body: "テスト通知です。これが表示されていれば通知設定は完了です。",
+      url: getSiteUrl(),
+      tag: "test",
+    });
+    return { ok: true, summary };
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "テスト通知の送信に失敗しました",
+    };
+  }
+}

--- a/src/lib/ics/start-time.test.ts
+++ b/src/lib/ics/start-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeStartTimeForIcs } from "./route";
+import { normalizeStartTimeForIcs } from "./start-time";
 
 describe("normalizeStartTimeForIcs", () => {
   it("null / 空文字は null を返す", () => {

--- a/src/lib/ics/start-time.test.ts
+++ b/src/lib/ics/start-time.test.ts
@@ -38,4 +38,9 @@ describe("normalizeStartTimeForIcs", () => {
   it("不正な文字列は null を返す", () => {
     expect(normalizeStartTimeForIcs("not-a-time")).toBeNull();
   });
+
+  it("範囲外の HH:MM は HH:MM[:SS] パターンで受理せず null を返す", () => {
+    expect(normalizeStartTimeForIcs("25:61")).toBeNull();
+    expect(normalizeStartTimeForIcs("24:00")).toBeNull();
+  });
 });

--- a/src/lib/ics/start-time.ts
+++ b/src/lib/ics/start-time.ts
@@ -1,0 +1,23 @@
+// lives.start_time は schema 上 timestamptz。フォーム入力経路によっては
+// "HH:MM:SS" 形式の文字列が入っている場合もあるため両方を許容する。
+export function normalizeStartTimeForIcs(value: string | null): string | null {
+  if (!value) return null;
+  const hhmm = value.match(/^(\d{2}):(\d{2})(?::(\d{2}))?$/);
+  if (hhmm) {
+    return `${hhmm[1]}:${hhmm[2]}:${hhmm[3] ?? "00"}`;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Tokyo",
+  }).formatToParts(date);
+  const hh = parts.find((p) => p.type === "hour")?.value;
+  const mm = parts.find((p) => p.type === "minute")?.value;
+  const ss = parts.find((p) => p.type === "second")?.value;
+  if (!hh || !mm || !ss) return null;
+  return `${hh}:${mm}:${ss}`;
+}

--- a/src/lib/ics/start-time.ts
+++ b/src/lib/ics/start-time.ts
@@ -2,7 +2,7 @@
 // "HH:MM:SS" 形式の文字列が入っている場合もあるため両方を許容する。
 export function normalizeStartTimeForIcs(value: string | null): string | null {
   if (!value) return null;
-  const hhmm = value.match(/^(\d{2}):(\d{2})(?::(\d{2}))?$/);
+  const hhmm = value.match(/^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/);
   if (hhmm) {
     return `${hhmm[1]}:${hhmm[2]}:${hhmm[3] ?? "00"}`;
   }

--- a/src/lib/push/sender.test.ts
+++ b/src/lib/push/sender.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const webPushMock = vi.hoisted(() => {
+  class WebPushError extends Error {
+    statusCode: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  }
+  return {
+    sendNotification: vi.fn(),
+    setVapidDetails: vi.fn(),
+    WebPushError,
+  };
+});
+
+vi.mock("web-push", () => webPushMock);
+
+const adminMock = vi.hoisted(() => ({ from: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ adminClient: adminMock }));
+
+import { sendPush, sendPushToAll } from "./sender";
+
+const SUB = { endpoint: "https://push.example/abc", p256dh: "p", auth: "a" };
+const PAYLOAD = { title: "t", body: "b" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.VAPID_PUBLIC_KEY = "pub";
+  process.env.VAPID_PRIVATE_KEY = "priv";
+  process.env.VAPID_SUBJECT = "mailto:test@example.com";
+});
+
+describe("sendPush", () => {
+  it("送信成功で true を返す", async () => {
+    webPushMock.sendNotification.mockResolvedValueOnce({});
+    await expect(sendPush(SUB, PAYLOAD)).resolves.toBe(true);
+    expect(webPushMock.sendNotification).toHaveBeenCalledWith(
+      { endpoint: SUB.endpoint, keys: { p256dh: "p", auth: "a" } },
+      JSON.stringify(PAYLOAD)
+    );
+  });
+
+  it("410 なら購読を削除して false を返す", async () => {
+    webPushMock.sendNotification.mockRejectedValueOnce(
+      new webPushMock.WebPushError("gone", 410)
+    );
+    const eq = vi.fn().mockResolvedValue({ error: null });
+    const del = vi.fn(() => ({ eq }));
+    adminMock.from.mockReturnValue({ delete: del });
+
+    await expect(sendPush(SUB, PAYLOAD)).resolves.toBe(false);
+    expect(adminMock.from).toHaveBeenCalledWith("push_subscriptions");
+    expect(eq).toHaveBeenCalledWith("endpoint", SUB.endpoint);
+  });
+
+  it("410/404 以外のエラーは再 throw する", async () => {
+    webPushMock.sendNotification.mockRejectedValueOnce(
+      new webPushMock.WebPushError("boom", 500)
+    );
+    await expect(sendPush(SUB, PAYLOAD)).rejects.toThrow("boom");
+  });
+
+  it("VAPID 環境変数が無いと throw する", async () => {
+    delete process.env.VAPID_PRIVATE_KEY;
+    // 別モジュール状態に依存しないよう動的 import で再評価
+    vi.resetModules();
+    const { sendPush: freshSendPush } = await import("./sender");
+    await expect(freshSendPush(SUB, PAYLOAD)).rejects.toThrow(/VAPID/);
+  });
+});
+
+describe("sendPushToAll", () => {
+  it("成功 / 失効削除 / 失敗を集計する", async () => {
+    const subs = [
+      { endpoint: "e1", p256dh: "p", auth: "a" },
+      { endpoint: "e2", p256dh: "p", auth: "a" },
+      { endpoint: "e3", p256dh: "p", auth: "a" },
+    ];
+    const eq = vi.fn().mockResolvedValue({ error: null });
+    adminMock.from.mockReturnValue({
+      select: vi.fn().mockResolvedValue({ data: subs, error: null }),
+      delete: vi.fn(() => ({ eq })),
+    });
+
+    webPushMock.sendNotification
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new webPushMock.WebPushError("gone", 410))
+      .mockRejectedValueOnce(new webPushMock.WebPushError("boom", 500));
+
+    const summary = await sendPushToAll(PAYLOAD);
+    expect(summary).toEqual({ sent: 1, removed: 1, failed: 1 });
+  });
+});

--- a/src/lib/push/sender.ts
+++ b/src/lib/push/sender.ts
@@ -1,0 +1,95 @@
+import "server-only";
+import {
+  sendNotification,
+  setVapidDetails,
+  WebPushError,
+  type PushSubscription as WebPushSubscription,
+} from "web-push";
+import { adminClient } from "@/lib/supabase/admin";
+import type { PushPayload, PushSubscriptionRow } from "@/lib/types/push";
+
+let vapidConfigured = false;
+
+function configureVapid(): void {
+  if (vapidConfigured) return;
+  const publicKey = process.env.VAPID_PUBLIC_KEY;
+  const privateKey = process.env.VAPID_PRIVATE_KEY;
+  const subject = process.env.VAPID_SUBJECT;
+  if (!publicKey || !privateKey || !subject) {
+    throw new Error(
+      "VAPID 環境変数（VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY / VAPID_SUBJECT）が未設定です"
+    );
+  }
+  setVapidDetails(subject, publicKey, privateKey);
+  vapidConfigured = true;
+}
+
+type SubscriptionLike = Pick<PushSubscriptionRow, "endpoint" | "p256dh" | "auth">;
+
+// 失効した endpoint（404/410）は GC して二度と送らない。
+async function deleteSubscription(endpoint: string): Promise<void> {
+  await adminClient.from("push_subscriptions").delete().eq("endpoint", endpoint);
+}
+
+// 単一端末への送信。成功で true、endpoint 失効で削除して false、それ以外は throw。
+export async function sendPush(
+  subscription: SubscriptionLike,
+  payload: PushPayload
+): Promise<boolean> {
+  configureVapid();
+
+  const target: WebPushSubscription = {
+    endpoint: subscription.endpoint,
+    keys: { p256dh: subscription.p256dh, auth: subscription.auth },
+  };
+
+  try {
+    await sendNotification(target, JSON.stringify(payload));
+    return true;
+  } catch (err) {
+    if (
+      err instanceof WebPushError &&
+      (err.statusCode === 404 || err.statusCode === 410)
+    ) {
+      await deleteSubscription(subscription.endpoint);
+      return false;
+    }
+    throw err;
+  }
+}
+
+export type SendPushSummary = {
+  sent: number;
+  removed: number;
+  failed: number;
+};
+
+// 全購読端末へ送信。失効端末は GC、その他の失敗は握りつぶしてカウントだけ返す。
+export async function sendPushToAll(
+  payload: PushPayload
+): Promise<SendPushSummary> {
+  configureVapid();
+
+  const { data, error } = await adminClient
+    .from("push_subscriptions")
+    .select("endpoint, p256dh, auth");
+  if (error) {
+    throw new Error(`購読端末の取得に失敗しました: ${error.message}`);
+  }
+
+  const subscriptions = data ?? [];
+  const results = await Promise.allSettled(
+    subscriptions.map((sub) => sendPush(sub, payload))
+  );
+
+  const summary: SendPushSummary = { sent: 0, removed: 0, failed: 0 };
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      if (result.value) summary.sent += 1;
+      else summary.removed += 1;
+    } else {
+      summary.failed += 1;
+    }
+  }
+  return summary;
+}

--- a/src/lib/push/sender.ts
+++ b/src/lib/push/sender.ts
@@ -27,8 +27,16 @@ function configureVapid(): void {
 type SubscriptionLike = Pick<PushSubscriptionRow, "endpoint" | "p256dh" | "auth">;
 
 // 失効した endpoint（404/410）は GC して二度と送らない。
+// 削除に失敗した場合は throw し、呼び出し側で「送信失敗」として扱う
+// （stale 行が残ったまま removed に計上されると以後のブロードキャストで毎回失敗するため）。
 async function deleteSubscription(endpoint: string): Promise<void> {
-  await adminClient.from("push_subscriptions").delete().eq("endpoint", endpoint);
+  const { error } = await adminClient
+    .from("push_subscriptions")
+    .delete()
+    .eq("endpoint", endpoint);
+  if (error) {
+    throw new Error(`失効した購読端末の削除に失敗しました: ${error.message}`);
+  }
 }
 
 // 単一端末への送信。成功で true、endpoint 失効で削除して false、それ以外は throw。

--- a/src/lib/types/push.ts
+++ b/src/lib/types/push.ts
@@ -1,0 +1,27 @@
+// ブラウザの PushSubscription.toJSON() の形（subscribe API が受け取る payload）
+export type PushSubscriptionJSON = {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+};
+
+// Service Worker の push ハンドラに渡す通知本文
+export type PushPayload = {
+  title: string;
+  body: string;
+  url?: string;
+  tag?: string;
+};
+
+// push_subscriptions テーブルの行
+export type PushSubscriptionRow = {
+  id: string;
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+  user_agent: string | null;
+  created_at: string;
+  last_seen_at: string;
+};

--- a/supabase/migrations/007_push_subscriptions.sql
+++ b/supabase/migrations/007_push_subscriptions.sql
@@ -1,0 +1,33 @@
+-- ============================================
+-- Web Push 購読端末（push_subscriptions）
+-- ============================================
+-- Web Push（VAPID）でスマホ等にプッシュ通知を送るための購読情報を保持する。
+-- 後続の Fany 連携（先行抽選通知）や YouTube 新着通知などで使い回す。
+--
+-- 自分専用アプリだが家族・友人にも配れるよう user_id への紐付けは省略する。
+-- 1 端末 = 1 行（複数端末で複数 subscription が並ぶ想定）。
+
+create table push_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  endpoint text not null unique,
+  p256dh text not null,
+  auth text not null,
+  user_agent text,
+  created_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now()
+);
+
+comment on table push_subscriptions is
+  'Web Push（VAPID）の購読端末。endpoint / p256dh / auth は機微情報のため anon には読ませない';
+
+-- ============================================
+-- RLS
+-- ============================================
+-- insert: anon 可（誰でも自分の端末を購読登録できる）
+-- select / delete / update: ポリシー無し → anon / authenticated からは不可。
+--   購読一覧の取得・GC（404/410 の削除）はサーバ側（Route Handler / Server Action）から
+--   service_role キーで実行する（service_role は RLS をバイパスする）。
+alter table push_subscriptions enable row level security;
+
+create policy push_subscriptions_insert
+  on push_subscriptions for insert to anon, authenticated with check (true);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // server-only は next の依存配下にあり vite から解決できないため空モジュールに差し替える
+      "server-only": path.resolve(__dirname, "./vitest/server-only-stub.ts"),
     },
   },
   test: {

--- a/vitest/server-only-stub.ts
+++ b/vitest/server-only-stub.ts
@@ -1,0 +1,2 @@
+// vitest 用の "server-only" 差し替えスタブ（実行時は何もしない）。
+export {};


### PR DESCRIPTION
## 概要

Web Push（VAPID）でスマホにプッシュ通知を送れる基盤を構築しました（issue #96 / `docs/plans/pwa-notifications.md` フェーズ2）。後続の Fany 連携（#97）や YouTube 新着通知などで使い回せます。

前提の PWA 基盤（#95）は導入済み（`public/manifest.webmanifest` / `src/app/sw.ts`）のため、その上に Web Push を載せています。

## 変更内容

### DB（migration 007）
- `push_subscriptions` テーブルを新設（`endpoint` UNIQUE / `p256dh` / `auth` / `user_agent` / `created_at` / `last_seen_at`）
- RLS: `insert` は anon 可、`select` / `delete` はポリシー無し（= service_role のみ）。`endpoint` 等は機微情報のため anon に読ませない
- 自分専用アプリだが家族・友人にも配れるよう user_id 紐付けは省略

### サーバ側
- `web-push` パッケージを追加
- `src/lib/push/sender.ts` — `sendPush()` / `sendPushToAll()`。404/410 が返った endpoint は自動 GC
- `POST /api/push/subscribe` — `PushSubscription` を service_role で upsert
- `POST /api/push/unsubscribe` — endpoint 指定で delete
- `src/lib/actions/push.ts` — 管理画面用の `sendTestPush()`（認証必須）

### クライアント側
- `src/components/features/push/push-toggle.tsx` — `Notification.requestPermission()` → `pushManager.subscribe` → `/api/push/subscribe`。真値は `pushManager.getSubscription()`
- 公開フッターに設置（`VAPID_PUBLIC_KEY` 未設定時は非表示。ログイン不要で誰でも購読可）
- Service Worker に `push` / `notificationclick` ハンドラを追加（`{title, body, url, tag}` を `showNotification`、クリックで該当 URL を開く）

### 管理画面
- `/admin/notifications` を新設（購読端末一覧 + テスト送信ボタン）、sidebar に導線追加

### その他
- `.env.example` に `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` を追記
- `src/lib/push/sender.test.ts` を追加（成功 / 失効削除 / 失敗の集計、VAPID 未設定時の throw）
- vitest が `server-only` を解決できるようスタブの alias を追加

### 既存ビルド不具合の修正（#96 スコープ外・別コミット）
- `src/app/lives.ics/route.ts` が route ファイルから `normalizeStartTimeForIcs` を export しており、Next 16 の `next build` 型検証で失敗していた（#112 でマージ済みの既存問題で main も同状態）
- ヘルパーを `src/lib/ics/start-time.ts` へ切り出し、route / テストの import を差し替えて `next build` を緑に

## 手動セットアップ（マージ後）
- `npx web-push generate-vapid-keys` で VAPID キーを一度だけ生成し、Vercel と `.env` に登録（キーを変えると既存購読が全て無効になるので注意）
- Supabase に migration 007 を適用
- 動作確認: iPhone（PWA インストール済み）でフッターから購読 → `/admin/notifications` でテスト送信 → 通知が届くこと

## 確認
- [x] `pnpm test`（167 passed）
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec eslint src`（クリーン）
- [x] `pnpm build`（service worker のバンドル含め成功）
- [ ] 実機（iPhone PWA）での購読→テスト送信は VAPID キー登録後に要確認

Closes #96


---
_Generated by [Claude Code](https://claude.ai/code/session_01JVoW4t7rfA3D9qu7HJ6aE7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Web Push notification support with subscription management
  * Added push notification toggle in the footer to enable/disable notifications
  * Added admin page for viewing active push subscriptions and testing notification delivery

* **Documentation**
  * Added Web Push (VAPID) configuration documentation to environment setup guide

* **Chores**
  * Added web-push dependency and related type definitions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->