### PR TITLE
feat: YouTube動画自動取得のVercel Cronを追加 (#39)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ NEXT_PUBLIC_SITE_URL=
 # 取得手順は docs/setup.md「Step 9」を参照
 YOUTUBE_API_KEY=
 
+# Vercel Cron 用シークレット（/api/cron/* の認証）。任意のランダム文字列を生成して設定する。
+# 例: openssl rand -hex 32
+# Vercel に登録すると Cron 実行時に Authorization: Bearer <CRON_SECRET> が自動付与される。
+CRON_SECRET=
+
 # Web Push（VAPID）。`npx web-push generate-vapid-keys` で一度だけ生成し使い回す。
 # 変更すると既存の購読が全て無効になるので注意。
 # VAPID_PUBLIC_KEY は公開フッターの購読ボタンにも使われる（クライアントへ露出してよい値）。

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -337,8 +337,60 @@ Vercel の環境変数にも同じキーを登録する（`Production` / `Previe
    - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
    - `SUPABASE_SERVICE_ROLE_KEY`
    - `NEXT_PUBLIC_SITE_URL`（例: `https://dondecorte-lab.vercel.app`）
+   - `YOUTUBE_API_KEY`（YouTube 動画自動取得 / Cron で使用。Step 9 参照）
+   - `CRON_SECRET`（Cron 認証用。`openssl rand -hex 32` 等で生成。Step 11 参照）
 3. 初回デプロイ後に公開URLで表示を確認する。
 4. YouTube サムネイル最適化のため `next.config.ts` の `images.remotePatterns` に `img.youtube.com` と `i.ytimg.com`（いずれも `/vi/**`）が含まれていることを確認する。
+
+---
+
+## Step 11: Cron（YouTube動画自動取得）セットアップ
+
+`/api/cron/youtube` を Vercel Cron が日次で叩き、`comedy_groups.youtube_channel_id` に登録された各チャンネルから新着動画を `videos` テーブルへ取り込む（issue #39 / #38）。
+
+> ℹ️ このルートは **Vercel Cron 専用のバックグラウンドジョブ**で、公開ページの表示には一切関与しない。失敗しても公開サイトにエラーは出ず、その日の取り込みがスキップされるだけ（1日1回実行）。
+
+### 11-1. スケジュール
+
+`vercel.json` の `crons` に設定済み。
+
+```json
+{
+  "crons": [{ "path": "/api/cron/youtube", "schedule": "0 3 * * *" }]
+}
+```
+
+- `0 3 * * *` = UTC 03:00 = **JST 12:00**。
+- Vercel 無料(Hobby)プランは日次粒度の Cron 1 本まで。
+
+### 11-2. 必要な環境変数（Vercel）
+
+| 変数 | 用途 | 未設定時の挙動 |
+| --- | --- | --- |
+| `CRON_SECRET` | Cron 認証。Vercel が `Authorization: Bearer <CRON_SECRET>` を自動付与 | ルートが**常に 401**（誰でも叩ける状態を避けるため一律拒否） |
+| `YOUTUBE_API_KEY` | YouTube Data API v3（Step 9） | 全チャンネル同期が失敗 → **500** |
+
+- `CRON_SECRET` は `openssl rand -hex 32` 等で生成し、Production（必要なら Preview）に登録する。
+- 設定変更後は再デプロイで反映。
+
+### 11-3. 前提データ
+
+- 本番 Supabase の `comedy_groups.youtube_channel_id` にチャンネルIDが入っていること（公式: `UC4y-_Xwudf7gB5sXsbipDkQ`）。`supabase/seed.sql`（#26）を流すと投入される。未投入なら巡回対象 0 件（エラーにはならず `200 / channels:0`）。
+
+### 11-4. 手動テスト
+
+デプロイ後、ローカルから手動で叩いて確認できる（`$CRON_SECRET` は Vercel に設定した値）。
+
+```bash
+curl -i -H "Authorization: Bearer $CRON_SECRET" \
+  https://dondecorte-lab.vercel.app/api/cron/youtube
+```
+
+- `200 { ok: true, channels, inserted, outcomes }` … 正常（`inserted` が新規取り込み件数）
+- `401` … `CRON_SECRET` 不一致 / 未設定
+- `500 { ok: false }` … 登録チャンネルがあるのに全件失敗（`YOUTUBE_API_KEY` 不正 / YouTube API 障害など）
+
+実行履歴とログは Vercel の **Cron Jobs / Functions ログ**で確認する。
 
 ---
 

--- a/src/app/api/cron/youtube/route.test.ts
+++ b/src/app/api/cron/youtube/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const syncAllChannelsMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/integrations/youtube/sync", () => ({
+  syncAllChannels: syncAllChannelsMock,
+}));
+
+import { GET } from "./route";
+
+function buildRequest(authorization?: string): Request {
+  return new Request("https://example.com/api/cron/youtube", {
+    headers: authorization ? { authorization } : {},
+  });
+}
+
+const ORIGINAL_SECRET = process.env.CRON_SECRET;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.CRON_SECRET = "test-secret";
+});
+
+afterEach(() => {
+  process.env.CRON_SECRET = ORIGINAL_SECRET;
+});
+
+describe("GET /api/cron/youtube", () => {
+  it("CRON_SECRET 未設定なら 401", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(buildRequest("Bearer test-secret"));
+    expect(res.status).toBe(401);
+    expect(syncAllChannelsMock).not.toHaveBeenCalled();
+  });
+
+  it("Authorization ヘッダが無ければ 401", async () => {
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(401);
+    expect(syncAllChannelsMock).not.toHaveBeenCalled();
+  });
+
+  it("シークレットが一致しなければ 401", async () => {
+    const res = await GET(buildRequest("Bearer wrong"));
+    expect(res.status).toBe(401);
+    expect(syncAllChannelsMock).not.toHaveBeenCalled();
+  });
+
+  it("正しいシークレットなら同期を実行して結果を返す", async () => {
+    syncAllChannelsMock.mockResolvedValue({
+      channels: 1,
+      inserted: 2,
+      outcomes: [
+        {
+          channelId: "UC_abc",
+          ok: true,
+          result: {
+            fetched: 3,
+            inserted: 2,
+            skipped: 1,
+            insertedVideoIds: ["a", "b"],
+          },
+        },
+      ],
+    });
+
+    const res = await GET(buildRequest("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, channels: 1, inserted: 2 });
+    expect(syncAllChannelsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("同期が例外を投げたら 500 を返す", async () => {
+    syncAllChannelsMock.mockRejectedValue(new Error("boom"));
+    const res = await GET(buildRequest("Bearer test-secret"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ ok: false, error: "boom" });
+  });
+});

--- a/src/app/api/cron/youtube/route.test.ts
+++ b/src/app/api/cron/youtube/route.test.ts
@@ -69,6 +69,55 @@ describe("GET /api/cron/youtube", () => {
     expect(syncAllChannelsMock).toHaveBeenCalledTimes(1);
   });
 
+  it("登録チャンネルがあるのに全件失敗したら 500 / ok:false を返す", async () => {
+    syncAllChannelsMock.mockResolvedValue({
+      channels: 2,
+      inserted: 0,
+      outcomes: [
+        { channelId: "UC_a", ok: false, error: "boom" },
+        { channelId: "UC_b", ok: false, error: "boom" },
+      ],
+    });
+
+    const res = await GET(buildRequest("Bearer test-secret"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: false, channels: 2 });
+  });
+
+  it("一部失敗でも1件でも成功していれば 200 / ok:true を返す", async () => {
+    syncAllChannelsMock.mockResolvedValue({
+      channels: 2,
+      inserted: 1,
+      outcomes: [
+        { channelId: "UC_a", ok: false, error: "boom" },
+        {
+          channelId: "UC_b",
+          ok: true,
+          result: { fetched: 1, inserted: 1, skipped: 0, insertedVideoIds: ["x"] },
+        },
+      ],
+    });
+
+    const res = await GET(buildRequest("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, channels: 2 });
+  });
+
+  it("登録チャンネルが0件なら 200 / ok:true を返す", async () => {
+    syncAllChannelsMock.mockResolvedValue({
+      channels: 0,
+      inserted: 0,
+      outcomes: [],
+    });
+
+    const res = await GET(buildRequest("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, channels: 0 });
+  });
+
   it("同期が例外を投げたら 500 を返す", async () => {
     syncAllChannelsMock.mockRejectedValue(new Error("boom"));
     const res = await GET(buildRequest("Bearer test-secret"));

--- a/src/app/api/cron/youtube/route.ts
+++ b/src/app/api/cron/youtube/route.ts
@@ -32,7 +32,17 @@ export async function GET(request: Request) {
 
   try {
     const summary = await syncAllChannels();
-    return NextResponse.json({ ok: true, ...summary });
+
+    // 登録チャンネルがあるのに全件失敗した場合（例: YOUTUBE_API_KEY 不正や
+    // YouTube API 障害）は 200/ok:true を返すと Vercel Cron が成功扱いになり、
+    // 取り込み停止が検知できなくなる。全滅時は 500 で失敗として表面化させる。
+    const allFailed =
+      summary.channels > 0 && summary.outcomes.every((o) => !o.ok);
+
+    return NextResponse.json(
+      { ok: !allFailed, ...summary },
+      { status: allFailed ? 500 : 200 }
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return NextResponse.json({ ok: false, error: message }, { status: 500 });

--- a/src/app/api/cron/youtube/route.ts
+++ b/src/app/api/cron/youtube/route.ts
@@ -1,0 +1,40 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { syncAllChannels } from "@/lib/integrations/youtube/sync";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// 文字列を一定時間で比較する（長さの違いも含めてタイミング攻撃を避ける）。
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+// Vercel Cron は CRON_SECRET 設定時に `Authorization: Bearer <CRON_SECRET>` を自動付与する。
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  // 秘密が未設定なら、誰でも叩ける状態を避けるため一律で拒否する。
+  if (!secret) return false;
+
+  const header = request.headers.get("authorization");
+  if (!header) return false;
+
+  return safeEqual(header, `Bearer ${secret}`);
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const summary = await syncAllChannels();
+    return NextResponse.json({ ok: true, ...summary });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/src/lib/integrations/youtube/sync.test.ts
+++ b/src/lib/integrations/youtube/sync.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/lib/supabase/admin", () => ({ adminClient: adminClientMock }));
 const fetchChannelVideosMock = vi.hoisted(() => vi.fn());
 vi.mock("./client", () => ({ fetchChannelVideos: fetchChannelVideosMock }));
 
-import { syncChannelVideos } from "./sync";
+import { syncChannelVideos, syncAllChannels } from "./sync";
 
 function buildVideo(id: string): YoutubeVideo {
   return {
@@ -135,6 +135,92 @@ describe("syncChannelVideos", () => {
 
     await expect(syncChannelVideos("UC_abc")).rejects.toThrow(
       "動画の保存に失敗しました: upsert boom"
+    );
+  });
+});
+
+// comedy_groups の select / videos の upsert を table 名で分岐してモックする
+function setupAllChannels(options: {
+  channelRows?: Array<{ youtube_channel_id: string | null }>;
+  channelsError?: { message: string } | null;
+}) {
+  const notMock = vi.fn().mockResolvedValue({
+    data: options.channelRows ?? [],
+    error: options.channelsError ?? null,
+  });
+  const selectMock = vi.fn(() => ({ not: notMock }));
+
+  const videoSelectMock = vi
+    .fn()
+    .mockResolvedValue({ data: [{ youtube_video_id: "x" }], error: null });
+  const upsertMock = vi.fn(() => ({ select: videoSelectMock }));
+
+  adminClientMock.from.mockImplementation((table: string) => {
+    if (table === "comedy_groups") return { select: selectMock };
+    return { upsert: upsertMock };
+  });
+
+  return { selectMock, notMock, upsertMock };
+}
+
+describe("syncAllChannels", () => {
+  it("登録チャンネルが無ければ何もしない", async () => {
+    setupAllChannels({ channelRows: [] });
+
+    const result = await syncAllChannels();
+
+    expect(result).toEqual({ channels: 0, inserted: 0, outcomes: [] });
+    expect(fetchChannelVideosMock).not.toHaveBeenCalled();
+  });
+
+  it("重複・null を除外して各チャンネルを同期する", async () => {
+    setupAllChannels({
+      channelRows: [
+        { youtube_channel_id: "UC_a" },
+        { youtube_channel_id: "UC_a" },
+        { youtube_channel_id: null },
+        { youtube_channel_id: "UC_b" },
+      ],
+    });
+    fetchChannelVideosMock.mockResolvedValue([buildVideo("x")]);
+
+    const result = await syncAllChannels();
+
+    expect(result.channels).toBe(2);
+    expect(result.inserted).toBe(2);
+    expect(result.outcomes.map((o) => o.channelId)).toEqual(["UC_a", "UC_b"]);
+    expect(result.outcomes.every((o) => o.ok)).toBe(true);
+    expect(fetchChannelVideosMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("1チャンネルが失敗しても他チャンネルは継続する", async () => {
+    setupAllChannels({
+      channelRows: [
+        { youtube_channel_id: "UC_a" },
+        { youtube_channel_id: "UC_b" },
+      ],
+    });
+    fetchChannelVideosMock
+      .mockRejectedValueOnce(new Error("UC_a fail"))
+      .mockResolvedValueOnce([buildVideo("x")]);
+
+    const result = await syncAllChannels();
+
+    expect(result.channels).toBe(2);
+    expect(result.inserted).toBe(1);
+    expect(result.outcomes[0]).toMatchObject({
+      channelId: "UC_a",
+      ok: false,
+      error: "UC_a fail",
+    });
+    expect(result.outcomes[1]).toMatchObject({ channelId: "UC_b", ok: true });
+  });
+
+  it("チャンネル一覧の取得に失敗したら例外を投げる", async () => {
+    setupAllChannels({ channelsError: { message: "select boom" } });
+
+    await expect(syncAllChannels()).rejects.toThrow(
+      "チャンネル一覧の取得に失敗しました: select boom"
     );
   });
 });

--- a/src/lib/integrations/youtube/sync.test.ts
+++ b/src/lib/integrations/youtube/sync.test.ts
@@ -193,6 +193,24 @@ describe("syncAllChannels", () => {
     expect(fetchChannelVideosMock).toHaveBeenCalledTimes(2);
   });
 
+  it("空白のみのチャンネルIDは除外し、前後空白はトリムする", async () => {
+    setupAllChannels({
+      channelRows: [
+        { youtube_channel_id: "   " },
+        { youtube_channel_id: " UC_a " },
+        { youtube_channel_id: "UC_a" },
+      ],
+    });
+    fetchChannelVideosMock.mockResolvedValue([buildVideo("x")]);
+
+    const result = await syncAllChannels();
+
+    expect(result.channels).toBe(1);
+    expect(result.outcomes.map((o) => o.channelId)).toEqual(["UC_a"]);
+    expect(fetchChannelVideosMock).toHaveBeenCalledTimes(1);
+    expect(fetchChannelVideosMock).toHaveBeenCalledWith("UC_a");
+  });
+
   it("1チャンネルが失敗しても他チャンネルは継続する", async () => {
     setupAllChannels({
       channelRows: [

--- a/src/lib/integrations/youtube/sync.ts
+++ b/src/lib/integrations/youtube/sync.ts
@@ -89,7 +89,9 @@ async function listSyncableChannelIds(): Promise<string[]> {
 
   const ids = (data ?? [])
     .map((row) => row.youtube_channel_id)
-    .filter((id): id is string => typeof id === "string" && id.length > 0);
+    .filter((id): id is string => typeof id === "string")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
 
   return [...new Set(ids)];
 }

--- a/src/lib/integrations/youtube/sync.ts
+++ b/src/lib/integrations/youtube/sync.ts
@@ -65,3 +65,56 @@ export async function syncChannelVideos(
     insertedVideoIds,
   };
 }
+
+export type ChannelSyncOutcome = {
+  channelId: string;
+} & ({ ok: true; result: SyncChannelResult } | { ok: false; error: string });
+
+export type SyncAllChannelsResult = {
+  channels: number;
+  inserted: number;
+  outcomes: ChannelSyncOutcome[];
+};
+
+// comedy_groups に登録された youtube_channel_id を全件取得する（重複・null は除外）。
+async function listSyncableChannelIds(): Promise<string[]> {
+  const { data, error } = await adminClient
+    .from("comedy_groups")
+    .select("youtube_channel_id")
+    .not("youtube_channel_id", "is", null);
+
+  if (error) {
+    throw new Error(`チャンネル一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  const ids = (data ?? [])
+    .map((row) => row.youtube_channel_id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+
+  return [...new Set(ids)];
+}
+
+// 登録済みチャンネルを巡回して同期する。
+// 1 チャンネルの失敗で全体を止めないよう、チャンネル単位でエラーを隔離する。
+export async function syncAllChannels(): Promise<SyncAllChannelsResult> {
+  const channelIds = await listSyncableChannelIds();
+
+  const outcomes: ChannelSyncOutcome[] = [];
+  let inserted = 0;
+
+  for (const channelId of channelIds) {
+    try {
+      const result = await syncChannelVideos(channelId);
+      inserted += result.inserted;
+      outcomes.push({ channelId, ok: true, result });
+    } catch (error) {
+      outcomes.push({
+        channelId,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { channels: channelIds.length, inserted, outcomes };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/youtube",
+      "schedule": "0 3 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

issue #39「Vercel Cron設定」の対応です。#108 で実装した YouTube 同期ロジックを、Vercel Cron で毎日1回自動実行する仕組みを追加します。

Closes #39

## 変更内容

### `src/app/api/cron/youtube/route.ts`（新規）

- YouTube 動画同期の Cron エンドポイント（`GET`）。
- **認証**: Vercel Cron が `CRON_SECRET` 設定時に自動付与する `Authorization: Bearer <CRON_SECRET>` を `node:crypto` の `timingSafeEqual` で検証（長さ違いも含めタイミング攻撃を回避）。
- `CRON_SECRET` 未設定時は「誰でも叩ける状態」を避けるため**一律 401**。
- 同期結果を JSON で返す。同期処理が例外を投げた場合は 500。

### `src/lib/integrations/youtube/sync.ts`

- `syncAllChannels()` を追加。
  - `comedy_groups.youtube_channel_id` を全件取得し、重複・null を除外。
  - 各チャンネルを既存の `syncChannelVideos`（#108）で同期。
  - **チャンネル単位でエラーを隔離**し、1 チャンネルの失敗で全体を止めない（`outcomes` に成否を集約）。

### `vercel.json`（新規）

- `crons` に日次実行（`0 3 * * *` = UTC 03:00 / **JST 12:00**）で `/api/cron/youtube` を登録。

### `.env.example`

- `CRON_SECRET` のプレースホルダと生成例（`openssl rand -hex 32`）を追加。

### テスト

- `src/app/api/cron/youtube/route.test.ts`（新規）— 認証（未設定 / ヘッダ無し / 不一致 / 一致）と 200/500 を検証。
- `src/lib/integrations/youtube/sync.test.ts` — `syncAllChannels` のケースを追加（0件 / 重複・null除外 / チャンネル単位のエラー隔離 / 一覧取得失敗）。
- 計14ケース追加。lint・型チェッククリーン、**全215テストパス**。

## マージ後の手動作業

- Vercel に環境変数 `CRON_SECRET` を登録（`openssl rand -hex 32` 等）。
- `YOUTUBE_API_KEY` の登録（`docs/setup.md` Step 9）が前提。
- `comedy_groups` にドンデコルテ公式チャンネルID `UC4y-_Xwudf7gB5sXsbipDkQ` が入っていること（#78 の seed で投入済み）。

## 依存・補足

- #38（YouTube動画自動取得 / PR #108）の `syncChannelVideos` を利用。
- 取得動画の管理画面レビュー機能は #40 で対応予定。
- Vercel 無料プランの Cron は日次粒度のため、スケジュールは日次1本に収めています。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSWnx8rvuvTmmDj1URS1x2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSWnx8rvuvTmmDj1URS1x2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily automatic YouTube channel synchronization via scheduled cron.
  * Supports syncing multiple channels in one run, recording per-channel results while continuing on individual failures.
  * Secured the cron endpoint using Bearer-token authorization.
* **Bug Fixes**
  * Adjusted cron success/failure behavior so fully failing runs return an error status.
* **Tests**
  * Added route and sync test coverage for authorization and multi-channel sync outcomes.
* **Documentation**
  * Updated setup guide with cron/YouTube environment variables and manual test instructions.
* **Chores**
  * Updated environment example to include the cron secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->