### PR TITLE
feat: public スキーマ全テーブルへの明示的な GRANT を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ Tailwindカスタムカラー: `brand-brown-*`, `brand-sky-*`, `brand-cream`, `b
 - 新しいテーブルを `create table` した直後、必ず以下を明示的に書く（2026-05-30 以降の Supabase 新挙動対応。`public` スキーマのテーブルはデフォルトでは Data API に公開されなくなる）:
   - 公開読み取り対象: `grant select on public.<table> to anon;` + `grant select, insert, update, delete on public.<table> to authenticated, service_role;`
   - 機微情報を含むテーブル（例: `push_subscriptions`）: anon は必要最小限のみ。読み書きはサーバ側 `service_role` 経由に限定する
+- `serial` / `bigserial` / `generated ... as identity` を使うテーブルは、008 でデフォルト sequence 権限も revoke しているため、`grant usage, select on sequence public.<table>_<col>_seq to anon, authenticated, service_role;`（必要なロールのみ）も書く。本プロジェクトは現状すべて `uuid` 主キーなので不要だが、将来 serial / identity を採用する場合は忘れずに
 - RLS だけでは PostgREST から `permission denied` で弾かれるため、`enable row level security` / `create policy` と **必ずセット** で `grant` を書く
 - 新しい RPC 関数を `create function` したら `grant execute on function ... to authenticated;`（または `service_role`）を忘れずに
 - 参考: `supabase/migrations/008_explicit_grants.sql`、https://github.com/orgs/supabase/discussions/45329

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,14 @@ Tailwindカスタムカラー: `brand-brown-*`, `brand-sky-*`, `brand-cream`, `b
 - `lib/actions/` に配置。`"use server"` 付き。
 - cast処理は各actionsファイル内に含める（Phase4でservices層に分離予定）
 
+### DB migration（GRANT 必須）
+- 新しいテーブルを `create table` した直後、必ず以下を明示的に書く（2026-05-30 以降の Supabase 新挙動対応。`public` スキーマのテーブルはデフォルトでは Data API に公開されなくなる）:
+  - 公開読み取り対象: `grant select on public.<table> to anon;` + `grant select, insert, update, delete on public.<table> to authenticated, service_role;`
+  - 機微情報を含むテーブル（例: `push_subscriptions`）: anon は必要最小限のみ。読み書きはサーバ側 `service_role` 経由に限定する
+- RLS だけでは PostgREST から `permission denied` で弾かれるため、`enable row level security` / `create policy` と **必ずセット** で `grant` を書く
+- 新しい RPC 関数を `create function` したら `grant execute on function ... to authenticated;`（または `service_role`）を忘れずに
+- 参考: `supabase/migrations/008_explicit_grants.sql`、https://github.com/orgs/supabase/discussions/45329
+
 ### cast-selector（最重要共通コンポーネント）
 - 管理画面の6コンテンツ（video, live, radio, article, tv, topic）全てで使い回す
 - Artist / Combo / Unit のタブ切り替え + 検索 + 選択タグ表示

--- a/docs/design.md
+++ b/docs/design.md
@@ -620,6 +620,11 @@ grant select, insert, update, delete on public.push_subscriptions to service_rol
 
 -- RPC 関数
 grant execute on function public.<func>(<args>) to authenticated;
+
+-- serial / bigserial / generated ... as identity を使う場合は backing sequence にも grant が必要
+-- （008 で sequence のデフォルト権限も revoke しているため）。本プロジェクトは uuid 主キーのみで
+-- 現状は不要だが、採用した際は忘れずに：
+-- grant usage, select on sequence public.<table>_<col>_seq to anon, authenticated, service_role;
 ```
 
 既存テーブルへの一括 GRANT は `supabase/migrations/008_explicit_grants.sql` に集約済み。同 migration では将来のテーブルでデフォルト GRANT に依存しないよう `alter default privileges ... revoke ...` も実行している。

--- a/docs/design.md
+++ b/docs/design.md
@@ -604,6 +604,28 @@ create policy memos_update on memos for update to authenticated using (true) wit
 create policy memos_delete on memos for delete to authenticated using (true);
 ```
 
