### PR TITLE
feat: カレンダーview + Googleカレンダー個別追加導線 (#114)

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -304,6 +304,35 @@ mkdir -p supabase/migrations
 - `start_time` あり → 2 時間予定 / `start_time` なし → 終日予定
 - 即時反映が必要になったら issue #43（OAuth で直接書き込み）を検討
 
+## カレンダー view + イベント個別追加 (#114)
+
+`/lives.ics` の「全件まとめて URL 購読」に対し、`/calendar` では **見たいライブを 1 件ずつ**
+Google カレンダーへ追加できる。
+
+### カレンダー view
+
+- `/calendar` … 月表示（日曜始まり）+「これからのライブ」リスト
+- `?ym=YYYY-MM` で表示月を切り替え（前月 / 翌月リンク）
+- 月セルのライブはライブ詳細へリンク
+
+### 個別追加導線
+
+ライブ詳細（`/lives/[id]`）と `/calendar` のリスト項目に、以下 2 つのボタンを表示する。
+
+1. **Google カレンダーに追加**（テンプレート URL / ワンタップ）
+   - `src/lib/calendar/google-url.ts` が生成
+   - `ctz=Asia/Tokyo`。時刻指定は `dates=...T.../...T...`、終日は `dates=YYYYMMDD/翌日`
+   - ⚠️ テンプレート URL は **リマインド時刻を指定できない**（ユーザー既定の通知になる）
+2. **.ics で追加**（`GET /lives/[id].ics` 相当 → 実体は `/lives/[id]/ics`）
+   - VALARM 付き。`start_time` あり → 前日 + 2 時間前 / なし → 前日のみ
+   - リマインド時刻を初期設定したい場合はこちらを使う（Google 含む任意アプリに取り込み可）
+
+### スコープ
+
+- 先行抽選期間（`live_presales`）の重ね表示は #97（Fany 連携）でテーブルが用意され次第に対応予定。
+  本対応はライブ日のみで先行リリースしている。
+- VALARM 生成は `src/lib/ics/builder.ts` の `reminders?: { minutesBefore }[]` で対応。
+
 ---
 
 ## 実装順序チェックリスト

--- a/src/app/(public)/calendar/page.tsx
+++ b/src/app/(public)/calendar/page.tsx
@@ -1,0 +1,204 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { AddToCalendar } from "@/components/features/calendar/add-to-calendar";
+import {
+  buildMonthMatrix,
+  formatYearMonth,
+  parseYearMonth,
+  shiftMonth,
+  todayInTokyo,
+} from "@/lib/calendar/month-grid";
+import { listLivesForCalendar } from "@/lib/queries/lives";
+import type { LiveWithCasts } from "@/lib/types/live";
+import { formatDate, formatTime } from "@/lib/utils/date";
+import { getSiteUrl } from "@/lib/utils/site-url";
+
+export const dynamic = "force-dynamic";
+
+const DESCRIPTION = "ドンデコルテさん関連のライブをカレンダーで確認できます。";
+const WEEKDAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+const UPCOMING_LIMIT = 12;
+
+export const metadata: Metadata = {
+  title: "カレンダー",
+  description: DESCRIPTION,
+  alternates: { canonical: "/calendar" },
+  openGraph: {
+    title: "カレンダー",
+    description: DESCRIPTION,
+    url: "/calendar",
+  },
+};
+
+type SearchParams = Promise<{ ym?: string | string[] }>;
+
+function ymParam(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function CalendarPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const today = todayInTokyo();
+  const [todayYear, todayMonth] = today.split("-").map(Number);
+  const { year, month } = parseYearMonth(
+    ymParam(params.ym),
+    todayYear,
+    todayMonth
+  );
+
+  const lives = await listLivesForCalendar();
+  const siteUrl = getSiteUrl();
+
+  const byDate = new Map<string, LiveWithCasts[]>();
+  for (const live of lives) {
+    if (!live.event_date) continue;
+    const bucket = byDate.get(live.event_date) ?? [];
+    bucket.push(live);
+    byDate.set(live.event_date, bucket);
+  }
+
+  const matrix = buildMonthMatrix(year, month, today);
+  const prev = shiftMonth(year, month, -1);
+  const next = shiftMonth(year, month, 1);
+
+  const upcoming = lives
+    .filter((live) => live.event_date && live.event_date >= today)
+    .slice(0, UPCOMING_LIMIT);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl flex-1 px-4 py-8 md:py-12">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+          カレンダー
+        </h1>
+        <p className="mt-2 text-sm text-brand-gold md:text-base">
+          {DESCRIPTION}
+        </p>
+      </header>
+
+      <div className="mb-4 flex items-center justify-between">
+        <Link
+          href={`/calendar?ym=${formatYearMonth(prev.year, prev.month)}`}
+          className="rounded-md border border-brand-border-dark bg-brand-card-dark px-3 py-1.5 text-sm text-brand-gold transition hover:text-brand-sky-light"
+        >
+          ← {prev.year}年{prev.month}月
+        </Link>
+        <h2 className="text-lg font-semibold text-brand-cream md:text-xl">
+          {year}年{month}月
+        </h2>
+        <Link
+          href={`/calendar?ym=${formatYearMonth(next.year, next.month)}`}
+          className="rounded-md border border-brand-border-dark bg-brand-card-dark px-3 py-1.5 text-sm text-brand-gold transition hover:text-brand-sky-light"
+        >
+          {next.year}年{next.month}月 →
+        </Link>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-brand-border-dark">
+        <div className="grid grid-cols-7 border-b border-brand-border-dark bg-brand-card-dark">
+          {WEEKDAY_LABELS.map((label) => (
+            <div
+              key={label}
+              className="px-1 py-2 text-center text-xs font-medium text-brand-gold"
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+        <div className="grid grid-cols-7">
+          {matrix.flat().map((cell) => {
+            const dayLives = byDate.get(cell.date) ?? [];
+            return (
+              <div
+                key={cell.date}
+                className={`min-h-[84px] border-b border-r border-brand-border-dark p-1 last:border-r-0 ${
+                  cell.inCurrentMonth
+                    ? "bg-brand-bg-dark"
+                    : "bg-brand-bg-dark/40"
+                }`}
+              >
+                <div
+                  className={`mb-1 text-right text-xs ${
+                    cell.isToday
+                      ? "font-bold text-brand-sky-light"
+                      : cell.inCurrentMonth
+                        ? "text-brand-gold"
+                        : "text-brand-muted/60"
+                  }`}
+                >
+                  {cell.day}
+                </div>
+                <ul className="space-y-1">
+                  {dayLives.map((live) => (
+                    <li key={live.id}>
+                      <Link
+                        href={`/lives/${live.id}`}
+                        className="block truncate rounded bg-brand-sky-pale/10 px-1 py-0.5 text-[11px] leading-tight text-brand-sky-light transition hover:bg-brand-sky-pale/20"
+                        title={live.title}
+                      >
+                        {formatTime(live.start_time)
+                          ? `${formatTime(live.start_time)} `
+                          : ""}
+                        {live.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <section className="mt-8">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-brand-cream">
+            これからのライブ
+          </h2>
+          <a
+            href="/lives.ics"
+            className="text-xs text-brand-muted transition hover:text-brand-sky-light"
+          >
+            全ライブをカレンダー購読 (.ics)
+          </a>
+        </div>
+
+        {upcoming.length === 0 ? (
+          <p className="rounded-lg border border-brand-border-dark bg-brand-card-dark p-4 text-sm text-brand-muted">
+            予定されているライブはまだありません。
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {upcoming.map((live) => (
+              <li
+                key={live.id}
+                className="rounded-lg border border-brand-border-dark bg-brand-card-dark p-4"
+              >
+                <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-xs text-brand-muted">
+                  <span className="text-brand-sky-light">
+                    {formatDate(live.event_date)}
+                    {formatTime(live.start_time)
+                      ? ` ${formatTime(live.start_time)}`
+                      : ""}
+                  </span>
+                  {live.venue ? <span>{live.venue}</span> : null}
+                </div>
+                <Link
+                  href={`/lives/${live.id}`}
+                  className="mt-1 block text-sm font-medium text-brand-cream transition hover:text-brand-sky-light"
+                >
+                  {live.title}
+                </Link>
+                <AddToCalendar live={live} siteUrl={siteUrl} className="mt-3" />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(public)/lives/[id]/ics/route.ts
+++ b/src/app/(public)/lives/[id]/ics/route.ts
@@ -1,0 +1,58 @@
+import {
+  ALL_DAY_LIVE_REMINDERS,
+  buildLiveCalendarDescription,
+  TIMED_LIVE_REMINDERS,
+} from "@/lib/calendar/live-event";
+import { buildIcsCalendar, type IcsEvent } from "@/lib/ics/builder";
+import { normalizeStartTimeForIcs } from "@/lib/ics/start-time";
+import { getLive } from "@/lib/queries/lives";
+import { getSiteUrl } from "@/lib/utils/site-url";
+
+export const dynamic = "force-dynamic";
+
+const PRODID = "-//dondecorte-lab//Live//JA";
+const CALENDAR_NAME = "ドンデコルテ出演ライブ";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const live = await getLive(id);
+  if (!live || !live.event_date) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const siteUrl = getSiteUrl();
+  const host = new URL(siteUrl).host;
+  const startTime = normalizeStartTimeForIcs(live.start_time);
+
+  const event: IcsEvent = {
+    uid: `live-${live.id}@${host}`,
+    date: live.event_date,
+    startTime,
+    summary: live.title,
+    location: live.venue,
+    description: buildLiveCalendarDescription({
+      description: live.description,
+      casts: live.casts,
+      detailUrl: `${siteUrl}/lives/${live.id}`,
+    }),
+    url: live.url,
+    reminders: startTime ? TIMED_LIVE_REMINDERS : ALL_DAY_LIVE_REMINDERS,
+  };
+
+  const body = buildIcsCalendar([event], {
+    prodId: PRODID,
+    calendarName: CALENDAR_NAME,
+  });
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/calendar; charset=utf-8",
+      "Content-Disposition": `attachment; filename="dondecorte-live-${live.id}.ics"`,
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/src/app/(public)/lives/[id]/page.tsx
+++ b/src/app/(public)/lives/[id]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cache } from "react";
+import { AddToCalendar } from "@/components/features/calendar/add-to-calendar";
 import { MemoSection } from "@/components/features/memo/memo-section";
 import { RelatedContents } from "@/components/features/related/related-contents";
 import { PerformerTagList } from "@/components/shared/performer-tags";
@@ -9,6 +10,7 @@ import { getLive as fetchLive } from "@/lib/queries/lives";
 import { getRelatedContents } from "@/lib/queries/related-contents";
 import type { CastEntry } from "@/lib/types";
 import { formatDate, formatTime } from "@/lib/utils/date";
+import { getSiteUrl } from "@/lib/utils/site-url";
 import { normalizeExternalUrl } from "@/lib/utils/url";
 
 export const dynamic = "force-dynamic";
@@ -108,6 +110,14 @@ export default async function LiveDetailPage({ params }: Props) {
         <div className="mt-4">
           <PerformerTagList performers={live.casts} />
         </div>
+      ) : null}
+
+      {live.event_date ? (
+        <AddToCalendar
+          live={live}
+          siteUrl={getSiteUrl()}
+          className="mt-6"
+        />
       ) : null}
 
       {safeUrl ? (

--- a/src/app/(public)/lives/page.tsx
+++ b/src/app/(public)/lives/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { LiveList } from "@/components/features/live/live-list";
 import { ListFilterBar } from "@/components/shared/list-filter-bar";
 import {
@@ -42,13 +43,21 @@ export default async function LivesPage({
 
   return (
     <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 md:py-12">
-      <header className="mb-6 md:mb-8">
-        <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
-          ライブ
-        </h1>
-        <p className="mt-2 text-sm text-brand-gold md:text-base">
-          ドンデコルテさん関連のライブ情報一覧。
-        </p>
+      <header className="mb-6 flex flex-wrap items-start justify-between gap-3 md:mb-8">
+        <div>
+          <h1 className="text-2xl font-bold text-brand-cream md:text-3xl">
+            ライブ
+          </h1>
+          <p className="mt-2 text-sm text-brand-gold md:text-base">
+            ドンデコルテさん関連のライブ情報一覧。
+          </p>
+        </div>
+        <Link
+          href="/calendar"
+          className="rounded-md border border-brand-border-dark bg-brand-card-dark px-3 py-1.5 text-sm text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky"
+        >
+          カレンダーで見る
+        </Link>
       </header>
 
       <ListFilterBar performers={performers} />

--- a/src/app/lives.ics/route.ts
+++ b/src/app/lives.ics/route.ts
@@ -1,3 +1,4 @@
+import { buildLiveCalendarDescription } from "@/lib/calendar/live-event";
 import { buildIcsCalendar, type IcsEvent } from "@/lib/ics/builder";
 import { normalizeStartTimeForIcs } from "@/lib/ics/start-time";
 import { listLivesForCalendar } from "@/lib/queries/lives";
@@ -7,20 +8,6 @@ export const dynamic = "force-dynamic";
 
 const PRODID = "-//dondecorte-lab//Lives//JA";
 const CALENDAR_NAME = "ドンデコルテ出演ライブ";
-
-function buildDescription(args: {
-  description: string | null;
-  casts: { name: string }[];
-  detailUrl: string;
-}): string | null {
-  const parts: string[] = [];
-  if (args.description) parts.push(args.description);
-  if (args.casts.length > 0) {
-    parts.push(`出演: ${args.casts.map((c) => c.name).join(", ")}`);
-  }
-  parts.push(args.detailUrl);
-  return parts.length > 0 ? parts.join("\n") : null;
-}
 
 export async function GET() {
   const lives = await listLivesForCalendar();
@@ -35,7 +22,7 @@ export async function GET() {
       startTime: normalizeStartTimeForIcs(live.start_time),
       summary: live.title,
       location: live.venue,
-      description: buildDescription({
+      description: buildLiveCalendarDescription({
         description: live.description,
         casts: live.casts,
         detailUrl: `${siteUrl}/lives/${live.id}`,

--- a/src/components/features/calendar/add-to-calendar.tsx
+++ b/src/components/features/calendar/add-to-calendar.tsx
@@ -1,0 +1,55 @@
+import { buildGoogleCalendarUrl } from "@/lib/calendar/google-url";
+import { buildLiveCalendarDescription } from "@/lib/calendar/live-event";
+import { normalizeStartTimeForIcs } from "@/lib/ics/start-time";
+
+type Props = {
+  live: {
+    id: string;
+    title: string;
+    event_date: string | null;
+    start_time: string | null;
+    venue: string | null;
+    description: string | null;
+    casts: { name: string }[];
+  };
+  siteUrl: string;
+  className?: string;
+};
+
+const linkClass =
+  "inline-flex items-center gap-1 rounded-md border border-brand-border-dark bg-brand-card-dark px-3 py-1.5 text-xs font-medium text-brand-sky-light transition hover:border-brand-sky hover:text-brand-sky";
+
+export function AddToCalendar({ live, siteUrl, className }: Props) {
+  if (!live.event_date) return null;
+
+  const detailUrl = `${siteUrl}/lives/${live.id}`;
+  const details = buildLiveCalendarDescription({
+    description: live.description,
+    casts: live.casts,
+    detailUrl,
+  });
+  const googleUrl = buildGoogleCalendarUrl({
+    title: live.title,
+    date: live.event_date,
+    startTime: normalizeStartTimeForIcs(live.start_time),
+    location: live.venue,
+    details,
+  });
+  const icsHref = `/lives/${live.id}/ics`;
+
+  return (
+    <div className={`flex flex-wrap gap-2 ${className ?? ""}`}>
+      <a
+        href={googleUrl}
+        target="_blank"
+        rel="noreferrer noopener"
+        className={linkClass}
+      >
+        Google カレンダーに追加 ↗
+      </a>
+      <a href={icsHref} download className={linkClass}>
+        .ics で追加
+      </a>
+    </div>
+  );
+}

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -18,6 +18,7 @@ const PRIMARY_ITEMS: NavItem[] = [
 
 const MORE_ITEMS: NavItem[] = [
   { href: "/timeline", label: "タイムライン" },
+  { href: "/calendar", label: "カレンダー" },
   { href: "/combos", label: "コンビ" },
   { href: "/units", label: "ユニット" },
   { href: "/radios", label: "ラジオ" },

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -7,6 +7,7 @@ const NAV_ITEMS = [
   { href: "/timeline", label: "タイムライン" },
   { href: "/videos", label: "動画" },
   { href: "/lives", label: "ライブ" },
+  { href: "/calendar", label: "カレンダー" },
   { href: "/radios", label: "ラジオ" },
   { href: "/articles", label: "記事" },
   { href: "/tv", label: "TV" },

--- a/src/lib/calendar/google-url.test.ts
+++ b/src/lib/calendar/google-url.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { buildGoogleCalendarUrl } from "./google-url";
+
+function parse(url: string): URLSearchParams {
+  return new URL(url).searchParams;
+}
+
+describe("buildGoogleCalendarUrl", () => {
+  it("render エンドポイント + action=TEMPLATE を使う", () => {
+    const url = buildGoogleCalendarUrl({
+      title: "単独ライブ",
+      date: "2026-06-01",
+      startTime: "19:00",
+    });
+    expect(url.startsWith("https://calendar.google.com/calendar/render?")).toBe(
+      true
+    );
+    expect(parse(url).get("action")).toBe("TEMPLATE");
+    expect(parse(url).get("text")).toBe("単独ライブ");
+  });
+
+  it("時刻指定: dates を local 連結 + ctz=Asia/Tokyo を付与", () => {
+    const url = buildGoogleCalendarUrl({
+      title: "ライブ",
+      date: "2026-06-01",
+      startTime: "19:00",
+    });
+    const params = parse(url);
+    expect(params.get("dates")).toBe("20260601T190000/20260601T210000");
+    expect(params.get("ctz")).toBe("Asia/Tokyo");
+  });
+
+  it("durationMinutes で終了時刻が変わる", () => {
+    const url = buildGoogleCalendarUrl({
+      title: "夜ライブ",
+      date: "2026-06-01",
+      startTime: "23:00",
+      durationMinutes: 90,
+    });
+    expect(parse(url).get("dates")).toBe("20260601T230000/20260602T003000");
+  });
+
+  it("終日: 終了日を翌日（排他的）にする / ctz は付けない", () => {
+    const url = buildGoogleCalendarUrl({
+      title: "終日イベント",
+      date: "2026-06-01",
+      startTime: null,
+    });
+    const params = parse(url);
+    expect(params.get("dates")).toBe("20260601/20260602");
+    expect(params.get("ctz")).toBeNull();
+  });
+
+  it("終日の複数日: endDate を含む帯にする", () => {
+    const url = buildGoogleCalendarUrl({
+      title: "先行抽選期間",
+      date: "2026-06-01",
+      startTime: null,
+      endDate: "2026-06-05",
+    });
+    expect(parse(url).get("dates")).toBe("20260601/20260606");
+  });
+
+  it("details / location をエンコードして付与する", () => {
+    const url = buildGoogleCalendarUrl({
+      title: "ライブ",
+      date: "2026-06-01",
+      startTime: "19:00",
+      details: "出演: 渡辺銀次, 小橋共作\nhttps://example.com/lives/1",
+      location: "神保町よしもと漫才劇場",
+    });
+    const params = parse(url);
+    expect(params.get("details")).toBe(
+      "出演: 渡辺銀次, 小橋共作\nhttps://example.com/lives/1"
+    );
+    expect(params.get("location")).toBe("神保町よしもと漫才劇場");
+  });
+
+  it("空の details / location は省略する", () => {
+    const url = buildGoogleCalendarUrl({
+      title: "ライブ",
+      date: "2026-06-01",
+      startTime: "19:00",
+      details: null,
+      location: null,
+    });
+    const params = parse(url);
+    expect(params.has("details")).toBe(false);
+    expect(params.has("location")).toBe(false);
+  });
+
+  it("不正な date は例外", () => {
+    expect(() =>
+      buildGoogleCalendarUrl({
+        title: "x",
+        date: "2026/06/01",
+        startTime: null,
+      })
+    ).toThrow(/YYYY-MM-DD/);
+  });
+});

--- a/src/lib/calendar/google-url.test.ts
+++ b/src/lib/calendar/google-url.test.ts
@@ -89,7 +89,7 @@ describe("buildGoogleCalendarUrl", () => {
     expect(params.has("location")).toBe(false);
   });
 
-  it("不正な date は例外", () => {
+  it("不正な date 形式は例外", () => {
     expect(() =>
       buildGoogleCalendarUrl({
         title: "x",
@@ -97,5 +97,25 @@ describe("buildGoogleCalendarUrl", () => {
         startTime: null,
       })
     ).toThrow(/YYYY-MM-DD/);
+  });
+
+  it("存在しない日付（2026-02-30）は例外", () => {
+    expect(() =>
+      buildGoogleCalendarUrl({
+        title: "x",
+        date: "2026-02-30",
+        startTime: null,
+      })
+    ).toThrow(/存在しない日付/);
+  });
+
+  it("範囲外の時刻（24:99:99）は例外", () => {
+    expect(() =>
+      buildGoogleCalendarUrl({
+        title: "x",
+        date: "2026-06-01",
+        startTime: "24:99:99",
+      })
+    ).toThrow(/範囲外/);
   });
 });

--- a/src/lib/calendar/google-url.ts
+++ b/src/lib/calendar/google-url.ts
@@ -31,7 +31,18 @@ function parseDate(dateStr: string): { y: number; m: number; d: number } {
   if (!match) {
     throw new Error(`date は YYYY-MM-DD 形式で渡してください: ${dateStr}`);
   }
-  return { y: Number(match[1]), m: Number(match[2]), d: Number(match[3]) };
+  const y = Number(match[1]);
+  const m = Number(match[2]);
+  const d = Number(match[3]);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  const isValid =
+    dt.getUTCFullYear() === y &&
+    dt.getUTCMonth() + 1 === m &&
+    dt.getUTCDate() === d;
+  if (!isValid) {
+    throw new Error(`存在しない日付です: ${dateStr}`);
+  }
+  return { y, m, d };
 }
 
 function parseTime(time: string): { hh: string; mm: string; ss: string } {
@@ -41,11 +52,13 @@ function parseTime(time: string): { hh: string; mm: string; ss: string } {
       `startTime は HH:MM もしくは HH:MM:SS 形式で渡してください: ${time}`
     );
   }
-  return {
-    hh: pad2(Number(match[1])),
-    mm: pad2(Number(match[2])),
-    ss: pad2(Number(match[3] ?? 0)),
-  };
+  const hh = Number(match[1]);
+  const mm = Number(match[2]);
+  const ss = Number(match[3] ?? 0);
+  if (hh > 23 || mm > 59 || ss > 59) {
+    throw new Error(`startTime の値が範囲外です: ${time}`);
+  }
+  return { hh: pad2(hh), mm: pad2(mm), ss: pad2(ss) };
 }
 
 function compactDate(dateStr: string): string {

--- a/src/lib/calendar/google-url.ts
+++ b/src/lib/calendar/google-url.ts
@@ -1,0 +1,104 @@
+// Google カレンダーの「テンプレート URL」ビルダ。OAuth 不要でワンタップ追加できる。
+// 注意: テンプレート URL ではリマインド時刻を指定できない（ユーザー既定の通知になる）。
+// リマインド時刻を初期設定したい場合は個別 .ics（VALARM 付き）を使う。
+
+const RENDER_BASE = "https://calendar.google.com/calendar/render";
+const DEFAULT_TIMEZONE = "Asia/Tokyo";
+const DEFAULT_DURATION_MINUTES = 120;
+
+export type GoogleCalendarEvent = {
+  title: string;
+  /** YYYY-MM-DD */
+  date: string;
+  /** HH:MM or HH:MM:SS。null なら終日イベント。 */
+  startTime: string | null;
+  /** 時刻指定イベントの長さ。既定 120 分。終日イベントでは無視。 */
+  durationMinutes?: number;
+  /** 終日イベントの終了日（YYYY-MM-DD、含む）。複数日にまたがる帯に使う。 */
+  endDate?: string | null;
+  details?: string | null;
+  location?: string | null;
+  /** 既定 Asia/Tokyo。時刻指定イベントの ctz に使う。 */
+  timezone?: string;
+};
+
+function pad2(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+function parseDate(dateStr: string): { y: number; m: number; d: number } {
+  const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    throw new Error(`date は YYYY-MM-DD 形式で渡してください: ${dateStr}`);
+  }
+  return { y: Number(match[1]), m: Number(match[2]), d: Number(match[3]) };
+}
+
+function parseTime(time: string): { hh: string; mm: string; ss: string } {
+  const match = time.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
+  if (!match) {
+    throw new Error(
+      `startTime は HH:MM もしくは HH:MM:SS 形式で渡してください: ${time}`
+    );
+  }
+  return {
+    hh: pad2(Number(match[1])),
+    mm: pad2(Number(match[2])),
+    ss: pad2(Number(match[3] ?? 0)),
+  };
+}
+
+function compactDate(dateStr: string): string {
+  return dateStr.replace(/-/g, "");
+}
+
+function addDays(dateStr: string, days: number): string {
+  const { y, m, d } = parseDate(dateStr);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return `${dt.getUTCFullYear()}-${pad2(dt.getUTCMonth() + 1)}-${pad2(dt.getUTCDate())}`;
+}
+
+function buildTimedRange(
+  date: string,
+  startTime: string,
+  durationMinutes: number
+): string {
+  const { y, m, d } = parseDate(date);
+  const { hh, mm, ss } = parseTime(startTime);
+  const start = new Date(
+    Date.UTC(y, m - 1, d, Number(hh), Number(mm), Number(ss))
+  );
+  const end = new Date(start.getTime() + durationMinutes * 60_000);
+  const fmt = (dt: Date) =>
+    `${dt.getUTCFullYear()}${pad2(dt.getUTCMonth() + 1)}${pad2(dt.getUTCDate())}` +
+    `T${pad2(dt.getUTCHours())}${pad2(dt.getUTCMinutes())}${pad2(dt.getUTCSeconds())}`;
+  return `${fmt(start)}/${fmt(end)}`;
+}
+
+function buildAllDayRange(date: string, endDate?: string | null): string {
+  // Google の終日イベントは終了日が「翌日（排他的）」。
+  const lastDay = endDate ?? date;
+  const exclusiveEnd = addDays(lastDay, 1);
+  return `${compactDate(date)}/${compactDate(exclusiveEnd)}`;
+}
+
+export function buildGoogleCalendarUrl(event: GoogleCalendarEvent): string {
+  const timezone = event.timezone ?? DEFAULT_TIMEZONE;
+  const params = new URLSearchParams();
+  params.set("action", "TEMPLATE");
+  params.set("text", event.title);
+
+  if (event.startTime) {
+    const duration = event.durationMinutes ?? DEFAULT_DURATION_MINUTES;
+    params.set("dates", buildTimedRange(event.date, event.startTime, duration));
+    params.set("ctz", timezone);
+  } else {
+    params.set("dates", buildAllDayRange(event.date, event.endDate));
+  }
+
+  if (event.details) params.set("details", event.details);
+  if (event.location) params.set("location", event.location);
+
+  return `${RENDER_BASE}?${params.toString()}`;
+}

--- a/src/lib/calendar/live-event.ts
+++ b/src/lib/calendar/live-event.ts
@@ -1,0 +1,24 @@
+import type { IcsReminder } from "@/lib/ics/builder";
+
+// ライブ開始のリマインダ（VALARM）。前日同時刻 + 当日 2 時間前。
+export const TIMED_LIVE_REMINDERS: IcsReminder[] = [
+  { minutesBefore: 1440 },
+  { minutesBefore: 120 },
+];
+
+// 終日扱い（開始時刻未定）のライブは前日リマインダのみ。
+export const ALL_DAY_LIVE_REMINDERS: IcsReminder[] = [{ minutesBefore: 1440 }];
+
+export function buildLiveCalendarDescription(args: {
+  description: string | null;
+  casts: { name: string }[];
+  detailUrl: string;
+}): string {
+  const parts: string[] = [];
+  if (args.description) parts.push(args.description);
+  if (args.casts.length > 0) {
+    parts.push(`出演: ${args.casts.map((c) => c.name).join(", ")}`);
+  }
+  parts.push(args.detailUrl);
+  return parts.join("\n");
+}

--- a/src/lib/calendar/month-grid.test.ts
+++ b/src/lib/calendar/month-grid.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMonthMatrix,
+  parseYearMonth,
+  shiftMonth,
+  todayInTokyo,
+} from "./month-grid";
+
+describe("parseYearMonth", () => {
+  it("YYYY-MM をパースする", () => {
+    expect(parseYearMonth("2026-06", 2000, 1)).toEqual({ year: 2026, month: 6 });
+  });
+
+  it("不正値はフォールバック", () => {
+    expect(parseYearMonth("bad", 2026, 5)).toEqual({ year: 2026, month: 5 });
+    expect(parseYearMonth("2026-13", 2026, 5)).toEqual({ year: 2026, month: 5 });
+    expect(parseYearMonth(undefined, 2026, 5)).toEqual({ year: 2026, month: 5 });
+  });
+});
+
+describe("shiftMonth", () => {
+  it("年をまたいで前後に移動する", () => {
+    expect(shiftMonth(2026, 1, -1)).toEqual({ year: 2025, month: 12 });
+    expect(shiftMonth(2026, 12, 1)).toEqual({ year: 2027, month: 1 });
+  });
+});
+
+describe("buildMonthMatrix", () => {
+  it("6週×7日 = 42セルを返す", () => {
+    const matrix = buildMonthMatrix(2026, 6, "2026-06-15");
+    expect(matrix.length).toBe(6);
+    expect(matrix.flat().length).toBe(42);
+  });
+
+  it("日曜始まりで月初・月末の前後日が埋まる", () => {
+    // 2026-06-01 は月曜。先頭セルは前月の日曜 2026-05-31。
+    const matrix = buildMonthMatrix(2026, 6, "2026-06-15");
+    const flat = matrix.flat();
+    expect(flat[0].date).toBe("2026-05-31");
+    expect(flat[0].inCurrentMonth).toBe(false);
+    const june1 = flat.find((c) => c.date === "2026-06-01");
+    expect(june1?.inCurrentMonth).toBe(true);
+  });
+
+  it("today フラグが立つ", () => {
+    const matrix = buildMonthMatrix(2026, 6, "2026-06-15");
+    const today = matrix.flat().find((c) => c.isToday);
+    expect(today?.date).toBe("2026-06-15");
+  });
+});
+
+describe("todayInTokyo", () => {
+  it("Asia/Tokyo の YYYY-MM-DD を返す", () => {
+    // UTC 2026-06-01 16:00 は JST で 2026-06-02 01:00。
+    expect(todayInTokyo(new Date("2026-06-01T16:00:00Z"))).toBe("2026-06-02");
+  });
+});

--- a/src/lib/calendar/month-grid.ts
+++ b/src/lib/calendar/month-grid.ts
@@ -1,0 +1,82 @@
+export type CalendarDay = {
+  /** YYYY-MM-DD */
+  date: string;
+  day: number;
+  inCurrentMonth: boolean;
+  isToday: boolean;
+};
+
+function pad2(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+function ymd(year: number, month: number, day: number): string {
+  return `${year}-${pad2(month)}-${pad2(day)}`;
+}
+
+export function todayInTokyo(now: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
+export function parseYearMonth(
+  value: string | undefined,
+  fallbackYear: number,
+  fallbackMonth: number
+): { year: number; month: number } {
+  const match = value?.match(/^(\d{4})-(\d{2})$/);
+  if (!match) return { year: fallbackYear, month: fallbackMonth };
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (month < 1 || month > 12) return { year: fallbackYear, month: fallbackMonth };
+  return { year, month };
+}
+
+export function shiftMonth(
+  year: number,
+  month: number,
+  delta: number
+): { year: number; month: number } {
+  const dt = new Date(Date.UTC(year, month - 1 + delta, 1));
+  return { year: dt.getUTCFullYear(), month: dt.getUTCMonth() + 1 };
+}
+
+export function formatYearMonth(year: number, month: number): string {
+  return `${year}-${pad2(month)}`;
+}
+
+// 日曜始まりの 6 週 × 7 日（42 セル）固定マトリクス。
+export function buildMonthMatrix(
+  year: number,
+  month: number,
+  today: string
+): CalendarDay[][] {
+  const first = new Date(Date.UTC(year, month - 1, 1));
+  const startWeekday = first.getUTCDay();
+  const cursor = new Date(first);
+  cursor.setUTCDate(1 - startWeekday);
+
+  const weeks: CalendarDay[][] = [];
+  for (let w = 0; w < 6; w++) {
+    const week: CalendarDay[] = [];
+    for (let d = 0; d < 7; d++) {
+      const y = cursor.getUTCFullYear();
+      const m = cursor.getUTCMonth() + 1;
+      const dd = cursor.getUTCDate();
+      const date = ymd(y, m, dd);
+      week.push({
+        date,
+        day: dd,
+        inCurrentMonth: m === month && y === year,
+        isToday: date === today,
+      });
+      cursor.setUTCDate(cursor.getUTCDate() + 1);
+    }
+    weeks.push(week);
+  }
+  return weeks;
+}

--- a/src/lib/calendar/month-grid.ts
+++ b/src/lib/calendar/month-grid.ts
@@ -15,12 +15,17 @@ function ymd(year: number, month: number, day: number): string {
 }
 
 export function todayInTokyo(now: Date = new Date()): string {
-  return new Intl.DateTimeFormat("en-CA", {
+  // format() の出力順は locale / ICU バージョンで揺れるため、type 指定でパーツを組む。
+  const parts = new Intl.DateTimeFormat("en-CA", {
     timeZone: "Asia/Tokyo",
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
-  }).format(now);
+  }).formatToParts(now);
+  const year = parts.find((p) => p.type === "year")?.value ?? "0000";
+  const month = parts.find((p) => p.type === "month")?.value ?? "01";
+  const day = parts.find((p) => p.type === "day")?.value ?? "01";
+  return `${year}-${month}-${day}`;
 }
 
 export function parseYearMonth(

--- a/src/lib/ics/builder.test.ts
+++ b/src/lib/ics/builder.test.ts
@@ -3,6 +3,7 @@ import {
   buildIcsCalendar,
   escapeIcsText,
   foldIcsLine,
+  formatReminderTrigger,
   type IcsEvent,
 } from "./builder";
 
@@ -51,6 +52,28 @@ describe("foldIcsLine", () => {
     for (const seg of folded.split("\r\n")) {
       expect(Buffer.byteLength(seg, "utf8")).toBeLessThanOrEqual(76);
     }
+  });
+});
+
+describe("formatReminderTrigger", () => {
+  it("日単位に丸める", () => {
+    expect(formatReminderTrigger(1440)).toBe("-P1D");
+    expect(formatReminderTrigger(2880)).toBe("-P2D");
+  });
+
+  it("時単位に丸める", () => {
+    expect(formatReminderTrigger(120)).toBe("-PT2H");
+    expect(formatReminderTrigger(60)).toBe("-PT1H");
+  });
+
+  it("分単位はそのまま", () => {
+    expect(formatReminderTrigger(30)).toBe("-PT30M");
+    expect(formatReminderTrigger(90)).toBe("-PT90M");
+  });
+
+  it("0 以下は -PT0M", () => {
+    expect(formatReminderTrigger(0)).toBe("-PT0M");
+    expect(formatReminderTrigger(-10)).toBe("-PT0M");
   });
 });
 
@@ -185,6 +208,37 @@ describe("buildIcsCalendar", () => {
     const vevents = ics.split("BEGIN:VEVENT").length - 1;
     expect(vevents).toBe(2);
     expect(ics.indexOf("UID:a")).toBeLessThan(ics.indexOf("UID:b"));
+  });
+
+  it("reminders を VALARM (DISPLAY) として出力する", () => {
+    const event: IcsEvent = {
+      uid: "u",
+      date: "2026-06-01",
+      startTime: "19:00",
+      summary: "単独ライブ",
+      reminders: [{ minutesBefore: 1440 }, { minutesBefore: 120 }],
+    };
+    const ics = buildIcsCalendar([event], baseOptions);
+    expect(ics).toContain("BEGIN:VALARM");
+    expect(ics).toContain("ACTION:DISPLAY");
+    expect(ics).toContain("DESCRIPTION:単独ライブ");
+    expect(ics).toContain("TRIGGER:-P1D");
+    expect(ics).toContain("TRIGGER:-PT2H");
+    expect(ics).toContain("END:VALARM");
+    expect(ics.split("BEGIN:VALARM").length - 1).toBe(2);
+    // VALARM は VEVENT 内（END:VEVENT より前）に置く
+    expect(ics.indexOf("BEGIN:VALARM")).toBeLessThan(ics.indexOf("END:VEVENT"));
+  });
+
+  it("reminders 未指定なら VALARM を出力しない", () => {
+    const event: IcsEvent = {
+      uid: "u",
+      date: "2026-06-01",
+      startTime: "19:00",
+      summary: "ライブ",
+    };
+    const ics = buildIcsCalendar([event], baseOptions);
+    expect(ics).not.toContain("BEGIN:VALARM");
   });
 
   it("行末は全て CRLF", () => {

--- a/src/lib/ics/builder.test.ts
+++ b/src/lib/ics/builder.test.ts
@@ -75,6 +75,11 @@ describe("formatReminderTrigger", () => {
     expect(formatReminderTrigger(0)).toBe("-PT0M");
     expect(formatReminderTrigger(-10)).toBe("-PT0M");
   });
+
+  it("非有限値は例外", () => {
+    expect(() => formatReminderTrigger(Number.NaN)).toThrow(/有限/);
+    expect(() => formatReminderTrigger(Number.POSITIVE_INFINITY)).toThrow(/有限/);
+  });
 });
 
 describe("buildIcsCalendar", () => {

--- a/src/lib/ics/builder.ts
+++ b/src/lib/ics/builder.ts
@@ -149,6 +149,11 @@ function addMinutesToLocal(
 
 // VALARM の TRIGGER は開始時刻からの相対時間。分→日/時/分の順で見やすく丸める。
 export function formatReminderTrigger(minutesBefore: number): string {
+  if (!Number.isFinite(minutesBefore)) {
+    throw new Error(
+      `IcsReminder.minutesBefore は有限の数値で渡してください: ${minutesBefore}`
+    );
+  }
   const minutes = Math.max(0, Math.round(minutesBefore));
   if (minutes === 0) return "-PT0M";
   if (minutes % 1440 === 0) return `-P${minutes / 1440}D`;

--- a/src/lib/ics/builder.ts
+++ b/src/lib/ics/builder.ts
@@ -1,3 +1,8 @@
+/** 開始時刻の何分前にリマインドするか。例: 1440 = 前日同時刻 / 120 = 2時間前。 */
+export type IcsReminder = {
+  minutesBefore: number;
+};
+
 export type IcsEvent = {
   uid: string;
   /** YYYY-MM-DD */
@@ -10,6 +15,8 @@ export type IcsEvent = {
   location?: string | null;
   description?: string | null;
   url?: string | null;
+  /** VALARM。各要素が 1 つの DISPLAY アラームになる。 */
+  reminders?: IcsReminder[];
 };
 
 export type IcsCalendarOptions = {
@@ -140,6 +147,25 @@ function addMinutesToLocal(
   };
 }
 
+// VALARM の TRIGGER は開始時刻からの相対時間。分→日/時/分の順で見やすく丸める。
+export function formatReminderTrigger(minutesBefore: number): string {
+  const minutes = Math.max(0, Math.round(minutesBefore));
+  if (minutes === 0) return "-PT0M";
+  if (minutes % 1440 === 0) return `-P${minutes / 1440}D`;
+  if (minutes % 60 === 0) return `-PT${minutes / 60}H`;
+  return `-PT${minutes}M`;
+}
+
+function buildAlarm(reminder: IcsReminder, summary: string): string[] {
+  return [
+    "BEGIN:VALARM",
+    "ACTION:DISPLAY",
+    `DESCRIPTION:${escapeIcsText(summary)}`,
+    `TRIGGER:${formatReminderTrigger(reminder.minutesBefore)}`,
+    "END:VALARM",
+  ];
+}
+
 function buildEvent(
   event: IcsEvent,
   options: { timezone: string; dtstamp: string }
@@ -176,6 +202,9 @@ function buildEvent(
   }
   if (event.url) {
     lines.push(`URL:${event.url}`);
+  }
+  for (const reminder of event.reminders ?? []) {
+    lines.push(...buildAlarm(reminder, event.summary));
   }
   lines.push("END:VEVENT");
   return lines;


### PR DESCRIPTION
## 概要

issue #114「カレンダーview + Googleカレンダー個別追加導線（ライブ日・抽選期間）」の対応です。

公開側に **カレンダー view** を新設し、各ライブを **1件ずつ Google カレンダーに追加**できる導線（テンプレート URL / VALARM 付き個別 .ics）を用意しました。リマインドは Google カレンダー側に委譲する方針（#115）に沿っています。

依存先の #111（`src/lib/ics/builder.ts` / `/lives.ics`）は完了済みのため、**外部 API キーや Google Cloud の手動設定なしで先行リリース可能**な範囲を実装しています。

Closes #114

## 変更内容

### カレンダー view（公開側）

- `src/app/(public)/calendar/page.tsx` を新設
  - 月表示（日曜始まり、6週×7日固定）+「これからのライブ」リスト
  - `?ym=YYYY-MM` で表示月を切り替え（前月 / 翌月リンク）
  - 月セルのライブはライブ詳細へリンク

### Google カレンダー個別追加導線

- `src/lib/calendar/google-url.ts` … テンプレート URL ビルダ
  - 時刻指定: `dates=...T.../...T...` + `ctz=Asia/Tokyo`
  - 終日: `dates=YYYYMMDD/翌日（排他的）`、複数日 `endDate` 対応（抽選期間の帯を見据えた実装）
  - ⚠️ テンプレート URL はリマインド時刻を指定できない点をコメントで明記
- 個別 .ics ルート `GET /lives/[id]/ics`
  - VALARM 付き。`start_time` あり → 前日 + 2時間前 / なし → 前日のみ
  - `Content-Disposition: attachment` でダウンロード

### ICS builder（#111 の拡張）

- `src/lib/ics/builder.ts` に `reminders?: { minutesBefore }[]` を追加し VALARM(DISPLAY) を出力
- TRIGGER は分→日/時/分に丸める（`formatReminderTrigger`）
- 既存 `/lives.ics` と description 生成ロジックを `src/lib/calendar/live-event.ts` に集約

### UI / 導線

- `AddToCalendar` コンポーネント（ライブ詳細・カレンダー view で共用）
- ヘッダー / ボトムナビ / ライブ一覧ページにカレンダー導線を追加

## テスト

- `builder.test.ts` … VALARM 出力 / `formatReminderTrigger`
- `google-url.test.ts` … 時刻指定・終日・複数日・エンコード・異常系
- `month-grid.test.ts` … 月マトリクス / 月送り / Asia/Tokyo の today
- `pnpm test` 全 **189 件パス** / `pnpm lint` クリーン / `tsc --noEmit` クリーン
- `pnpm build`（placeholder env）で全体パス。`/calendar`・`/lives/[id]/ics` が dynamic ルートとして認識されることを確認

## スコープ外（後続）

- 先行抽選期間（`live_presales`）の重ね表示・個別 .ics への抽選イベント同梱は #97（Fany 連携）でテーブルが用意され次第に対応予定。本 PR はライブ日のみで先行リリース。
- Google Calendar OAuth 直接書き込みは #43。

## 動作確認の補足

実データ（Supabase 接続）でのブラウザ確認はこの環境では行えていません。ビルド・型・テストでの検証のみ実施しています。マージ後に本番でカレンダー表示と各追加導線の動作確認をお願いします。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PodiSWw3f6DTNXCAY2JhUA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar view to browse and discover upcoming live events organized by month
  * Added one-click integration to add individual live events to Google Calendar
  * Added .ics file download option for specific live events
  * Calendar navigation added to app header and menu

* **Documentation**
  * Updated setup guide with calendar feature instructions and usage details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->