+### GRANT（2026-05-30 以降の Supabase 新挙動対応）
+
+Supabase は 2026-05-30 以降の新規プロジェクトで `public` スキーマのテーブルをデフォルトで Data API に公開しなくなる（既存プロジェクトも 2026-10-30 以降同じ挙動）。RLS とは別に **SQL レベルの GRANT が必須** になるため、新しいテーブル / RPC 関数を追加する migration では必ず明示的に書く。
+
+```sql
+-- 公開読み取り対象テーブルの典型パターン
+grant select on public.<table> to anon;
+grant select, insert, update, delete on public.<table> to authenticated;
+grant select, insert, update, delete on public.<table> to service_role;
+
+-- 機微情報を含むテーブル（push_subscriptions 等）は anon を最小限に
+grant insert on public.push_subscriptions to anon;
+grant select, insert, update, delete on public.push_subscriptions to service_role;
+
+-- RPC 関数
+grant execute on function public.<func>(<args>) to authenticated;
+```
+
+既存テーブルへの一括 GRANT は `supabase/migrations/008_explicit_grants.sql` に集約済み。同 migration では将来のテーブルでデフォルト GRANT に依存しないよう `alter default privileges ... revoke ...` も実行している。
+
+参考: https://github.com/orgs/supabase/discussions/45329
+
 ---
 
 ## よく使うクエリ例

--- a/supabase/migrations/008_explicit_grants.sql
+++ b/supabase/migrations/008_explicit_grants.sql
@@ -1,0 +1,62 @@
+-- ============================================
+-- public スキーマ全テーブルへの明示的な GRANT
+-- ============================================
+-- Supabase は 2026-05-30 以降の新規プロジェクトで、`public` スキーマの
+-- テーブルをデフォルトでは Data API（PostgREST / GraphQL / supabase-js）に
+-- 公開しなくなる。既存プロジェクトも 2026-10-30 以降は同じ挙動に切り替わる。
+-- 参考: https://github.com/orgs/supabase/discussions/45329
+--
+-- 既存の migration 001 / 004 / 005 / 007 は RLS ポリシーのみで、SQL レベルの
+-- GRANT を Supabase のデフォルト権限に依存していた。新挙動下では RLS の前に
+-- GRANT が無いと PostgREST が「permission denied」で弾くため、ここで明示的に
+-- 付与する。同時に将来のテーブルでもデフォルト GRANT に依存しないよう、
+-- alter default privileges で revoke しておく（個別 migration で都度 grant する運用に変える）。
+
+-- ============================================
+-- 1. 公開読み取り対象テーブル（anon: SELECT / authenticated, service_role: CRUD）
+-- ============================================
+-- メモ含む 16 テーブル。書き込みは RLS で `authenticated` のみに絞られる。
+do $$
+declare
+  t text;
+begin
+  for t in
+    select unnest(array[
+      'artists','comedy_groups','comedy_group_members',
+      'units','unit_members','achievements',
+      'videos','lives','radios','articles','tv_shows','topics',
+      'casts','memos','tags','taggings'
+    ])
+  loop
+    execute format('grant select on public.%I to anon', t);
+    execute format('grant select, insert, update, delete on public.%I to authenticated', t);
+    execute format('grant select, insert, update, delete on public.%I to service_role', t);
+  end loop;
+end $$;
+
+-- ============================================
+-- 2. push_subscriptions（機微情報のため anon は INSERT のみ）
+-- ============================================
+-- endpoint / p256dh / auth が anon に読めると第三者が任意送信できてしまうため、
+-- RLS でも anon の SELECT を許可していない。GRANT も合わせる。
+-- 読み取り・削除はサーバ側で service_role から実行する。
+grant insert on public.push_subscriptions to anon;
+grant select, insert, update, delete on public.push_subscriptions to service_role;
+
+-- ============================================
+-- 3. RPC 関数への EXECUTE 権限
+-- ============================================
+-- migration 006 の upsert_content_with_casts は既に grant 済み。
+-- migration 002 の replace_comedy_group_members は未付与だったため明示する。
+grant execute on function public.replace_comedy_group_members(uuid, jsonb) to authenticated;
+
+-- ============================================
+-- 4. 将来のテーブル：デフォルト GRANT を切る
+-- ============================================
+-- 以降 `create table` した直後に明示的に `grant ... to anon/authenticated/service_role` を
+-- 書く運用に統一する（CLAUDE.md / docs/design.md にルール記載）。
+alter default privileges for role postgres in schema public
+  revoke select, insert, update, delete on tables from anon, authenticated, service_role;
+
+alter default privileges for role postgres in schema public
+  revoke usage, select on sequences from anon, authenticated, service_role;


### PR DESCRIPTION
## 概要

Supabase の挙動変更（[supabase/discussions/45329](https://github.com/orgs/supabase/discussions/45329)）への対応。

- **2026-05-30** 以降の新規プロジェクトでは、`public` スキーマのテーブルがデフォルトでは Data API（PostgREST / GraphQL / supabase-js）に公開されなくなる
- **既存プロジェクト** も **2026-10-30** 以降は同じ挙動に切り替わる
- 既存の migration（001 / 004 / 005 / 007）は RLS ポリシーのみで、SQL レベルの `GRANT` を Supabase のデフォルト権限に依存していた。新挙動下では RLS の前に GRANT が無いと PostgREST が `permission denied` で弾くため、ここで明示的に付与する

## 変更内容

### `supabase/migrations/008_explicit_grants.sql`（新規）

- **公開読み取り対象 16 テーブル** に `anon: SELECT` / `authenticated, service_role: CRUD` を明示付与
  - artists / comedy_groups / comedy_group_members / units / unit_members / achievements
  - videos / lives / radios / articles / tv_shows / topics
  - casts / memos / tags / taggings
- **`push_subscriptions`** は機微情報（endpoint / p256dh / auth が漏れると第三者が任意送信できる）のため、`anon: INSERT のみ` / `service_role: CRUD`。読み取り・GC はサーバ側から service_role で実行
- **`replace_comedy_group_members(uuid, jsonb)`** RPC に `grant execute to authenticated`（migration 002 で漏れていたため補完）
  - 既に `grant execute` 済みの `upsert_content_with_casts`（migration 006）はそのまま
- **将来のテーブルでデフォルト GRANT に依存しない運用** にするため、`alter default privileges for role postgres in schema public revoke ...` を実行

### `CLAUDE.md`

「コーディング規約」に「**DB migration（GRANT 必須）**」セクションを追加。新テーブル / 新 RPC 追加時の必須パターンを記載。

### `docs/design.md`

RLS セクションの直後に「GRANT」サブセクションを追加し、テンプレートと参考リンクを明記。

## 影響

- 既存プロジェクトは現状でも動いているため **今すぐの破壊的変更はなし**
- 2026-10-30 以降にデフォルト GRANT が失われても、この migration 適用後はそのまま動作し続ける
- 以降の新規 migration では `create table` / `create function` の直後に GRANT を書く運用に統一

## 関連 PR

PR #106（Web Push 通知基盤）の `push_subscriptions` への GRANT 漏れもこの migration でカバー済み。同 PR は main から大きく乖離しスタール状態だったため別途クローズ。

## テスト

- SQL のみの変更でアプリコードに影響なし
- 本 migration を Supabase に流した後、公開ページの SELECT / 管理画面の CRUD / Web Push 購読が引き続き動くことを確認する想定

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU1n1XskHGZdHo45MDL3j7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on mandatory SQL-level permission grants, migration procedures, and examples for granting access.
  * Clarified practices for handling sensitive tables and generated identifiers to preserve least-privilege.

* **Chores**
  * Applied explicit database permission changes and updated migration steps to ensure API access remains functional without relying on default privileges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiiragi17/dondecorte-lab/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->